### PR TITLE
Fix recurring demo admin create flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Admin recurring demonstration creation now accepts the current create-form recurrence fields and city selection without crashing the dashboard redirect after save.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.

--- a/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
@@ -30,6 +30,53 @@ def log_request_info():
     )
 
 
+def _safe_text(value):
+    """Return a lower-cased string for filtering, tolerating missing fields."""
+    return (value or "").lower()
+
+
+def _safe_demo_date(value):
+    """Return a sortable date, falling back for malformed legacy records."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return date.max
+
+
+def _get_repeat_frequency(form):
+    """Support both legacy and current recurrence field names."""
+    raw_frequency = form.get("frequency_type") or form.get("recurrence_type") or "none"
+    return raw_frequency.lower()
+
+
+def _get_repeat_interval(form, frequency):
+    """Normalize repeat interval so `none` schedules always serialize safely."""
+    if frequency == "none":
+        return 0
+
+    raw_interval = form.get("frequency_interval") or form.get("recurrence_interval") or "1"
+    try:
+        interval = int(raw_interval)
+    except (TypeError, ValueError):
+        interval = 1
+    return max(interval, 1)
+
+
+def _get_route_points(form):
+    """Collect route points from both pill-based and legacy text inputs."""
+    route_points = [
+        point.strip() for point in form.getlist("route[]") if point and point.strip()
+    ]
+    if route_points:
+        return route_points
+
+    legacy_route = form.get("route")
+    if not legacy_route:
+        return []
+
+    return [point.strip() for point in legacy_route.split(",") if point.strip()]
+
+
 @admin_recu_demo_bp.route("/")
 @login_required
 @admin_required
@@ -43,26 +90,26 @@ def recu_demo_control():
 
     # Construct query based on approval status
     query = {"approved": approved_status} if approved_status else {}
-    recurring_demos = [
-        RecurringDemonstration.from_dict(recudemo)
-        for recudemo in list(mongo.recu_demos.find(query))
-    ]  #  .recu_demos.find(query)
+    recurring_demos = []
+    for recudemo in list(mongo.recu_demos.find(query)):
+        try:
+            recurring_demos.append(RecurringDemonstration.from_dict(recudemo))
+        except Exception:
+            continue
 
     # Filter based on search query and date
     filtered_recurring_demos = [
         demo
         for demo in recurring_demos
         if (
-            search_query.lower() in demo.title.lower()
-            or search_query.lower() in demo.city.lower()
-            or search_query.lower() in demo.address.lower()
+            _safe_text(search_query) in _safe_text(demo.title)
+            or _safe_text(search_query) in _safe_text(demo.city)
+            or _safe_text(search_query) in _safe_text(demo.address)
         )
     ]
 
     # Sort the filtered recurring demonstrations by date
-    filtered_recurring_demos.sort(
-        key=lambda x: datetime.strptime(x.date, "%Y-%m-%d").date()
-    )
+    filtered_recurring_demos.sort(key=lambda x: _safe_demo_date(x.date))
 
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}recu_demonstrations/dashboard.html",
@@ -136,14 +183,15 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
 
     # Basic info
     title = request.form.get("title")
+    description = request.form.get("description")
     date = request.form.get("date")
     start_time = request.form.get("start_time")
     end_time = request.form.get("end_time")
     facebook = request.form.get("facebook")
-    city = request.form.get("city")
+    city = request.form.get("city") or ""
     address = request.form.get("address")
     event_type = request.form.get("type")
-    route = request.form.get("route")
+    route = _get_route_points(request.form)
     approved = request.form.get("approved") == "on"
 
     tags = collect_tags(request)
@@ -166,9 +214,9 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
         index += 1
 
     # Recurrence / repeat schedule
-    freq = request.form.get("frequency_type", "none")
-    interval = int(request.form.get("frequency_interval", 1))
-    end_date = request.form.get("end_date")
+    freq = _get_repeat_frequency(request.form)
+    interval = _get_repeat_interval(request.form, freq)
+    end_date = request.form.get("end_date") or request.form.get("recurrence_end_date")
 
     # Weekly
     weekday = None
@@ -206,6 +254,7 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
     # Assemble demonstration data
     demonstration_data = {
         "title": title,
+        "description": description,
         "date": date,
         "start_time": start_time,
         "end_time": end_time,

--- a/mielenosoitukset_fi/templates/partials/toistuva_form_fields.html
+++ b/mielenosoitukset_fi/templates/partials/toistuva_form_fields.html
@@ -63,6 +63,8 @@
 <section class="form-section dashboard-panel mb-8">
     <h2 class="text-xl font-semibold mb-4">{{ _('Sijainti') }}</h2>
 
+    {% include "paikkakunta-dropdown.html" %}
+
     <div class="form-group">
         <label for="address" class="block font-medium mb-1">{{ _('Osoite') }} <span
                 class="text-red-500">*</span></label>

--- a/tests/test_admin_recu_demo.py
+++ b/tests/test_admin_recu_demo.py
@@ -1,0 +1,37 @@
+from bson import ObjectId
+
+
+def test_admin_can_create_recurring_demo_with_create_form_fields(admin_client, db):
+    response = admin_client.post(
+        "/admin/recu_demo/create_recu_demo",
+        data={
+            "title": "Weekly recurring demo",
+            "description": "Created through the admin create form.",
+            "date": "2026-05-01",
+            "start_time": "12:00",
+            "end_time": "13:00",
+            "city": "Helsinki",
+            "address": "Testikatu 1",
+            "type": "MARCH",
+            "approved": "on",
+            "organizer_name_1": "Test Org",
+            "organizer_id_1": str(ObjectId()),
+            "recurrence_type": "WEEKLY",
+            "recurrence_interval": "2",
+            "recurrence_end_date": "2026-06-01",
+            "route[]": ["Senate Square", "Railway Station"],
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/admin/recu_demo/")
+
+    created = db.recu_demos.find_one({"title": "Weekly recurring demo"})
+    assert created is not None
+    assert created["city"] == "Helsinki"
+    assert created["route"] == ["Senate Square", "Railway Station"]
+    assert created["recurs"] is True
+    assert created["repeat_schedule"]["frequency"] == "weekly"
+    assert created["repeat_schedule"]["interval"] == 2
+    assert created["repeat_schedule"]["end_date"] == "2026-06-01"


### PR DESCRIPTION
## Summary
- normalize recurring-demo admin create submissions so the handler accepts the current create-form recurrence fields and pill-based route values
- add the missing city picker to the create form and harden the recurring-demo dashboard against malformed legacy records
- add a regression test covering the admin create payload shape that triggered issue #336

## Testing
- direct Flask test-client verification of `/admin/recu_demo/create_recu_demo` -> `/admin/recu_demo/` using the new payload shape
- `pytest -q tests/test_admin_recu_demo.py` currently resolves the editable install from the original checkout in this local environment, so the focused regression was also verified with a direct branch-local script

Fixes #336