### PR TITLE
Potential fix for code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -168,7 +168,10 @@ def create_app() -> Flask:
     def screenshot(demo_id):
         # check if the screenshot is already created
         from mielenosoitukset_fi.utils import _CUR_DIR
-        _path = os.path.join(_CUR_DIR, "static/demo_preview", f"{demo_id}.png")
+        base_path = os.path.join(_CUR_DIR, "static/demo_preview")
+        _path = os.path.normpath(os.path.join(base_path, f"{demo_id}.png"))
+        if not _path.startswith(base_path):
+            raise Exception("Invalid path")
         if os.path.exists(_path):
             return redirect(f"/static/demo_preview/{demo_id}.png")
         


### PR DESCRIPTION
Potential fix for [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/42](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/42)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path and then checking that it starts with the expected base directory. This will prevent directory traversal attacks by ensuring that the path does not escape the intended directory.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the base directory.
3. If the path is not valid, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
