### PR TITLE
Make the public guides accessible without login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
+* Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.
 * Added `docs/roadmap_2026.md`, a project roadmap that groups the April 27, 2026 backlog into admin UX, multilinguality, reliability, and cleanup workstreams with milestones for closing the 2026 baseline issues.
 * Added regression coverage for duplicate demo submissions, duplicate-submission merge handling, and background-job demo audit/history recording so CI catches duplicate creation and demo ID drift earlier.
 * Added a source-driven surface manifest for Flask routes, background jobs, and Socket.IO events so CI fails when the application surface changes without an explicit test coverage update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * PR preview URLs now use `pr-<id>.mielenosoitukset.fi` instead of the deeper `previews.*` nesting, which keeps them within Cloudflare's normal first-level subdomain coverage.
 * Preview config files are now written world-readable inside the container mount, so the app process can load its per-PR config instead of crashing on permission denied.
 * Preview Caddy routing now points directly at each app container's Docker IP, avoiding the flaky localhost publish path on the preview host.
+* Public guides at `/ohjeet` are now accessible without login, and the public footer links to them directly so the documentation is easier to find.
 * Fixed the config loader so the Flask session secret stays separate from the S3 secret key; preview login pages no longer 500 because `session` is unavailable.
 * Admin dashboard theme switching now applies explicit `light`/`dark` modes consistently in the shared admin shell, aligning Bootstrap theme variables with the custom theme classes and improving sidebar/footer readability.
 * Admin dashboard reporter info popups now use theme-aware body text colors, fixing unreadable white-on-white submitter details in the modal.

--- a/deploy/preview_deploy.sh
+++ b/deploy/preview_deploy.sh
@@ -250,8 +250,8 @@ deploy_preview() {
 
   echo "[preview] publishing caddy snippet"
   cat >"$snippet_file" <<EOF
-@preview host ${hostname}
-handle @preview {
+@preview_pr_${pr_number} host ${hostname}
+handle @preview_pr_${pr_number} {
   reverse_proxy ${container_ip}:5002
 }
 EOF

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -2346,8 +2346,6 @@ def init_routes(app):
 
     @app.route("/ohjeet/")
     @app.route("/ohjeet")
-    @login_required
-    @admin_required
     def public_guides():
         return render_template("ohjeet/index.html")
 

--- a/mielenosoitukset_fi/templates/base.html
+++ b/mielenosoitukset_fi/templates/base.html
@@ -876,6 +876,8 @@ body.banner-closed {
         |
         <li><a href="{{ url_for('contact') }}">{{ _('Ota yhteyttä') }}</a></li>
         |
+        <li><a href="{{ url_for('public_guides') }}">{{ _('Ohjeet') }}</a></li>
+        |
         <li><a href="{{ url_for('developer.dashboard') }}">{{ _('Kehittäjille') }}</a></li>
       </ul>
       <ul class="social-media-links">

--- a/tests/test_public_guides.py
+++ b/tests/test_public_guides.py
@@ -1,0 +1,7 @@
+def test_public_guides_are_accessible_without_login(client):
+    response = client.get("/ohjeet")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Selkeät ohjeet kaikille järjestäjille" in body
+    assert "Ohjekeskus" in body


### PR DESCRIPTION
## Summary
- make the public guides route accessible without login
- add a visible public footer link so the guides are easier to discover
- add regression coverage that verifies `/ohjeet` works for anonymous users

## Testing
- `python -m pytest -q tests/test_public_guides.py --maxfail=1`

Refs #563