### PR TITLE
Remove unnecessary sleep during duplicate merging to improve performa…

### DIFF
--- a/scripts/repeat_v2.py
+++ b/scripts/repeat_v2.py
@@ -227,7 +227,6 @@ def merge_duplicates():
             try:
                 Demonstration(**base_demo).merge(duplicate_id)
                 print("MERGING", duplicate_id)
-                time.sleep(200)
                 merged_count += 1
             except Exception as e:
                 logger.error(f"Error merging duplicate {duplicate_id}: {e}")


### PR DESCRIPTION
This pull request includes a small change to the `scripts/repeat_v2.py` file. The change removes an unnecessary sleep call in the `merge_duplicates` function to improve performance.

* [`scripts/repeat_v2.py`](diffhunk://#diff-7aa6b8917a4d0e481b313586def9d13724fc4be926844a1aacc3337c9a140a10L230): Removed the `time.sleep(200)` call in the `merge_duplicates` function.