### PR TITLE
Stabilize background job audit action ordering test

### DIFF
--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -28,7 +28,10 @@ def _history_for_demo(db, demo_id):
 
 
 def _audit_actions_for_demo(db, demo_id):
-    return [doc["action"] for doc in db.demo_audit_logs.find({"demo_id": str(demo_id)})]
+    cursor = db.demo_audit_logs.find({"demo_id": str(demo_id)}).sort(
+        [("timestamp", 1), ("_id", 1)]
+    )
+    return [doc["action"] for doc in cursor]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- sort audit log entries by `timestamp` and `_id` in the test helper used by the background job history assertion
- remove reliance on MongoDB's unspecified default query ordering for action-sequence comparisons
- keep the change limited to the test helper because the flaky behavior is in the assertion path

## Testing
- `pytest -q tests/test_background_jobs.py -k preserves_demo_id_on_replace_and_update`

Fixes #540