### PR TITLE
Potential fix for code scanning alert no. 50: DOM text reinterpreted as HTML

### DIFF
--- a/mielenosoitukset_fi/templates/tag_list.html
+++ b/mielenosoitukset_fi/templates/tag_list.html
@@ -748,11 +748,16 @@ document.addEventListener("DOMContentLoaded", function() {
             currentCities.push(selectedCity);
             selectedCitiesInput.val(currentCities.join(","));
             const filterDiv = $("<div>")
-              .addClass("filter")
-              .html(`<span>{{ _('Kaupunki') }}: ${selectedCity}</span>
-                <a href="#" data-city="${selectedCity}">
-                  <i class="fas fa-times"></i>
-                </a>`);
+              .addClass("filter");
+            filterDiv.append(
+              $("<span>").text(`{{ _('Kaupunki') }}: ${selectedCity}`)
+            );
+            filterDiv.append(
+              $("<a>")
+                .attr("href", "#")
+                .attr("data-city", selectedCity)
+                .append($("<i>").addClass("fas fa-times"))
+            );
             filters.append(filterDiv);
             filterDiv.find("a").on("click", function (event) {
               event.preventDefault();


### PR DESCRIPTION
Potential fix for [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/50](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/50)

To fix the issue, the `selectedCity` variable must be properly escaped before being interpolated into the HTML string. Escaping ensures that any special characters in the text are treated as literal text rather than HTML/JavaScript. The best approach is to use a library or built-in function that provides robust escaping for HTML contexts.

In this case, the `.text()` method of jQuery can be used instead of `.html()` to safely insert text into the DOM. This method automatically escapes any special characters, preventing XSS vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
