### PR TITLE
Show actual developer rate-limit defaults in the app detail panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 * PR preview URLs now use `pr-<id>.mielenosoitukset.fi` instead of the deeper `previews.*` nesting, which keeps them within Cloudflare's normal first-level subdomain coverage.
 * Preview config files are now written world-readable inside the container mount, so the app process can load its per-PR config instead of crashing on permission denied.
 * Preview Caddy routing now points directly at each app container's Docker IP, avoiding the flaky localhost publish path on the preview host.
+* Fixed the config loader so the Flask session secret stays separate from the S3 secret key; preview login pages no longer 500 because `session` is unavailable.
+* Developer app detail now shows the actual global rate-limit defaults instead of placeholder `N/A` values, making the permissions and requests panel easier to read.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Preview Caddy routing now points directly at each app container's Docker IP, avoiding the flaky localhost publish path on the preview host.
 * Fixed the config loader so the Flask session secret stays separate from the S3 secret key; preview login pages no longer 500 because `session` is unavailable.
 * Developer app detail now shows the actual global rate-limit defaults instead of placeholder `N/A` values, making the permissions and requests panel easier to read.
+* Developer app detail now hides rate-limit policy text in environments where limiter enforcement is disabled, so the preview/admin UI no longer implies limits are active when they are not.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -66,12 +66,15 @@ def create_app(config_overrides=None) -> Flask:
     if config_overrides:
         app.config.update(config_overrides)
     _configure_timezone(app)
+
+    rate_limit_defaults = ["86400 per day", "3600 per hour", "10 per second"]
+    app.config["RATE_LIMIT_DEFAULTS"] = rate_limit_defaults
     
     if app.config.get("ENFORCE_RATELIMIT", True):
         Limiter(
             get_remote_address,
             app=app,
-            default_limits=["86400 per day", "3600 per hour", "10 per second"],
+            default_limits=rate_limit_defaults,
             storage_uri=app.config["MONGO_URI"],
         )
     

--- a/mielenosoitukset_fi/developer_bp.py
+++ b/mielenosoitukset_fi/developer_bp.py
@@ -83,11 +83,10 @@ def app_detail(app_id):
         t["_id"] = str(t["_id"])
         if t.get("expires_at"):
             t["expires_at"] = t["expires_at"].isoformat()
-    # Placeholder rate-limit info
+    rate_limits = list(current_app.config.get("RATE_LIMIT_DEFAULTS", []))
     rate_info = {
-        "limit": "100/min",
-        "remaining": "N/A",
-        "reset": "N/A",
+        "limits": rate_limits,
+        "policy": "Sovelluksen oletusrajat",
     }
     current_scopes = sorted(list(set(app.get("allowed_scopes", ["read"]))))
     return render_template("developer/app_detail.html", app=app, tokens=tokens, rate_info=rate_info, current_scopes=current_scopes)

--- a/mielenosoitukset_fi/developer_bp.py
+++ b/mielenosoitukset_fi/developer_bp.py
@@ -83,9 +83,11 @@ def app_detail(app_id):
         t["_id"] = str(t["_id"])
         if t.get("expires_at"):
             t["expires_at"] = t["expires_at"].isoformat()
+    rate_limit_enabled = current_app.config.get("ENFORCE_RATELIMIT", True)
     rate_limits = list(current_app.config.get("RATE_LIMIT_DEFAULTS", []))
     rate_info = {
-        "limits": rate_limits,
+        "enabled": rate_limit_enabled,
+        "limits": rate_limits if rate_limit_enabled else [],
         "policy": "Sovelluksen oletusrajat",
     }
     current_scopes = sorted(list(set(app.get("allowed_scopes", ["read"]))))

--- a/mielenosoitukset_fi/templates/developer/app_detail.html
+++ b/mielenosoitukset_fi/templates/developer/app_detail.html
@@ -102,7 +102,16 @@
 
   <div class="dev-card">
     <h5 class="mb-2">Rate limit</h5>
-    <p class="meta">Nykyinen raja: {{ rate_info.limit }}. Jäljellä: {{ rate_info.remaining }}. Reset: {{ rate_info.reset }}. (Tiedot viitteellisiä.)</p>
+    <p class="meta mb-2">{{ rate_info.policy }} koskee tätä kehittäjäpaneelia.</p>
+    {% if rate_info.limits %}
+      <ul class="list-unstyled mb-0">
+        {% for limit in rate_info.limits %}
+          <li class="mb-2"><span class="pill">{{ limit }}</span></li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="meta mb-0">Rajoituksia ei ole määritelty.</p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/developer/app_detail.html
+++ b/mielenosoitukset_fi/templates/developer/app_detail.html
@@ -102,15 +102,15 @@
 
   <div class="dev-card">
     <h5 class="mb-2">Rate limit</h5>
-    <p class="meta mb-2">{{ rate_info.policy }} koskee tätä kehittäjäpaneelia.</p>
-    {% if rate_info.limits %}
+    {% if rate_info.enabled %}
+      <p class="meta mb-2">{{ rate_info.policy }} koskee tätä kehittäjäpaneelia.</p>
       <ul class="list-unstyled mb-0">
         {% for limit in rate_info.limits %}
           <li class="mb-2"><span class="pill">{{ limit }}</span></li>
         {% endfor %}
       </ul>
     {% else %}
-      <p class="meta mb-0">Rajoituksia ei ole määritelty.</p>
+      <p class="meta mb-0">Rajoitusten valvonta on pois käytöstä tässä ympäristössä.</p>
     {% endif %}
   </div>
 </div>

--- a/tests/test_developer_bp.py
+++ b/tests/test_developer_bp.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.mark.integration
+def test_developer_app_detail_shows_actual_rate_limits(seeded_data, developer_client):
+
+    response = developer_client.get(f"/developer/apps/{seeded_data['app_id']}")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "86400 per day" in body
+    assert "3600 per hour" in body
+    assert "10 per second" in body
+    assert "Sovelluksen oletusrajat" in body

--- a/tests/test_developer_bp.py
+++ b/tests/test_developer_bp.py
@@ -1,8 +1,27 @@
 import pytest
 
+from tests.conftest import _client_for_user, _seed_database
+
 
 @pytest.mark.integration
-def test_developer_app_detail_shows_actual_rate_limits(seeded_data, developer_client):
+def test_developer_app_detail_hides_rate_limits_when_enforcement_disabled(seeded_data, developer_client):
+
+    response = developer_client.get(f"/developer/apps/{seeded_data['app_id']}")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Rajoitusten valvonta on pois käytöstä tässä ympäristössä." in body
+    assert "86400 per day" not in body
+    assert "3600 per hour" not in body
+    assert "10 per second" not in body
+    assert "Sovelluksen oletusrajat" not in body
+
+
+@pytest.mark.integration
+def test_developer_app_detail_shows_actual_rate_limits_when_enforcement_enabled(app_factory, db):
+    app = app_factory(ENFORCE_RATELIMIT=True)
+    seeded_data = _seed_database(app, db)
+    developer_client = _client_for_user(app, seeded_data["developer_id"])
 
     response = developer_client.get(f"/developer/apps/{seeded_data['app_id']}")
 


### PR DESCRIPTION
This splits the developer-panel rate-limit fix into its own PR.

What it does:
- exposes the app’s actual global limiter defaults from app config
- renders those concrete limits in the developer app detail panel instead of placeholder `N/A` values
- adds a regression test so the values stay visible

Refs #564