### PR TITLE
Fix issues

### DIFF
--- a/mielenosoitukset_fi/utils/screenshot.py
+++ b/mielenosoitukset_fi/utils/screenshot.py
@@ -3,7 +3,7 @@ import imgkit
 import os
 
 # Specify the path to the wkhtmltoimage binary
-config = imgkit.config(wkhtmltoimage='/bin/wkhtmltoimage')
+config = imgkit.config()
 
 def create_screenshot(demo_data, output_path="../static/demo_preview/"):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ PyYAML==6.0.2
 Requests==2.32.3
 Werkzeug==3.1.3
 flask_autosec @ git+https://github.com/botsarefuture/flask_autosec.git@main
+wkhtmltoimage==0.12.6


### PR DESCRIPTION
This pull request includes a small change to the `mielenosoitukset_fi/utils/screenshot.py` file. The change involves modifying the configuration of the `imgkit` library to use the default `wkhtmltoimage` binary path instead of specifying a custom path.

* [`mielenosoitukset_fi/utils/screenshot.py`](diffhunk://#diff-3520f24d91e061212ffdfc919db836393a31e0c587d39cc6a31ed6ed31145db7L6-R6): Removed the custom path to the `wkhtmltoimage` binary in the `imgkit.config` call.