### PR TITLE
Fix string formatting in storage_uri for rate limiter configuration

### DIFF
--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -60,7 +60,7 @@ def create_app() -> Flask:
         get_remote_address,
         app=app,
         default_limits=["86400 per day", "3600 per hour", "10 per second"],
-        storage_uri=f"{app.config["MONGO_URI"]}/mielenosoitukset_fi.limiter",
+        storage_uri=f"{app.config['MONGO_URI']}/mielenosoitukset_fi.limiter",
     )
     # Locale selector function
     def get_locale():


### PR DESCRIPTION
This pull request includes a small but important change to the `create_app` function in the `mielenosoitukset_fi/app.py` file. The change corrects the usage of quotation marks in the `storage_uri` configuration.

* [`mielenosoitukset_fi/app.py`](diffhunk://#diff-60268cb9e50d7f428866a0ad8885eeb947b461b1081d9164055d077100f07989L63-R63): Changed double quotes to single quotes in the `storage_uri` assignment to ensure proper string formatting.