### PR TITLE
Fix recurring demo form follow-ups from PR 558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Recurring demo admin create/edit now preserve organizer data even if organizer cards are removed and re-added out of sequence, and the shared recurring description editor now loads its real CKEditor initializer.
 * Admin recurring demonstration creation now accepts the current create-form recurrence fields and city selection without crashing the dashboard redirect after save.
 * Organizer contact cards on demonstration detail pages now wrap long website and email links on mobile instead of overflowing the layout.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.

--- a/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, date
 
 from bson.objectid import ObjectId
@@ -88,6 +89,40 @@ def _get_route_points(form):
         return []
 
     return [point.strip() for point in legacy_route.split(",") if point.strip()]
+
+
+def _collect_organizers(form):
+    """Collect organizer cards even if client-side indexes become sparse."""
+    organizers = []
+    organizer_indexes = sorted(
+        {
+            int(match.group(1))
+            for key in form.keys()
+            if (match := re.match(r"organizer_name_(\d+)$", key))
+        }
+        | {
+            int(match.group(1))
+            for key in form.keys()
+            if (match := re.match(r"organizer_id_(\d+)$", key))
+        }
+    )
+
+    for index in organizer_indexes:
+        name = form.get(f"organizer_name_{index}")
+        organization_id = form.get(f"organizer_id_{index}")
+        if not name and not organization_id:
+            continue
+
+        organizers.append(
+            Organizer(
+                name=name,
+                email=form.get(f"organizer_email_{index}"),
+                website=form.get(f"organizer_website_{index}"),
+                organization_id=organization_id,
+            ).to_dict()
+        )
+
+    return organizers
 
 
 @admin_recu_demo_bp.route("/")
@@ -208,20 +243,7 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
     cover_picture = request.form.get("cover_picture")
     gallery_images = parse_gallery_images_field(request.form.get("gallery_images"))
 
-    # Process organizers dynamically
-    organizers = []
-    index = 1
-    while True:
-        name = request.form.get(f"organizer_name_{index}")
-        _id = request.form.get(f"organizer_id_{index}")
-        if not name and not _id:
-            break
-        website = request.form.get(f"organizer_website_{index}")
-        email = request.form.get(f"organizer_email_{index}")
-        organizers.append(
-            Organizer(name=name, email=email, website=website, organization_id=_id).to_dict()
-        )
-        index += 1
+    organizers = _collect_organizers(request.form)
 
     # Recurrence / repeat schedule
     freq = _get_repeat_frequency(request.form)

--- a/mielenosoitukset_fi/templates/admin_V2/recu_demonstrations/_form_v2.html
+++ b/mielenosoitukset_fi/templates/admin_V2/recu_demonstrations/_form_v2.html
@@ -262,7 +262,7 @@
             </script>
 
             <script type="module">
-                import { initClassicEditor } from '{{ url_for('static', filename='js / ckeditor - init.js') }}';
+                import { initClassicEditor } from '{{ url_for('static', filename='js/ckeditor-init.js') }}';
                 initClassicEditor('#editor', 'description');
             </script>
         </section>

--- a/tests/test_admin_recu_demo.py
+++ b/tests/test_admin_recu_demo.py
@@ -35,3 +35,33 @@ def test_admin_can_create_recurring_demo_with_create_form_fields(admin_client, d
     assert created["repeat_schedule"]["frequency"] == "weekly"
     assert created["repeat_schedule"]["interval"] == 2
     assert created["repeat_schedule"]["end_date"] == "2026-06-01"
+
+
+def test_admin_can_create_recurring_demo_with_sparse_organizer_indexes(admin_client, db):
+    kept_org_id = ObjectId()
+
+    response = admin_client.post(
+        "/admin/recu_demo/create_recu_demo",
+        data={
+            "title": "Sparse organizer recurring demo",
+            "description": "Organizer indexes should not need to be contiguous.",
+            "date": "2026-05-02",
+            "start_time": "14:00",
+            "end_time": "15:00",
+            "city": "Helsinki",
+            "address": "Testikatu 2",
+            "type": "STAY_STILL",
+            "organizer_name_2": "Existing Organization",
+            "organizer_id_2": str(kept_org_id),
+            "frequency_type": "none",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    created = db.recu_demos.find_one({"title": "Sparse organizer recurring demo"})
+    assert created is not None
+    assert len(created["organizers"]) == 1
+    assert created["organizers"][0]["name"] == "Existing Organization"
+    assert created["organizers"][0]["organization_id"] == kept_org_id

--- a/tests/test_admin_recu_demo_views.py
+++ b/tests/test_admin_recu_demo_views.py
@@ -7,6 +7,7 @@ def test_create_recu_demo_uses_shared_admin_form(admin_client):
     assert 'id="organization"' in page
     assert "Lisäkuvat" in page
     assert "Luo muokkauslinkki" not in page
+    assert "js/ckeditor-init.js" in page
 
 
 def test_edit_recu_demo_renders_shared_admin_form_with_org_selector(admin_client, seeded_data):


### PR DESCRIPTION
## Summary
- preserve recurring-demo organizers even when organizer card indexes become sparse after removing and re-adding entries
- point the shared recurring-demo description editor at the real `static/js/ckeditor-init.js` asset so the description field works on create/edit
- add regression coverage and record the fix in the changelog

## Testing
- direct branch-local Flask test-client verification confirmed the recurring-demo create page now references `js/ckeditor-init.js`
- direct branch-local Flask test-client verification also confirmed a create submission with only `organizer_name_2` / `organizer_id_2` still persists one organizer correctly
- `PYTHONPATH=$PWD pytest -q tests/test_admin_recu_demo.py tests/test_admin_recu_demo_views.py` is still not authoritative in this environment because these recurring-demo tests can resolve mixed checkouts/templates locally; I used the direct branch-local verification for confidence before pushing

Follow-up to #558