### PR TITLE
Fix admin submitter info modal contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.
 * Tag normalization now strips leading `#` in public submit and demo change suggestion flows, preventing accidental `##tag` rendering.
 * Aligned `botocore` pin with `boto3==1.42.74` in `requirements.txt` to keep pip dependency resolution valid.

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
@@ -162,6 +162,10 @@
     color: light-dark(#000, #fff);
   }
 
+  .submitter-info-body {
+    color: light-dark(#1f2937, #e5e7f4);
+  }
+
   /* smooth fade/slide when a row is removed */
   tr.fade‑out {
     opacity: 0;
@@ -969,7 +973,7 @@
           <button type="button" class="btn-close btn-close-white" aria-label="{{ _('Sulje') }}"
             id="submitterInfoCloseBtn"></button>
         </div>
-        <div class="modal-body p-4 text-center" id="submitter-info-content" style="color: white;">
+        <div class="modal-body p-4 text-center submitter-info-body" id="submitter-info-content">
           <!-- Dynamically filled content -->
           <div id="noSubmitterInfo" class="alert alert-warning d-none">
             <i class="fa-solid fa-circle-exclamation me-2"></i>


### PR DESCRIPTION
## Summary
- remove the hardcoded white text color from the admin submitter info modal body
- use a theme-aware text color so reporter details remain readable in light and dark modes
- add the changelog entry required for the user-facing admin dashboard fix

## Testing
- not run (template/CSS-only change)

Fixes #545