### PR TITLE
Add pagination and richer search to the admin user list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * PR preview URLs now use `pr-<id>.mielenosoitukset.fi` instead of the deeper `previews.*` nesting, which keeps them within Cloudflare's normal first-level subdomain coverage.
 * Preview config files are now written world-readable inside the container mount, so the app process can load its per-PR config instead of crashing on permission denied.
 * Preview Caddy routing now points directly at each app container's Docker IP, avoiding the flaky localhost publish path on the preview host.
+* Admin user list now paginates server-side and searches display names in addition to usernames and emails, making the user control panel easier to scan at larger scale.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.
 * Demo cards keep cover images centered without stretching, preventing warped previews across list views.

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -1,6 +1,8 @@
 from bson.objectid import ObjectId
 from flask import Blueprint, redirect, render_template, request, session, url_for, jsonify
 from flask_login import current_user, login_required
+import math
+import re
 
 from mielenosoitukset_fi.users.models import User
 from mielenosoitukset_fi.emailer.EmailSender import EmailSender
@@ -37,23 +39,44 @@ def log_request_info():
 @permission_required("LIST_USERS")
 def user_control():
     """Render the user control panel with a list of users."""
-    search_query = request.args.get("search", "")
+    search_query = (request.args.get("search", "") or "").strip()
+    page = max(request.args.get("page", default=1, type=int) or 1, 1)
+    per_page = request.args.get("per_page", default=20, type=int) or 20
+    per_page = min(max(per_page, 1), 100)
     pending_token_requests = mongo.api_token_requests.count_documents({"status": "pending"})
-    users_cursor = mongo.users.find(
-        {
+    search_filter = {}
+    if search_query:
+        escaped_query = re.escape(search_query)
+        search_filter = {
             "$or": [
-                {"username": {"$regex": search_query, "$options": "i"}},
-                {"email": {"$regex": search_query, "$options": "i"}},
+                {"username": {"$regex": escaped_query, "$options": "i"}},
+                {"email": {"$regex": escaped_query, "$options": "i"}},
+                {"displayname": {"$regex": escaped_query, "$options": "i"}},
             ]
         }
-        if search_query
-        else {}
+
+    total_users = mongo.users.count_documents(search_filter)
+    total_pages = max(math.ceil(total_users / per_page), 1)
+    page = min(page, total_pages)
+    prev_page = page - 1 if page > 1 else None
+    next_page = page + 1 if page < total_pages else None
+    users_cursor = (
+        mongo.users.find(search_filter)
+        .sort("username", 1)
+        .skip((page - 1) * per_page)
+        .limit(per_page)
     )
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}user/list.html",
-        users=users_cursor,
+        users=list(users_cursor),
         search_query=search_query,
+        current_page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+        prev_page=prev_page,
+        next_page=next_page,
         pending_token_requests=pending_token_requests,
+        total_users=total_users,
     )
 
 

--- a/mielenosoitukset_fi/templates/admin_V2/_users_table.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_users_table.html
@@ -98,9 +98,7 @@
   </tbody>
 </table>
 
-<!-- Pagination -->
-<!-- AS OF NOW WE DO NOT SUPPORT NAVIGATION -->
-<!--
+{% if users %}
 <nav aria-label="User pagination">
   <ul class="pagination justify-content-center mt-3">
     {% if prev_page %}
@@ -123,14 +121,12 @@
       <li class="page-item disabled"><span class="page-link">{{ _('Seuraava') }} <i class="fas fa-angle-right"></i></span></li>
     {% endif %}
   </ul>
-</nav>-->
-
-<script>
-// Initialize Bootstrap tooltips
-document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
-  new bootstrap.Tooltip(el);
-});
-</script>
+</nav>
+{% else %}
+<div class="alert alert-light border mt-3 mb-0">
+  {{ _('Ei käyttäjiä tällä haulla.') }}
+</div>
+{% endif %}
 
 <style>
 /* Hover effect + pointer */

--- a/mielenosoitukset_fi/templates/admin_V2/user/list.html
+++ b/mielenosoitukset_fi/templates/admin_V2/user/list.html
@@ -112,18 +112,35 @@
   }
 
   // ======== Live Search ========
+  function loadUserTable(url) {
+    $.get(url, function (html) {
+      const newTable = $(html).find('#usersTableContainer').html();
+      $('#usersTableContainer').html(newTable);
+      initUserTableEnhancements($('#usersTableContainer'));
+    });
+  }
+
   let searchTimeout;
   $('#userSearch').on('input', function () {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
       const query = encodeURIComponent($(this).val());
-      $.get(`{{ url_for('admin_user.user_control') }}?search=${query}`, function (html) {
-        // Extract only the table part from the returned HTML
-        const newTable = $(html).find('#usersTableContainer').html();
-        $('#usersTableContainer').html(newTable);
-      });
+      loadUserTable(`{{ url_for('admin_user.user_control') }}?search=${query}&page=1&per_page={{ per_page }}`);
     }, 300);
   });
+
+  $(document).on('click', '#usersTableContainer .pagination a.page-link', function (event) {
+    event.preventDefault();
+    loadUserTable(this.href);
+  });
+
+  function initUserTableEnhancements(scope = $(document)) {
+    scope.find('[data-bs-toggle="tooltip"]').each(function () {
+      bootstrap.Tooltip.getOrCreateInstance(this);
+    });
+  }
+
+  initUserTableEnhancements();
 
   // ======== Sortable Table Columns ========
   $(document).on('click', 'th.sortable', function () {

--- a/tests/test_admin_user_bp.py
+++ b/tests/test_admin_user_bp.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timezone
+
+from bson import ObjectId
+
+
+def _insert_admin_user_list_entries(db):
+    entries = [
+        {
+            "_id": ObjectId(),
+            "username": "pagination-user-01",
+            "displayname": "Pagination User 01",
+            "email": "pagination-user-01@example.test",
+            "role": "user",
+            "confirmed": True,
+            "last_login": datetime.now(timezone.utc),
+            "global_permissions": [],
+        },
+        {
+            "_id": ObjectId(),
+            "username": "pagination-user-02",
+            "displayname": "Pagination User 02",
+            "email": "pagination-user-02@example.test",
+            "role": "user",
+            "confirmed": True,
+            "last_login": datetime.now(timezone.utc),
+            "global_permissions": [],
+        },
+        {
+            "_id": ObjectId(),
+            "username": "pagination-user-03",
+            "displayname": "Pagination User 03",
+            "email": "pagination-user-03@example.test",
+            "role": "user",
+            "confirmed": True,
+            "last_login": datetime.now(timezone.utc),
+            "global_permissions": [],
+        },
+        {
+            "_id": ObjectId(),
+            "username": "displayname-search-user",
+            "displayname": "Friendly Admin",
+            "email": "friendly-admin@example.test",
+            "role": "user",
+            "confirmed": True,
+            "last_login": datetime.now(timezone.utc),
+            "global_permissions": [],
+        },
+    ]
+    db.users.insert_many(entries)
+
+
+def test_user_control_paginates_results(admin_client, db, seeded_data):
+    _insert_admin_user_list_entries(db)
+
+    first_page = admin_client.get("/admin/user/?search=pagination-user-&page=1&per_page=2")
+    second_page = admin_client.get("/admin/user/?search=pagination-user-&page=2&per_page=2")
+
+    assert first_page.status_code == 200
+    assert second_page.status_code == 200
+
+    first_body = first_page.get_data(as_text=True)
+    second_body = second_page.get_data(as_text=True)
+
+    assert "pagination-user-01" in first_body
+    assert "pagination-user-02" in first_body
+    assert "pagination-user-03" not in first_body
+    assert "Sivu 1 / 2" in first_body
+
+    assert "pagination-user-03" in second_body
+    assert "Sivu 2 / 2" in second_body
+
+
+def test_user_control_searches_display_names(admin_client, db, seeded_data):
+    _insert_admin_user_list_entries(db)
+
+    response = admin_client.get("/admin/user/?search=friendly")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Friendly Admin" in body
+    assert "displayname-search-user" in body


### PR DESCRIPTION
## Summary
- add server-side pagination to the admin user list
- search users by username, email, and display name instead of only the narrower original fields
- keep AJAX search and pagination links in sync with the rendered table
- add regression coverage for both pagination and display-name search

## Testing
- `python -m pytest -q tests/test_admin_user_bp.py --maxfail=1`

Fixes #548