### PR TITLE
Fix code scanning alert no. 21: DOM text reinterpreted as HTML

### DIFF
--- a/templates/admin/demonstrations/form.html
+++ b/templates/admin/demonstrations/form.html
@@ -68,6 +68,15 @@
     // Organizer JS functions
     let organizerCount = {{ demo.organizers | length if demo and demo.organizers else 0 }};
 
+    function escapeHtml(unsafe) {
+        return unsafe
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+    }
+
     function addOrganizer() {
         const selectedOrgId = document.getElementById('organization').value;
         if (selectedOrgId) {
@@ -83,7 +92,7 @@
                 <label for="organizer_email_${organizerCount}_">{{ _('Sähköposti') }}</label>
                 <input type="email" id="organizer_email_${organizerCount}_" name="organizer_email_${organizerCount}_" class="form-control disabled" disabled="disabled" value="{{ _('Täytetään automaattisesti') }}">
                 <label for="organizer_id_${organizerCount}">{{ _('Organisaation ID') }}</label>
-                <input type="text" id="organizer_id_${organizerCount}" name="organizer_id_${organizerCount}" class="form-control disabled" value="${selectedOrgId}">
+                <input type="text" id="organizer_id_${organizerCount}" name="organizer_id_${organizerCount}" class="form-control disabled" value="${escapeHtml(selectedOrgId)}">
                 <button type="button" class="btn btn-danger btn-sm mt-2" onclick="removeOrganizer(this)">{{ _('Poista') }}</button>
             `;
             document.getElementById('organizers-container').appendChild(newOrganizer);


### PR DESCRIPTION
Fixes [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/21](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/21)

To fix the problem, we need to ensure that the `selectedOrgId` value is properly sanitized or escaped before being inserted into the HTML. One effective way to do this is to use a function that escapes any HTML special characters in the `selectedOrgId` value. This will prevent any malicious content from being interpreted as HTML.

The best way to fix this without changing existing functionality is to create a utility function that escapes HTML special characters and use this function to sanitize the `selectedOrgId` value before inserting it into the HTML template string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
