### PR TITLE
Fix organizer contact overflow on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Organizer contact cards on demonstration detail pages now wrap long website and email links on mobile instead of overflowing the layout.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -846,7 +846,8 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
 
   .contact-item {
     flex: 1 1 220px;
-    min-width: 200px;
+    min-width: 0;
+    max-width: 100%;
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -861,10 +862,14 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
   }
 
   .contact-item a {
+    min-width: 0;
+    max-width: 100%;
     color: var(--color-text);
     font-weight: 600;
     text-decoration: none;
     transition: var(--transition);
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .contact-item a:hover {
@@ -1040,6 +1045,10 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
 
     .organizers-grid {
       grid-template-columns: 1fr;
+    }
+
+    .contact-item {
+      flex-basis: 100%;
     }
 
     .countdown-timer {


### PR DESCRIPTION
## Summary
- allow organizer contact cards on the demonstration detail page to shrink and wrap on narrow screens
- make long website and email strings break safely instead of overflowing the mobile layout
- add the changelog entry for the user-facing mobile layout fix

## Testing
- not run (template/CSS-only change)

Fixes #536