### PR TITLE
Fix code scanning alert no. 18: URL redirection from remote source

### DIFF
--- a/users/BPs/profile.py
+++ b/users/BPs/profile.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, abort
+from urllib.parse import urlparse
 from flask_login import current_user, login_required
 from bson.objectid import ObjectId
 from database_manager import DatabaseManager
@@ -91,7 +92,11 @@ def follow(username):
         flash_message("Tapahtui virhe.", "danger")
         logger.error(f"Error following user {username}: {e}")
         
-    return redirect(request.referrer or "/")  # TODO: #197 Use safe referrer // redirect to home if referrer is not available
+    referrer = request.referrer or "/"
+    referrer = referrer.replace('\\', '')
+    if not urlparse(referrer).netloc and not urlparse(referrer).scheme:
+        return redirect(referrer, code=302)
+    return redirect("/", code=302)
 
 @profile_bp.route("/unfollow/<username>", methods=["POST"])
 @login_required
@@ -113,4 +118,8 @@ def unfollow(username):
         flash_message("Tapahtui virhe.", "danger")
         logger.error(f"Error unfollowing user {username}: {e}")
         
-    return redirect(request.referrer)  # TODO: #197 Use safe referrer // redirect to home if referrer is not available
+    referrer = request.referrer or "/"
+    referrer = referrer.replace('\\', '')
+    if not urlparse(referrer).netloc and not urlparse(referrer).scheme:
+        return redirect(referrer, code=302)
+    return redirect("/", code=302)


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/18](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/18)

To fix the problem, we need to validate the `request.referrer` before using it in a redirect. We can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty, ensuring that the referrer is a relative path. If the referrer is not valid, we should redirect to a safe default, such as the home page.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Replace the direct use of `request.referrer` with a validation check.
3. If the referrer is valid, use it for the redirect; otherwise, redirect to the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
