### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/admin/admin_demo_bp.py
+++ b/admin/admin_demo_bp.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from bson.objectid import ObjectId
-
+import logging
 from flask import Blueprint, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 
@@ -407,4 +407,5 @@ def accept_demo(demo_id):
             200,
         )
     except Exception as e:
-        return jsonify({"status": "ERROR", "message": str(e)}), 500
+        logging.error("An error occurred while accepting the demonstration: %s", str(e))
+        return jsonify({"status": "ERROR", "message": "An internal error has occurred."}), 500


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/9](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/9)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling block to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
