### PR TITLE
Potential fix for code scanning alert no. 46: DOM text reinterpreted as HTML

### DIFF
--- a/mielenosoitukset_fi/templates/AM/signup_s1.html
+++ b/mielenosoitukset_fi/templates/AM/signup_s1.html
@@ -110,13 +110,24 @@
 </div>
 
 <script>
+    function escapeHTML(text) {
+        const map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+    }
+
     function navigateToPage(pageNumber) {
         const pages = document.querySelectorAll('page');
         const form = document.getElementById('signup-form');
         const hiddenRoles = document.getElementById('hidden-roles');
         if (pageNumber === 4) {
             const selectedRoles = Array.from(form.querySelectorAll('input[name="roles"]:checked'))
-                .map(input => input.nextElementSibling.textContent.trim());
+                .map(input => escapeHTML(input.nextElementSibling.textContent.trim()));
             const reviewRoles = document.getElementById('review-roles');
             reviewRoles.innerHTML = selectedRoles.length
                 ? selectedRoles.map(role => `<li>${role}</li>`).join('')


### PR DESCRIPTION
Potential fix for [https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/46](https://github.com/botsarefuture/mielenosoitukset_fi/security/code-scanning/46)

To fix the issue, the text extracted from `input.nextElementSibling.textContent` must be properly escaped before being inserted into the DOM using `innerHTML`. Escaping ensures that any special characters in the text are treated as literal text rather than HTML or JavaScript. A safe approach is to use a utility function to encode the text for HTML, replacing characters like `<`, `>`, `&`, and `"` with their corresponding HTML entities.

**Steps to fix:**
1. Add a utility function to escape text for HTML.
2. Use this function to escape `role` before inserting it into the DOM via `innerHTML`.

**Required changes:**
- Add the escape function within the `<script>` block.
- Modify the `selectedRoles.map` logic to apply the escape function to `role`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
