### PR TITLE
Fix organization ID reference in admin demonstrations form for correc…

### DIFF
--- a/templates/admin/demonstrations/form.html
+++ b/templates/admin/demonstrations/form.html
@@ -211,7 +211,7 @@
                 <option value="">{{ _('Valitse järjestö') }}</option>
                 {% if current_user.global_admin %}
                 {% for organization in all_organizations %}
-                <option value="{{ organization.org_id }}">{{ organization.name }}</option>
+                <option value="{{ organization._id }}">{{ organization.name }}</option>
                 {% endfor %}
                 {% else %}
                 {% for organization in current_user.organizations %}


### PR DESCRIPTION
This pull request includes a change to the `templates/admin/demonstrations/form.html` file. The change updates the value used for the organization dropdown options to use the correct identifier.

* Updated the organization dropdown options to use `organization._id` instead of `organization.org_id` in `templates/admin/demonstrations/form.html`.…t data binding