### PR TITLE
Fix code scanning alert no. 20: URL redirection from remote source

### DIFF
--- a/users/routes.py
+++ b/users/routes.py
@@ -12,6 +12,7 @@ from users.models import User
 import jwt
 import datetime
 import importlib
+from urllib.parse import urlparse
 
 from classes import Organization
 from utils.auth import (
@@ -142,16 +143,22 @@ def login():
 
         if user.confirmed:
             login_user(user)
-            return redirect(
-                next_page or url_for("index")
-            )  # Redirect to the next page or the index
+            if next_page:
+                next_page = next_page.replace('\\', '')
+                if not urlparse(next_page).netloc and not urlparse(next_page).scheme:
+                    return redirect(next_page)  # Safe to redirect
+            return redirect(url_for("index"))  # Redirect to the index
 
         else:
             flash_message(
                 "Sähköpostiosoitettasi ei ole vahvistettu. Tarkista sähköpostisi."
             )
             verify_emailer(user.email, username)
-            return redirect(next_page or url_for("index"))
+            if next_page:
+                next_page = next_page.replace('\\', '')
+                if not urlparse(next_page).netloc and not urlparse(next_page).scheme:
+                    return redirect(next_page)  # Safe to redirect
+            return redirect(url_for("index"))  # Redirect to the index
 
     return render_template("login.html", next=next_page)
 


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/20](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/20)

To fix the problem, we need to validate the `next_page` parameter to ensure it does not contain an external URL. We can use the `urlparse` function from the Python standard library to check that the `next_page` URL does not specify an explicit host name. If it does, we should ignore the `next_page` parameter and redirect to a safe default URL instead.

We will make the following changes:
1. Import the `urlparse` function from the `urllib.parse` module.
2. Add validation logic to check the `next_page` parameter before using it in the redirect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
