### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/templates/admin/demonstrations/form.html
+++ b/templates/admin/demonstrations/form.html
@@ -74,9 +74,10 @@
                 <label for="organizer_email_${organizerCount}_">Sähköposti</label>
                 <input type="email" id="organizer_email_${organizerCount}_" name="organizer_email_${organizerCount}_" class="form-control disabled" disabled="disabled" value="Täytetään automaattisesti">
                 <label for="organizer_id_${organizerCount}">Organisaation ID</label>
-                <input type="text" id="organizer_id_${organizerCount}" name="organizer_id_${organizerCount}" class="form-control disabled" value="${selectedOrgId}">
+                <input type="text" id="organizer_id_${organizerCount}" name="organizer_id_${organizerCount}" class="form-control disabled">
                 <button type="button" class="btn btn-danger btn-sm mt-2" onclick="removeOrganizer(this)">Poista</button>
             `;
+            newOrganizer.querySelector(`#organizer_id_${organizerCount}`).value = selectedOrgId;
             document.getElementById('organizers-container').appendChild(newOrganizer);
         } else {
             alert('Valitse ensin järjestö!');


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/2](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/2)

To fix the problem, we need to ensure that the `selectedOrgId` value is properly sanitized before it is used to construct HTML content. One way to achieve this is by using a text node or setting the value of an attribute directly, rather than using `innerHTML`. This will prevent the interpretation of the value as HTML.

The best way to fix the problem without changing existing functionality is to use `textContent` or `setAttribute` to safely insert the `selectedOrgId` value. This ensures that any special characters in the `selectedOrgId` are treated as plain text and not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
