### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/admin/admin_demo_bp.py
+++ b/admin/admin_demo_bp.py
@@ -426,4 +426,5 @@ def accept_demo(demo_id):
             200,
         )
     except Exception as e:
-        return jsonify({"status": "ERROR", "message": str(e)}), 500
+        app.logger.error(f"Error accepting demonstration: {e}")
+        return jsonify({"status": "ERROR", "message": "An internal error has occurred."}), 500


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/9](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/9)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the exception and return a generic error message.

- Modify the exception handling block in the `accept_demo` function to log the exception and return a generic error message.
- Ensure that the logging mechanism is properly set up to capture and store the detailed error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
