### PR TITLE
Fix issues

### DIFF
--- a/mielenosoitukset_fi/utils/screenshot.py
+++ b/mielenosoitukset_fi/utils/screenshot.py
@@ -8,7 +8,6 @@ from mielenosoitukset_fi.utils.logger import logger
 # Set XDG_CACHE_HOME to a writable directory
 os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp()
 config = imgkit.config()
-config = imgkit.config()
 
 def create_screenshot(demo_data, output_path="../static/demo_preview/"):
     """

--- a/mielenosoitukset_fi/utils/screenshot.py
+++ b/mielenosoitukset_fi/utils/screenshot.py
@@ -1,8 +1,13 @@
 from flask import render_template
 import imgkit
 import os
+import tempfile
 
-# Specify the path to the wkhtmltoimage binary
+from mielenosoitukset_fi.utils.logger import logger
+
+# Set XDG_CACHE_HOME to a writable directory
+os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp()
+config = imgkit.config()
 config = imgkit.config()
 
 def create_screenshot(demo_data, output_path="../static/demo_preview/"):
@@ -21,17 +26,24 @@ def create_screenshot(demo_data, output_path="../static/demo_preview/"):
     str
         Full path of the created PNG file.
     """
-    base_path = os.path.abspath(os.path.dirname(__file__))
-    output_path = os.path.join(base_path, output_path)
-    demo_data = demo_data.to_dict(True)
-    html_content = render_template("preview.html", demo=demo_data)
-    filename = f"{demo_data['_id']}.png"
-    full_path = os.path.join(output_path, filename)
-    
-    _return_path = full_path.replace(base_path, "").replace("../", "/")
+    try:
+        base_path = os.path.abspath(os.path.dirname(__file__))
+        output_path = os.path.join(base_path, output_path)
+        os.makedirs(output_path, exist_ok=True)
+        
+        demo_data = demo_data.to_dict(True)
+        html_content = render_template("preview.html", demo=demo_data)
+        filename = f"{demo_data['_id']}.png"
+        full_path = os.path.join(output_path, filename)
+        
+        _return_path = full_path.replace(base_path, "").replace("../", "/")
 
-    imgkit.from_string(html_content, full_path, config=config)
-    return _return_path
+        imgkit.from_string(html_content, full_path, config=config)
+        logger.info(f"Screenshot created at: {full_path}")
+        return _return_path
+    except Exception as e:
+        logger.error(f"Failed to create screenshot: {e}")
+        raise
 
 if __name__ == "__main__":
     demo_data = {
@@ -40,5 +52,8 @@ if __name__ == "__main__":
         "location": "Demo Location",
         "description": "This is a demonstration description.",
     }
-    screenshot_path = create_screenshot(demo_data)
-    print(f"Screenshot saved at: {screenshot_path}")
+    try:
+        screenshot_path = create_screenshot(demo_data)
+        print(f"Screenshot saved at: {screenshot_path}")
+    except Exception as e:
+        print(f"Error: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ PyYAML==6.0.2
 Requests==2.32.3
 Werkzeug==3.1.3
 flask_autosec @ git+https://github.com/botsarefuture/flask_autosec.git@main
-wkhtmltoimage==0.12.6
+imgkit==1.2.0


### PR DESCRIPTION
This pull request includes several changes to the `create_screenshot` function in `mielenosoitukset_fi/utils/screenshot.py` to improve error handling and logging, as well as setting up a temporary cache directory for `imgkit`.

Improvements and error handling:

* Added a try-except block around the main logic of the `create_screenshot` function to catch and log any exceptions that occur during the screenshot creation process. [[1]](diffhunk://#diff-3520f24d91e061212ffdfc919db836393a31e0c587d39cc6a31ed6ed31145db7R28-R32) [[2]](diffhunk://#diff-3520f24d91e061212ffdfc919db836393a31e0c587d39cc6a31ed6ed31145db7R41-R45)
* Added logging to record successful screenshot creation and errors using the `logger` from `mielenosoitukset_fi.utils.logger`.

Environment setup:

* Set the `XDG_CACHE_HOME` environment variable to a temporary directory using `tempfile.mkdtemp()` to ensure `imgkit` has a writable cache directory.

Additional changes:

* Ensured the output directory exists by using `os.makedirs` with `exist_ok=True` before attempting to save the screenshot.
* Wrapped the main execution block in a try-except to handle and print errors during script execution.