### PR TITLE
Fix global_admin assignment for non-global_admin users

### DIFF
--- a/auth/models.py
+++ b/auth/models.py
@@ -21,6 +21,9 @@ class User(UserMixin):
         global_admin = user_doc.get('global_admin', False)
         if user_doc.get('role') == 'global_admin':
             global_admin = True
+
+        else:
+            global_admin = False # Fixes #25
             
         org_ids = [organization["org_id"] for organization in user_doc.get("organizations", [])]
 


### PR DESCRIPTION
Addressed an issue where 'global_admin' was not explicitly set to False for users without a 'global_admin' role. This ensures correct role assignment and avoids potential permission-related bugs.

Fixes #25