### PR TITLE
Rework board approval flow for privileged roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
+* Added a board-member approval workflow for `god` and `global_admin` access, including approval documents, per-member confirmation, automatic role application, tamper-evident signed request records, audited god demotion requests, and clearer board request/audit UI status messaging.
 * Added `docs/roadmap_2026.md`, a project roadmap that groups the April 27, 2026 backlog into admin UX, multilinguality, reliability, and cleanup workstreams with milestones for closing the 2026 baseline issues.
 * Added regression coverage for duplicate demo submissions, duplicate-submission merge handling, and background-job demo audit/history recording so CI catches duplicate creation and demo ID drift earlier.
 * Added a source-driven surface manifest for Flask routes, background jobs, and Socket.IO events so CI fails when the application surface changes without an explicit test coverage update.

--- a/config.py
+++ b/config.py
@@ -112,6 +112,10 @@ class Config:
         cls.BABEL_LANGUAGES = cls.BABEL_CONFIG.get("LANGUAGES", {"en": "English"})
 
         cls.SECRET_KEY = config.get("SECRET_KEY", "secret_key")
+        cls.BOARD_APPROVAL_SIGNING_KEY = config.get(
+            "BOARD_APPROVAL_SIGNING_KEY",
+            cls.SECRET_KEY,
+        )
         cls.PORT = config.get("PORT", 8000)
         cls.DEBUG = config.get("DEBUG", True)
 
@@ -134,7 +138,6 @@ class Config:
         cls.ENFORCE_RATELIMIT = config.get("ENFORCE_RATELIMIT", True)
 
         cls.ADMIN_EMAIL = config.get("ADMIN_EMAIL", "itc@luova.club")
-
         cls.CACHE_TYPE = config.get("CACHE_TYPE", "SimpleCache")
         cls.CACHE_DEFAULT_TIMEOUT = config.get("CACHE_DEFAULT_TIMEOUT", 300)
         cls.CACHE_REDIS_HOST = config.get("REDIS_HOST", "localhost")

--- a/docs/board_governance_handoff.md
+++ b/docs/board_governance_handoff.md
@@ -1,0 +1,60 @@
+# Board Governance Handoff
+
+Status: in progress on branch `fix-board-compliance-approval`
+
+## Shipped In This Branch
+
+- Added board-request based governance for `god` and `global_admin`.
+- Added `board_member` role-based access to the board clearance and board audit surfaces.
+- Blocked manual promotion to `god` / `global_admin` from the normal admin user editor.
+- Required board-request flow for demoting `god`.
+- Added tamper-evident integrity signatures for board requests so raw DB edits do not silently grant or preserve privileged access.
+- Updated the board UI and audit UI to reflect request status more clearly.
+- Added focused regression coverage in `tests/test_board_compliance.py`.
+
+## Important Security Model
+
+- `god` and `global_admin` are board-managed roles.
+- Requests require:
+  - approval document URL
+  - approval document SHA256
+  - approval from all active `board_member` users
+- Approved requests automatically apply the target role.
+- Direct DB edits to request payloads invalidate the request integrity signature.
+- Invalid requests no longer count as active clearance and cannot receive more votes.
+
+## Remaining Work
+
+1. Add stronger board-audit detail views.
+   - Show full request lifecycle grouped by request ID instead of only flat events.
+   - Include integrity-failure markers directly in the audit listing.
+
+2. Add upload-based approval-document handling.
+   - Replace URL-only input with actual managed file upload if that is the intended long-term path.
+   - Store immutable metadata for the uploaded approval document.
+
+3. Harden board-member lifecycle.
+   - Decide whether `board_member` itself should become board-managed.
+   - Add protections for removing the last active board member.
+
+4. Add dedicated admin tests for self-edit and privileged role transitions.
+   - Explicit `god` self-edit success path.
+   - Explicit rejection for manual `global_admin` promotion.
+
+5. Rework `/board/audit/ui` further.
+   - Improve filtering and request grouping.
+   - Replace remaining internal action vocabulary with user-facing language everywhere.
+
+6. Consider moving board-request signing off the main app secret.
+   - `BOARD_APPROVAL_SIGNING_KEY` exists now and falls back to `SECRET_KEY`.
+   - Production should set it explicitly.
+
+## Validation Already Run
+
+- `python -m pytest -q tests/test_board_compliance.py --maxfail=1`
+- `python -m py_compile config.py mielenosoitukset_fi/admin/board_compliance.py tests/test_board_compliance.py`
+
+## Caution
+
+- `.codex` is untracked local noise and should stay out of commits.
+- This branch contains a broad board-governance slice; do not mix unrelated preview/admin tasks into it.

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -4,7 +4,11 @@ from flask_login import current_user, login_required
 
 from mielenosoitukset_fi.users.models import User
 from mielenosoitukset_fi.emailer.EmailSender import EmailSender
-from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
+from mielenosoitukset_fi.utils.wrappers import (
+    admin_required,
+    permission_required,
+    has_board_approved_god_access,
+)
 from mielenosoitukset_fi.utils.variables import PERMISSIONS_GROUPS
 from mielenosoitukset_fi.utils.validators import valid_email
 from mielenosoitukset_fi.utils.database import stringify_object_ids
@@ -13,6 +17,12 @@ from mielenosoitukset_fi.utils.flashing import flash_message
 from .utils import get_org_name, mongo, _ADMIN_TEMPLATE_FOLDER
 from flask_babel import _
 from datetime import datetime
+from mielenosoitukset_fi.admin.board_compliance import (
+    BOARD_MANAGED_ROLES,
+    BOARD_MEMBER_ROLE,
+    has_board_clearance,
+    has_global_admin_clearance,
+)
 
 
 email_sender = EmailSender()
@@ -57,7 +67,24 @@ def user_control():
     )
 
 
-USER_ACCESS_LEVELS = {"god": 4, "global_admin": 3, "admin": 2, "user": 1}
+USER_ACCESS_LEVELS = {"god": 4, "global_admin": 3, "admin": 2, "board_member": 1, "user": 1}
+
+
+def _effective_access_level(user):
+    if not getattr(user, "is_authenticated", False):
+        return 0
+
+    if has_board_approved_god_access(user):
+        return USER_ACCESS_LEVELS["god"]
+
+    if getattr(user, "global_admin", False):
+        return USER_ACCESS_LEVELS["global_admin"]
+
+    role = getattr(user, "role", None)
+    if role == "god":
+        return 0
+
+    return USER_ACCESS_LEVELS.get(role, 0)
 
 
 def compare_user_levels(user1, user2):  # Check if the user1 is higher than user2
@@ -75,19 +102,17 @@ def compare_user_levels(user1, user2):  # Check if the user1 is higher than user
 
 
     """
-    if user1.role not in USER_ACCESS_LEVELS or user2.role not in USER_ACCESS_LEVELS:
-        if user2.role not in USER_ACCESS_LEVELS:
-            user2.role = "user"
-        else:
-            raise ValueError("Invalid user role")
-    
-    if user1._id == ObjectId("66c25768dad432ad39ce38d5"):
+    if has_board_approved_god_access(user1):
         return True
 
-    if user1.role == user2.role and not user1._id == ObjectId("66c25768dad432ad39ce38d5"): # HARD CODED EXCEPTION FOR EMILIA
+    if user1.role == user2.role:
         return False
 
-    return USER_ACCESS_LEVELS[user1.role] > USER_ACCESS_LEVELS[user2.role]
+    return _effective_access_level(user1) > _effective_access_level(user2)
+
+def _role_change_requires_board(current_role, requested_role) -> bool:
+    return requested_role in BOARD_MANAGED_ROLES and requested_role != current_role
+
 
 def safe_redirect(target):
     """Redirect safely with redi_count check to prevent loops."""
@@ -149,23 +174,34 @@ def edit_user(user_id):
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # estä oman roolin muutos
-        if current_user._id == user_id and incoming["role"] != current_user.role:
+        if current_user._id == ObjectId(user_id) and incoming["role"] != current_user.role:
             flash_message("Et voi muuttaa omaa rooliasi.", "error")
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # estä ylennys yli oman tason
-        if USER_ACCESS_LEVELS.get(incoming["role"], 0) > USER_ACCESS_LEVELS.get(current_user.role, 0):
+        if _role_change_requires_board(current["role"], incoming["role"]):
+            flash_message("God- ja global_admin-roolit myonnetaan board request -prosessin kautta, ei talla lomakkeella.", "error")
+            return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
+        if current["role"] == "god" and incoming["role"] != "god":
+            flash_message("God-roolin poisto vaatii board requestin ja board member -hyvaksynta ketjun.", "error")
+            return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
+        if current["role"] == "global_admin" and incoming["role"] == "god":
+            flash_message("God-rooli ei siirry suoraan lomakkeesta. Luo board request.", "error")
+            return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
+        elif USER_ACCESS_LEVELS.get(incoming["role"], 0) > USER_ACCESS_LEVELS.get(current_user.role, 0):
             flash_message("Et voi korottaa omaa tai toisen käyttäjän roolia korkeammalle kuin oma roolisi.", "error")
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # estä super-käyttäjän itse-alennus
-        if (user.role == "global_admin" and current_user._id == user_id
+        if (user.role == "global_admin" and current_user._id == ObjectId(user_id)
                 and incoming["role"] != "global_admin"):
             flash_message("Superkäyttäjät eivät voi alentaa itseään.", "error")
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # 3️⃣ Muutosdiff
         changes = {k: v for k, v in incoming.items() if v != current[k]}
+        if "role" in changes:
+            changes["global_admin"] = changes["role"] == "global_admin"
 
         # 4️⃣ Päivitä vain jos on muutoksia
         if changes:
@@ -253,17 +289,27 @@ def save_user(user_id):
     global_permissions = request.form.getlist("permissions[global][]")  # ← 🔥 this line
 
     # Prevent role escalation
-    if current_user._id == user_id and role != current_user.role:
+    if current_user._id == ObjectId(user_id) and role != current_user.role:
         flash_message("Et voi muuttaa omaa rooliasi.", "error")
         return redirect(url_for("admin_user.edit_user", user_id=user_id))
 
     # Prevent global admins from lowering their role
     if (
         user.role == "global_admin"
-        and current_user._id == user_id
+        and current_user._id == ObjectId(user_id)
         and role != "global_admin"
     ):
         flash_message("Et voi alentaa omaa rooliasi globaalina ylläpitäjänä.", "error")
+        return redirect(url_for("admin_user.edit_user", user_id=user_id))
+
+    if _role_change_requires_board(user.role, role):
+        flash_message("God- ja global_admin-roolit myonnetaan board request -prosessin kautta, ei talla lomakkeella.", "error")
+        return redirect(url_for("admin_user.edit_user", user_id=user_id))
+    if user.role == "god" and role != "god":
+        flash_message("God-roolin poisto vaatii board requestin ja board member -hyvaksynta ketjun.", "error")
+        return redirect(url_for("admin_user.edit_user", user_id=user_id))
+    if USER_ACCESS_LEVELS.get(role, 0) > USER_ACCESS_LEVELS.get(current_user.role, 0):
+        flash_message("Et voi korottaa omaa tai toisen käyttäjän roolia korkeammalle kuin oma roolisi.", "error")
         return redirect(url_for("admin_user.edit_user", user_id=user_id))
 
     # Validate required fields
@@ -280,6 +326,7 @@ def save_user(user_id):
     user.username = username
     user.email = email
     user.role = role
+    user.global_admin = role == "global_admin"
     user.confirmed = confirmed
     user.global_permissions = global_permissions  # ← 🔥 this line
 
@@ -324,13 +371,16 @@ import warnings
 
 
 @admin_user_bp.route("/api/check_clearance/<user_id>")
+@login_required
+@admin_required
+@permission_required("EDIT_USER")
 def check_clearance(user_id):
     """
-    Temporary endpoint to check if the board has approved the user for global_admin role.
-    Currently always returns False.
+    Check whether the user has a valid signed board clearance for god access.
     """
     return jsonify({
-        "has_clearance": False
+        "has_clearance": has_board_clearance(user_id),
+        "has_global_admin_clearance": has_global_admin_clearance(user_id),
     })
 
 
@@ -458,8 +508,12 @@ def create_user():
     if not valid_email(email):
         flash_message("Virheellinen sähköpostimuoto.", "error")
         return redirect(request.referrer or url_for("admin_user.user_control"))
-    if role not in ["user", "admin", "global_admin"]:
+    if role not in ["user", "admin", BOARD_MEMBER_ROLE, "global_admin", "god"]:
         flash_message("Rooli ei ole kelvollinen.", "error")
+        return redirect(request.referrer or url_for("admin_user.user_control"))
+
+    if role in BOARD_MANAGED_ROLES:
+        flash_message("God- ja global_admin-roolit luodaan board request -prosessin kautta, eika suoraan lomakkeella.", "error")
         return redirect(request.referrer or url_for("admin_user.user_control"))
 
     # Check if email already exists
@@ -529,7 +583,7 @@ def api_force_password_change():
     flask.Response
         JSON response indicating success or failure.
     """
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     user_id = data.get("user_id")
 
     if not user_id:
@@ -540,6 +594,12 @@ def api_force_password_change():
         return jsonify({"status": "ERROR", "message": "Käyttäjää ei löytynyt."}), 404
 
     user_ = User.from_db(user)
+
+    if compare_user_levels(current_user, user_) is False:
+        return jsonify({
+            "status": "ERROR",
+            "message": "Et voi pakottaa saman tai korkeamman tason käyttäjän salasanan vaihtoa.",
+        }), 403
     
     user_.forced_pwd_reset = True
     user_.save()

--- a/mielenosoitukset_fi/admin/board_audit.py
+++ b/mielenosoitukset_fi/admin/board_audit.py
@@ -1,8 +1,8 @@
 from flask import Blueprint, jsonify, render_template
-from flask_login import login_required, current_user
+from flask_login import login_required
 from datetime import datetime
 
-from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
+from mielenosoitukset_fi.utils.wrappers import permission_required
 from .utils import mongo
 from bson.objectid import ObjectId
 
@@ -30,7 +30,6 @@ def log_board_action(user_id, action, granted_by):
 
 @audit_bp.route("/logs", methods=["GET"])
 @login_required
-@admin_required
 @permission_required("VIEW_CLEARANCE_AUDIT")
 def get_logs():
     """Return all board compliance audit logs."""
@@ -51,7 +50,6 @@ def get_logs():
 
 @audit_bp.route("/ui")
 @login_required
-@admin_required
 @permission_required("VIEW_CLEARANCE_AUDIT")
 def audit_ui():
     """Render the audit log UI for the board."""

--- a/mielenosoitukset_fi/admin/board_compliance.py
+++ b/mielenosoitukset_fi/admin/board_compliance.py
@@ -1,121 +1,554 @@
-from flask import Blueprint, render_template, request, jsonify, redirect, url_for
-from flask_login import current_user, login_required
-from bson.objectid import ObjectId
+import hashlib
+import hmac
+import json
 from datetime import datetime
 
-from mielenosoitukset_fi.users.models import User
-from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
-from mielenosoitukset_fi.utils.flashing import flash_message
+from bson.objectid import ObjectId
+from flask import Blueprint, jsonify, render_template, request
+from flask_login import current_user, login_required
 
-from .utils import mongo
+from config import Config
+from mielenosoitukset_fi.utils.wrappers import permission_required
+
 from .board_audit import log_board_action
+from .utils import mongo
 
 board_bp = Blueprint("board_compliance", __name__, url_prefix="/board")
 
-# In-memory storage for simplicity; can be a separate Mongo collection
-BOARD_CLEARANCES = {}  # user_id -> {"approved": bool, "granted_by": str, "timestamp": datetime}
+BOARD_MEMBER_ROLE = "board_member"
+BOARD_MANAGED_ROLES = {"god", "global_admin"}
+BOARD_REQUEST_TYPES = {"assign_role", "revoke_god"}
+DEFAULT_GOD_FALLBACK_ROLE = "admin"
+BOARD_REQUEST_INTEGRITY_VERSION = "board-request-v1"
 
 
-# ────────────── GET CLEARANCE STATUS ──────────────
+def _requests_collection():
+    return mongo.board_clearance_requests
+
+
+def _now():
+    return datetime.utcnow()
+
+
+def _board_request_signing_key() -> bytes:
+    key = getattr(Config, "BOARD_APPROVAL_SIGNING_KEY", None) or Config.SECRET_KEY
+    return str(key).encode("utf-8")
+
+
+def _mongo_datetime_iso(value) -> str | None:
+    if not value:
+        return None
+    normalized = value.replace(microsecond=(value.microsecond // 1000) * 1000)
+    return normalized.isoformat()
+
+
+def _integrity_approvals(doc: dict) -> list[dict]:
+    approvals = []
+    for vote in doc.get("approvals", []):
+        approvals.append(
+            {
+                "board_member_id": vote.get("board_member_id"),
+                "username": vote.get("username"),
+                "decision": vote.get("decision"),
+                "note": vote.get("note"),
+                "decided_at": _mongo_datetime_iso(vote.get("decided_at")),
+            }
+        )
+    return sorted(approvals, key=lambda vote: (vote.get("board_member_id") or "", vote.get("decided_at") or ""))
+
+
+def _request_integrity_payload(doc: dict) -> dict:
+    return {
+        "version": BOARD_REQUEST_INTEGRITY_VERSION,
+        "user_id": doc.get("user_id"),
+        "username": doc.get("username"),
+        "current_role": doc.get("current_role"),
+        "requested_role": doc.get("requested_role"),
+        "request_type": doc.get("request_type"),
+        "fallback_role": doc.get("fallback_role"),
+        "status": doc.get("status"),
+        "requested_by": doc.get("requested_by"),
+        "requested_by_user_id": doc.get("requested_by_user_id"),
+        "reason": doc.get("reason"),
+        "approval_document_url": doc.get("approval_document_url"),
+        "approval_document_sha256": doc.get("approval_document_sha256"),
+        "required_approver_ids": sorted(doc.get("required_approver_ids", [])),
+        "approvals": _integrity_approvals(doc),
+        "created_at": _mongo_datetime_iso(doc.get("created_at")),
+        "resolved_at": _mongo_datetime_iso(doc.get("resolved_at")),
+        "active_role_grant": bool(doc.get("active_role_grant", False)),
+    }
+
+
+def _request_integrity_signature(doc: dict) -> str:
+    payload = json.dumps(
+        _request_integrity_payload(doc),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hmac.new(
+        _board_request_signing_key(),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _stamp_request_integrity(doc: dict) -> dict:
+    doc["integrity_version"] = BOARD_REQUEST_INTEGRITY_VERSION
+    doc["integrity_signature"] = _request_integrity_signature(doc)
+    return doc
+
+
+def _request_integrity_ok(doc: dict) -> bool:
+    if not doc:
+        return False
+    if doc.get("integrity_version") != BOARD_REQUEST_INTEGRITY_VERSION:
+        return False
+    signature = doc.get("integrity_signature")
+    if not signature:
+        return False
+    return hmac.compare_digest(signature, _request_integrity_signature(doc))
+
+
+def _is_board_member(user) -> bool:
+    if not getattr(user, "is_authenticated", False):
+        return False
+    return getattr(user, "role", None) == BOARD_MEMBER_ROLE or user.has_permission("MANAGE_CLEARANCE")
+
+
+def _board_members():
+    return list(
+        mongo.users.find(
+            {
+                "role": BOARD_MEMBER_ROLE,
+                "active": {"$ne": False},
+                "confirmed": True,
+            }
+        )
+    )
+
+
+def _required_board_member_ids():
+    return [str(doc["_id"]) for doc in _board_members()]
+
+
+def _serialize_vote(vote: dict) -> dict:
+    return {
+        "board_member_id": vote.get("board_member_id"),
+        "username": vote.get("username"),
+        "decision": vote.get("decision"),
+        "note": vote.get("note"),
+        "decided_at": vote.get("decided_at").isoformat() if vote.get("decided_at") else None,
+    }
+
+
+def _serialize_request(doc: dict) -> dict:
+    return {
+        "id": str(doc.get("_id")),
+        "user_id": doc.get("user_id"),
+        "username": doc.get("username"),
+        "current_role": doc.get("current_role"),
+        "requested_role": doc.get("requested_role"),
+        "request_type": doc.get("request_type"),
+        "fallback_role": doc.get("fallback_role"),
+        "status": doc.get("status"),
+        "requested_by": doc.get("requested_by"),
+        "reason": doc.get("reason"),
+        "approval_document_url": doc.get("approval_document_url"),
+        "approval_document_sha256": doc.get("approval_document_sha256"),
+        "created_at": doc.get("created_at").isoformat() if doc.get("created_at") else None,
+        "resolved_at": doc.get("resolved_at").isoformat() if doc.get("resolved_at") else None,
+        "approvals": [_serialize_vote(vote) for vote in doc.get("approvals", [])],
+        "required_approver_ids": doc.get("required_approver_ids", []),
+        "active_role_grant": bool(doc.get("active_role_grant", False)),
+        "integrity_valid": _request_integrity_ok(doc),
+    }
+
+
+def _active_role_request(user_id: str, role: str):
+    return _requests_collection().find_one(
+        {
+            "user_id": str(user_id),
+            "requested_role": role,
+            "request_type": "assign_role",
+            "status": "approved",
+            "active_role_grant": True,
+        },
+        sort=[("resolved_at", -1), ("_id", -1)],
+    )
+
+
+def has_board_clearance(user_id):
+    """Return True when the user has an active approved god request."""
+    request_doc = _active_role_request(str(user_id), "god")
+    return bool(request_doc and _request_integrity_ok(request_doc))
+
+
+def has_global_admin_clearance(user_id):
+    """Return True when the user has an active approved global_admin request."""
+    request_doc = _active_role_request(str(user_id), "global_admin")
+    return bool(request_doc and _request_integrity_ok(request_doc))
+
+
+def _apply_request_resolution(request_doc: dict):
+    user_oid = ObjectId(request_doc["user_id"])
+    user_doc = mongo.users.find_one({"_id": user_oid})
+    if not user_doc:
+        raise ValueError("Target user no longer exists.")
+
+    if request_doc["request_type"] == "assign_role":
+        new_role = request_doc["requested_role"]
+        update = {"role": new_role, "global_admin": new_role == "global_admin"}
+        if new_role == "global_admin":
+            update["global_admin"] = True
+        mongo.users.update_one({"_id": user_oid}, {"$set": update})
+
+        if new_role == "god":
+            _requests_collection().update_many(
+                {
+                    "user_id": request_doc["user_id"],
+                    "requested_role": "god",
+                    "request_type": "assign_role",
+                    "_id": {"$ne": request_doc["_id"]},
+                },
+                {"$set": {"active_role_grant": False}},
+            )
+        if new_role == "global_admin":
+            _requests_collection().update_many(
+                {
+                    "user_id": request_doc["user_id"],
+                    "requested_role": "global_admin",
+                    "request_type": "assign_role",
+                    "_id": {"$ne": request_doc["_id"]},
+                },
+                {"$set": {"active_role_grant": False}},
+            )
+
+    elif request_doc["request_type"] == "revoke_god":
+        fallback_role = request_doc.get("fallback_role") or DEFAULT_GOD_FALLBACK_ROLE
+        mongo.users.update_one(
+            {"_id": user_oid},
+            {"$set": {"role": fallback_role, "global_admin": False}},
+        )
+        _requests_collection().update_many(
+            {
+                "user_id": request_doc["user_id"],
+                "requested_role": "god",
+                "request_type": "assign_role",
+                "status": "approved",
+                "active_role_grant": True,
+            },
+            {"$set": {"active_role_grant": False}},
+        )
+    else:
+        raise ValueError(f"Unknown board request type: {request_doc['request_type']}")
+
+
+def _resolve_request_if_ready(request_doc: dict) -> dict:
+    required_approver_ids = set(request_doc.get("required_approver_ids", []))
+    votes = request_doc.get("approvals", [])
+    if not required_approver_ids:
+        raise ValueError("No active board members are configured.")
+
+    decisions = {vote["board_member_id"]: vote["decision"] for vote in votes}
+    if any(decision == "reject" for decision in decisions.values()):
+        update = {
+            "status": "rejected",
+            "resolved_at": _now(),
+            "updated_at": _now(),
+            "active_role_grant": False,
+        }
+        request_doc = _stamp_request_integrity({**request_doc, **update})
+        _requests_collection().update_one(
+            {"_id": request_doc["_id"]},
+            {
+                "$set": {
+                    "status": request_doc["status"],
+                    "resolved_at": request_doc["resolved_at"],
+                    "updated_at": request_doc["updated_at"],
+                    "active_role_grant": request_doc["active_role_grant"],
+                    "integrity_version": request_doc["integrity_version"],
+                    "integrity_signature": request_doc["integrity_signature"],
+                }
+            },
+        )
+        return request_doc
+
+    approved_ids = {
+        vote["board_member_id"]
+        for vote in votes
+        if vote.get("decision") == "approve"
+    }
+    if required_approver_ids.issubset(approved_ids):
+        update = {
+            "status": "approved",
+            "resolved_at": _now(),
+            "updated_at": _now(),
+            "active_role_grant": request_doc["request_type"] == "assign_role",
+        }
+        request_doc = _stamp_request_integrity({**request_doc, **update})
+        _requests_collection().update_one(
+            {"_id": request_doc["_id"]},
+            {
+                "$set": {
+                    "status": request_doc["status"],
+                    "resolved_at": request_doc["resolved_at"],
+                    "updated_at": request_doc["updated_at"],
+                    "active_role_grant": request_doc["active_role_grant"],
+                    "integrity_version": request_doc["integrity_version"],
+                    "integrity_signature": request_doc["integrity_signature"],
+                }
+            },
+        )
+        _apply_request_resolution(request_doc)
+        log_board_action(
+            request_doc["user_id"],
+            f"request:{request_doc['request_type']}:{request_doc['requested_role']}:approved",
+            "board-system",
+        )
+    return request_doc
+
+
+def _latest_request_for_user(user_id: str):
+    return _requests_collection().find_one(
+        {"user_id": str(user_id)},
+        sort=[("created_at", -1), ("_id", -1)],
+    )
+
+
 @board_bp.route("/api/clearance/<user_id>", methods=["GET"])
 @login_required
-@admin_required
 @permission_required("MANAGE_CLEARANCE")
 def get_clearance(user_id):
-    """
-    Get the board clearance status for a user.
-    """
-    clearance = BOARD_CLEARANCES.get(user_id, {"approved": False})
-    return jsonify(clearance)
-
-# ────────────── SET CLEARANCE ──────────────
-@board_bp.route("/api/clearance/<user_id>", methods=["POST"])
-@login_required
-@admin_required
-@permission_required("MANAGE_CLEARANCE")
-def set_clearance(user_id):
-    """
-    Grant or revoke board clearance for global_admin role.
-    Expects JSON:
-        { "approved": true/false }
-    """
-    data = request.get_json()
-    approved = bool(data.get("approved", False))
-
-    user_doc = mongo.users.find_one({"_id": ObjectId(user_id)})
+    """Return current board-managed role state and latest request for a user."""
+    try:
+        user_doc = mongo.users.find_one({"_id": ObjectId(user_id)})
+    except Exception:
+        user_doc = None
     if not user_doc:
         return jsonify({"status": "ERROR", "message": "Käyttäjää ei löytynyt."}), 404
 
-    user = User.from_db(user_doc)
+    latest = _latest_request_for_user(user_id)
+    return jsonify(
+        {
+            "user_id": str(user_id),
+            "role": user_doc.get("role"),
+            "has_god_clearance": has_board_clearance(user_id),
+            "has_global_admin_clearance": has_global_admin_clearance(user_id),
+            "latest_request": _serialize_request(latest) if latest else None,
+        }
+    )
 
-    # Only allow board to approve users who aren't already global_admin
-    #if user.role == "global_admin" and approved:
-    #    return jsonify({"status": "ERROR", "message": "Käyttäjä on jo superkäyttäjä."}), 400
 
-    BOARD_CLEARANCES[user_id] = {
-        "approved": approved,
-        "granted_by": current_user.username,
-        "timestamp": datetime.utcnow().isoformat(),
+@board_bp.route("/api/clearance/<user_id>", methods=["POST"])
+@login_required
+@permission_required("MANAGE_CLEARANCE")
+def create_request(user_id):
+    """Create a board request to grant global_admin/god or revoke god."""
+    data = request.get_json(silent=True) or {}
+
+    try:
+        user_oid = ObjectId(user_id)
+    except Exception:
+        return jsonify({"status": "ERROR", "message": "Virheellinen käyttäjän tunniste."}), 400
+
+    user_doc = mongo.users.find_one({"_id": user_oid})
+    if not user_doc:
+        return jsonify({"status": "ERROR", "message": "Käyttäjää ei löytynyt."}), 404
+
+    requested_role = (data.get("requested_role") or "").strip()
+    request_type = (data.get("request_type") or "assign_role").strip()
+    fallback_role = (data.get("fallback_role") or DEFAULT_GOD_FALLBACK_ROLE).strip()
+    approval_document_url = (data.get("approval_document_url") or "").strip()
+    approval_document_sha256 = (data.get("approval_document_sha256") or "").strip().lower()
+    reason = (data.get("reason") or "").strip()
+
+    if request_type not in BOARD_REQUEST_TYPES:
+        return jsonify({"status": "ERROR", "message": "Virheellinen board request type."}), 400
+
+    if request_type == "assign_role" and requested_role not in BOARD_MANAGED_ROLES:
+        return jsonify({"status": "ERROR", "message": "Voit pyytää vain god- tai global_admin-roolia."}), 400
+
+    if request_type == "revoke_god":
+        requested_role = "god"
+        if user_doc.get("role") != "god":
+            return jsonify({"status": "ERROR", "message": "Vain god-roolin poisto tarvitsee tämän prosessin."}), 400
+        if fallback_role in BOARD_MANAGED_ROLES:
+            return jsonify({"status": "ERROR", "message": "God-roolin poiston kohderooli ei voi olla board-managed role."}), 400
+
+    if not approval_document_url or not approval_document_sha256:
+        return jsonify(
+            {
+                "status": "ERROR",
+                "message": "Board request vaatii dokumentin URL:n ja SHA256-hashin.",
+            }
+        ), 400
+
+    existing_pending = _requests_collection().find_one(
+        {
+            "user_id": str(user_id),
+            "requested_role": requested_role,
+            "request_type": request_type,
+            "status": "pending",
+        }
+    )
+    if existing_pending:
+        return jsonify({"status": "ERROR", "message": "Tälle käyttäjälle on jo avoin board request."}), 409
+
+    required_approver_ids = _required_board_member_ids()
+    if not required_approver_ids:
+        return jsonify({"status": "ERROR", "message": "Yhtään aktiivista board_member-käyttäjää ei ole määritelty."}), 400
+
+    now = _now()
+    request_doc = {
+        "user_id": str(user_id),
+        "username": user_doc.get("username"),
+        "current_role": user_doc.get("role"),
+        "requested_role": requested_role,
+        "request_type": request_type,
+        "fallback_role": fallback_role if request_type == "revoke_god" else None,
+        "status": "pending",
+        "requested_by": getattr(current_user, "username", "unknown"),
+        "requested_by_user_id": getattr(current_user, "id", None),
+        "reason": reason,
+        "approval_document_url": approval_document_url,
+        "approval_document_sha256": approval_document_sha256,
+        "required_approver_ids": required_approver_ids,
+        "approvals": [],
+        "created_at": now,
+        "updated_at": now,
+        "resolved_at": None,
+        "active_role_grant": False,
     }
+    _stamp_request_integrity(request_doc)
+    result = _requests_collection().insert_one(request_doc)
+    request_doc["_id"] = result.inserted_id
+    log_board_action(
+        user_id,
+        f"request:{request_type}:{requested_role}:created",
+        getattr(current_user, "username", "unknown"),
+    )
+    return jsonify({"status": "OK", "request": _serialize_request(request_doc)})
 
-    action = "myönnetty" if approved else "peruttu"
 
-    # 🔥 Log the action in the audit log
-    log_board_action(user_id, action, current_user.username)
+@board_bp.route("/api/clearance/request/<request_id>/decision", methods=["POST"])
+@login_required
+@permission_required("MANAGE_CLEARANCE")
+def decide_request(request_id):
+    """Allow board members to approve or reject a request while logged in."""
+    if not _is_board_member(current_user):
+        return jsonify({"status": "ERROR", "message": "Vain board_member voi vahvistaa tai hylätä board requestin."}), 403
 
-    return jsonify({"status": "OK", "message": f"Board clearance {action} käyttäjälle {user.username}."})
+    data = request.get_json(silent=True) or {}
+    decision = (data.get("decision") or "").strip().lower()
+    note = (data.get("note") or "").strip()
+    if decision not in {"approve", "reject"}:
+        return jsonify({"status": "ERROR", "message": "Paatoksen tulee olla approve tai reject."}), 400
+
+    try:
+        request_oid = ObjectId(request_id)
+    except Exception:
+        return jsonify({"status": "ERROR", "message": "Virheellinen board request ID."}), 400
+
+    request_doc = _requests_collection().find_one({"_id": request_oid})
+    if not request_doc:
+        return jsonify({"status": "ERROR", "message": "Board requestia ei löytynyt."}), 404
+    if not _request_integrity_ok(request_doc):
+        return jsonify({"status": "ERROR", "message": "Board requestin eheystarkistus epaonnistui. Ratkaise tilanne auditin kautta ennen jatkoa."}), 409
+    if request_doc.get("status") != "pending":
+        return jsonify({"status": "ERROR", "message": "Board request on jo ratkaistu."}), 409
+
+    board_member_id = str(current_user.id)
+    if board_member_id not in request_doc.get("required_approver_ids", []):
+        return jsonify({"status": "ERROR", "message": "Et kuulu tämän requestin vaadittuihin board approvereihin."}), 403
+
+    approvals = [vote for vote in request_doc.get("approvals", []) if vote.get("board_member_id") != board_member_id]
+    approvals.append(
+        {
+            "board_member_id": board_member_id,
+            "username": getattr(current_user, "username", "unknown"),
+            "decision": decision,
+            "note": note,
+            "decided_at": _now(),
+        }
+    )
+    request_doc = _stamp_request_integrity(
+        {
+            **request_doc,
+            "approvals": approvals,
+            "updated_at": _now(),
+        }
+    )
+    _requests_collection().update_one(
+        {"_id": request_oid},
+        {
+            "$set": {
+                "approvals": request_doc["approvals"],
+                "updated_at": request_doc["updated_at"],
+                "integrity_version": request_doc["integrity_version"],
+                "integrity_signature": request_doc["integrity_signature"],
+            }
+        },
+    )
+    request_doc = _resolve_request_if_ready(request_doc)
+    log_board_action(
+        request_doc["user_id"],
+        f"request:{request_doc['request_type']}:{request_doc['requested_role']}:{decision}",
+        getattr(current_user, "username", "unknown"),
+    )
+    return jsonify({"status": "OK", "request": _serialize_request(request_doc)})
 
 
-# ────────────── LIST ALL CLEARANCES ──────────────
 @board_bp.route("/api/clearances", methods=["GET"])
 @login_required
-@admin_required
 @permission_required("MANAGE_CLEARANCE")
 def list_clearances():
-    """
-    List all users with board clearance info.
-    """
-    result = []
-    for uid, info in BOARD_CLEARANCES.items():
-        user_doc = mongo.users.find_one({"_id": ObjectId(uid)})
-        if user_doc:
-            result.append({
-                "user_id": uid,
+    """List board requests with current user roles for the board UI."""
+    requests_payload = [
+        _serialize_request(doc)
+        for doc in _requests_collection().find().sort("created_at", -1)
+    ]
+    users_payload = []
+    for user_doc in mongo.users.find().sort("username", 1):
+        users_payload.append(
+            {
+                "id": str(user_doc["_id"]),
                 "username": user_doc.get("username"),
-                "approved": info["approved"],
-                "granted_by": info["granted_by"],
-                "timestamp": info["timestamp"],
-            })
-    return jsonify(result)
+                "role": user_doc.get("role"),
+                "is_board_member": user_doc.get("role") == BOARD_MEMBER_ROLE,
+                "has_god_clearance": has_board_clearance(user_doc["_id"]),
+                "has_global_admin_clearance": has_global_admin_clearance(user_doc["_id"]),
+            }
+        )
+    return jsonify({"users": users_payload, "requests": requests_payload})
 
-
-# ────────────── FRONTEND UTILITY ──────────────
-def has_board_clearance(user_id):
-    """Check if a user has board clearance."""
-    clearance = BOARD_CLEARANCES.get(str(user_id))
-    return clearance and clearance.get("approved", False)
 
 @board_bp.route("/ui")
 @login_required
-@admin_required
 @permission_required("MANAGE_CLEARANCE")
 def clearance_ui():
-    """
-    Render the board clearance management UI.
-    """
-    # Fetch all users for the table
-    users_cursor = mongo.users.find()
+    """Render the board request UI."""
     users = []
-    for user_doc in users_cursor:
-        uid = str(user_doc["_id"])
-        clearance = BOARD_CLEARANCES.get(uid, {"approved": False, "granted_by": None, "timestamp": None})
-        users.append({
-            "id": uid,
-            "username": user_doc.get("username"),
-            "role": user_doc.get("role"),
-            "approved": clearance["approved"],
-            "granted_by": clearance.get("granted_by"),
-            "timestamp": clearance.get("timestamp"),
-        })
-
-    return render_template("board/clearances.html", users=users)
+    for user_doc in mongo.users.find().sort("username", 1):
+        users.append(
+            {
+                "id": str(user_doc["_id"]),
+                "username": user_doc.get("username"),
+                "role": user_doc.get("role"),
+                "is_board_member": user_doc.get("role") == BOARD_MEMBER_ROLE,
+                "has_god_clearance": has_board_clearance(user_doc["_id"]),
+                "has_global_admin_clearance": has_global_admin_clearance(user_doc["_id"]),
+            }
+        )
+    requests = [
+        _serialize_request(doc)
+        for doc in _requests_collection().find().sort("created_at", -1)
+    ]
+    return render_template(
+        "board/clearances.html",
+        users=users,
+        requests=requests,
+        is_board_member=_is_board_member(current_user),
+        board_member_count=len(_required_board_member_ids()),
+    )

--- a/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
@@ -169,11 +169,12 @@
         <div class="alert alert-info align-items-start mb-3" role="alert">
           <i class="fa-solid fa-circle-info me-2 mt-1"></i>
           <div class="flex-grow-1">
-            Huomio: <strong>Superkäyttäjä / global_admin</strong> -roolia voidaan myöntää vain automaattisesti 
-            sen jälkeen, kun hallitus on antanut kirjallisen hyväksynnän ja turvaluokituksen. 
-            Roolia ei voi valita tai myöntää manuaalisesti tässä muodossa.
+            Huomio: <strong>Superkäyttäjä / global_admin</strong> ja <strong>god</strong> vaativat
+            board requestin, lupalapun dokumentoinnin ja kaikkien aktiivisten <strong>board_member</strong>-kayttajien
+            kirjautuneen vahvistuksen. Niita ei voi myontaa suoraan tasta lomakkeesta.
             <br><br>
-            Mikä tahansa yritys myöntää roolin manuaalisesti ohittaa hyväksynnän, ei onnistu järjestelmässä.
+            Tasta lomakkeesta voi luoda tavallisia kayttajia, admineja ja board membereita. Board-managed roolit syntyvat
+            vasta board approval -nakymassa.
           </div>
         </div>
 
@@ -202,7 +203,9 @@
             <select class="form-select" id="role" name="role" required>
               <option value="user">{{ _('Käyttäjä') }}</option>
               <option value="admin">{{ _('Admin') }}</option>
+              <option value="board_member">{{ _('Board member') }}</option>
               <option value="global_admin" disabled>{{ _('Superkäyttäjä (vain hallituksen hyväksynnän jälkeen)') }}</option>
+              <option value="god" disabled>{{ _('God (vain board request + board member -vahvistuksilla)') }}</option>
             </select>
           </div>
           <div class="modal-footer">

--- a/mielenosoitukset_fi/templates/admin_V2/user/edit.html
+++ b/mielenosoitukset_fi/templates/admin_V2/user/edit.html
@@ -96,33 +96,30 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    const roleSelect = document.getElementById('role');
-    const globalAdminOption = document.getElementById('role_global_admin');
     const clearanceInfoEl = document.getElementById('clearanceInfo');
 
-    // API endpoint to check clearance
     fetch('{{ url_for("board_compliance.get_clearance", user_id=user.id) }}')
         .then(res => res.json())
         .then(data => {
-            if (data.approved) {
-                globalAdminOption.disabled = false;
-
-                // Show info about who granted it and when
-                const grantedBy = data.granted_by || "N/A";
-                const timestamp = data.timestamp ? new Date(data.timestamp).toLocaleString() : "N/A";
-                clearanceInfoEl.innerHTML = `
-                    <strong>{{ _('Hallituksen hyväksyntä myönnetty') }}:</strong> ${grantedBy} <br>
-                    <strong>{{ _('Päivämäärä') }}:</strong> ${timestamp}
-                `;
+            const latest = data.latest_request;
+            const rows = [];
+            rows.push(`<strong>{{ _('Nykyinen rooli') }}:</strong> ${data.role || "N/A"}`);
+            rows.push(`<strong>{{ _('God-clearance aktiivinen') }}:</strong> ${data.has_god_clearance ? "{{ _('Kyllä') }}" : "{{ _('Ei') }}"}`);
+            rows.push(`<strong>{{ _('Global admin clearance aktiivinen') }}:</strong> ${data.has_global_admin_clearance ? "{{ _('Kyllä') }}" : "{{ _('Ei') }}"}`);
+            if (latest) {
+                rows.push(`<strong>{{ _('Viimeisin board request') }}:</strong> ${latest.request_type} / ${latest.requested_role}`);
+                rows.push(`<strong>{{ _('Tila') }}:</strong> ${latest.status}`);
+                if (latest.approval_document_url) {
+                    rows.push(`<strong>{{ _('Dokumentti') }}:</strong> <a href="${latest.approval_document_url}" target="_blank" rel="noopener">${latest.approval_document_url}</a>`);
+                }
+            }
+            if (rows.length) {
+                clearanceInfoEl.innerHTML = rows.join('<br>');
                 clearanceInfoEl.style.display = "block";
-            } else {
-                globalAdminOption.disabled = true;
-                clearanceInfoEl.style.display = "none";
             }
         })
         .catch(err => {
             console.error('Error checking board clearance:', err);
-            globalAdminOption.disabled = true;
             clearanceInfoEl.style.display = "none";
         });
 });
@@ -166,13 +163,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 <option value="user" {% if user.role=='user' %}selected{% endif %}>{{ _('Käyttäjä') }}</option>
                 <option value="admin" {% if user.role=='admin' %}selected{% endif %}>{{ _('Järjestelmänvalvoja') }}
                 </option>
-                <option value="global_admin" id="role_global_admin" {% if user.role=='global_admin' %}selected{% endif
-                    %} disabled>
+                <option value="board_member" {% if user.role=='board_member' %}selected{% endif %}>
+                    {{ _('Board member') }}
+                </option>
+                <option value="global_admin" id="role_global_admin" {% if user.role=='global_admin' %}selected{% endif %} disabled>
                     {{ _('Superkäyttäjä (vain hallituksen hyväksynnän jälkeen)') }}
+                </option>
+                <option value="god" id="role_god" {% if user.role=='god' %}selected{% endif %} disabled>
+                    {{ _('God (board request + kaikkien board memberien hyväksyntä)') }}
                 </option>
             </select>
             <small class="muted" id="globalAdminNotice">
-                {{ _('Superkäyttäjärooli voidaan valita vain, jos hallitus on antanut hyväksynnän.') }}
+                {{ _('Board member voidaan asettaa tästä. God ja global_admin syntyvät board request -prosessin kautta automaattisesti.') }}
             </small>
 <div id="clearanceInfo" style="margin-top:0.5rem; display:none; padding:0.5rem; background-color:var(--input-bg); border-radius:8px;">
     <!-- Filled dynamically by JS -->

--- a/mielenosoitukset_fi/templates/board/audit_logs.html
+++ b/mielenosoitukset_fi/templates/board/audit_logs.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/admin/recu_dash.css') }}">
 <style>
     .container {
-        max-width: 1200px;
+        max-width: 1280px;
         margin: 2rem auto;
         background-color: var(--container-bg);
         color: var(--text);
@@ -16,7 +16,34 @@
     h2 {
         font-size: 2rem;
         color: var(--primary);
-        margin-bottom: 1rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .audit-summary {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        margin: 1rem 0 1.25rem;
+    }
+
+    .summary-card {
+        background: var(--input-bg);
+        border: 1px solid var(--input-border);
+        border-radius: 12px;
+        padding: 1rem;
+    }
+
+    .summary-card .label {
+        font-size: 0.85rem;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .summary-card .value {
+        font-size: 1.1rem;
+        font-weight: 700;
+        margin-top: 0.25rem;
     }
 
     table {
@@ -29,10 +56,14 @@
         padding: 0.75rem 1rem;
         text-align: left;
         border-bottom: 1px solid var(--input-border);
+        vertical-align: top;
     }
 
     th {
         background-color: var(--input-bg);
+        position: sticky;
+        top: 0;
+        z-index: 1;
     }
 
     tr:hover {
@@ -41,16 +72,56 @@
 
     input.search-box {
         width: 100%;
-        padding: 0.5rem 1rem;
-        border-radius: 8px;
+        padding: 0.65rem 1rem;
+        border-radius: 10px;
         border: 1px solid var(--input-border);
         margin-bottom: 1rem;
         font-size: 0.95rem;
+        background: var(--input-bg);
+        color: var(--text);
     }
 
     .muted {
         font-size: 0.9rem;
         color: var(--muted);
+    }
+
+    .badge-approved {
+        background: #1f8e4b;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+    }
+
+    .badge-revoked {
+        background: #c62828;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+    }
+
+    .badge-created {
+        background: #0d6efd;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+    }
+
+    .badge-vote {
+        background: #6f42c1;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+    }
+
+    .audit-link {
+        color: var(--primary);
+        text-decoration: underline;
+        word-break: break-all;
     }
 </style>
 {% endblock %}
@@ -59,8 +130,59 @@
 <script>
     async function fetchLogs() {
         const res = await fetch("{{ url_for('board_audit.get_logs') }}");
-        const logs = await res.json();
-        return logs;
+        return await res.json();
+    }
+
+    function describeAction(action) {
+        const parts = (action || '').split(':');
+        if (parts[0] !== 'request' || parts.length < 4) {
+            return {
+                badgeClass: 'badge-vote',
+                badgeLabel: 'Event',
+                label: action || 'Unknown event'
+            };
+        }
+
+        const [, requestType, role, stage] = parts;
+        const roleLabel = role === 'global_admin' ? 'global admin' : role;
+
+        if (stage === 'created') {
+            return {
+                badgeClass: 'badge-created',
+                badgeLabel: 'Requested',
+                label: requestType === 'revoke_god'
+                    ? `God demotion request created`
+                    : `${roleLabel} request created`
+            };
+        }
+
+        if (stage === 'approve' || stage === 'reject') {
+            return {
+                badgeClass: 'badge-vote',
+                badgeLabel: stage === 'approve' ? 'Vote' : 'Rejected vote',
+                label: requestType === 'revoke_god'
+                    ? `Board member marked god demotion as ${stage}`
+                    : `Board member marked ${roleLabel} request as ${stage}`
+            };
+        }
+
+        if (stage === 'approved') {
+            return {
+                badgeClass: 'badge-approved',
+                badgeLabel: 'Applied',
+                label: requestType === 'revoke_god'
+                    ? 'God demotion approved and applied'
+                    : `${roleLabel} access approved and applied`
+            };
+        }
+
+        return {
+            badgeClass: 'badge-revoked',
+            badgeLabel: 'Rejected',
+            label: requestType === 'revoke_god'
+                ? 'God demotion request rejected'
+                : `${roleLabel} request rejected`
+        };
     }
 
     function renderLogs(logs) {
@@ -68,10 +190,12 @@
         tbody.innerHTML = "";
         logs.forEach(log => {
             const tr = document.createElement("tr");
+            const action = describeAction(log.action);
+            const badge = `<span class="${action.badgeClass}">${action.badgeLabel}</span>`;
             tr.innerHTML = `
                 <td>${log.username || 'Unknown'}</td>
-                <td>${log.action}</td>
-                <td>${log.granted_by}</td>
+                <td>${badge} <span class="ms-2">${action.label}</span></td>
+                <td>${log.granted_by || '-'}</td>
                 <td>${new Date(log.timestamp).toLocaleString()}</td>
             `;
             tbody.appendChild(tr);
@@ -84,10 +208,11 @@
 
         const searchInput = document.querySelector("#search-log");
         searchInput.addEventListener("input", () => {
-            const filtered = logs.filter(log => 
-                log.username?.toLowerCase().includes(searchInput.value.toLowerCase()) ||
-                log.action.toLowerCase().includes(searchInput.value.toLowerCase()) ||
-                log.granted_by.toLowerCase().includes(searchInput.value.toLowerCase())
+            const term = searchInput.value.toLowerCase();
+            const filtered = logs.filter(log =>
+                log.username?.toLowerCase().includes(term) ||
+                log.action.toLowerCase().includes(term) ||
+                log.granted_by?.toLowerCase().includes(term)
             );
             renderLogs(filtered);
         });
@@ -99,22 +224,39 @@
 
 {% block main_content %}
 <section class="container">
-    <h2>Board Compliance Audit Log</h2>
-    <p class="muted">Tässä näet kaikki hallintopäätökset, roolimuutokset ja oikeuksien myöntämiset.</p>
-    <input type="text" class="search-box" id="search-log" placeholder="Hae käyttäjää, toimintoa tai myöntäjää...">
-    
+    <h2>Board clearance audit</h2>
+    <p class="muted">
+        This log tracks board requests, board member votes, automatic promotions to <code>god</code> / <code>global_admin</code>,
+        and board-approved <code>god</code> removals.
+    </p>
+
+    <div class="audit-summary">
+        <div class="summary-card">
+            <div class="label">Purpose</div>
+            <div class="value">Board decision history</div>
+        </div>
+        <div class="summary-card">
+            <div class="label">What it shows</div>
+            <div class="value">Requests, votes, promotions, demotions</div>
+        </div>
+        <div class="summary-card">
+            <div class="label">Related page</div>
+            <div class="value"><a class="audit-link" href="{{ url_for('board_compliance.clearance_ui') }}">Board clearances</a></div>
+        </div>
+    </div>
+
+    <input type="text" class="search-box" id="search-log" placeholder="Search user, action, or approver...">
+
     <table id="audit-log-table">
         <thead>
             <tr>
-                <th>Käyttäjä</th>
-                <th>Toiminto</th>
-                <th>Myöntäjä</th>
-                <th>Aika</th>
+                <th>User</th>
+                <th>Decision</th>
+                <th>Approver</th>
+                <th>Timestamp</th>
             </tr>
         </thead>
-        <tbody>
-            <!-- JS will fill this -->
-        </tbody>
+        <tbody></tbody>
     </table>
 </section>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/board/clearances.html
+++ b/mielenosoitukset_fi/templates/board/clearances.html
@@ -1,66 +1,365 @@
-{% extends "base.html" %}
-{% block content %}
-<div class="container mt-5">
-  <h1 class="mb-4">Board Clearance Management</h1>
+{% extends 'admin_base.html' %}
 
-  <div class="table-responsive">
-    <table class="table table-bordered table-hover">
-      <thead class="table-dark">
-        <tr>
-          <th>Username</th>
-          <th>Role</th>
-          <th>Status</th>
-          <th>Granted By</th>
-          <th>Timestamp</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for user in users %}
-        <tr>
-          <td>{{ user.username }}</td>
-          <td>{{ user.role | capitalize }}</td>
-          <td>
-            {% if user.approved %}
-              <span class="badge bg-success">Approved</span>
-            {% else %}
-              <span class="badge bg-danger">Not Approved</span>
-            {% endif %}
-          </td>
-          <td>{{ user.granted_by or "-" }}</td>
-          <td>{{ user.timestamp or "-" }}</td>
-          <td>
-            {% if not user.approved %}
-              <button class="btn btn-sm btn-success" onclick="updateClearance('{{ user.id }}', true)">
-                Grant
-              </button>
-            {% else %}
-              <button class="btn btn-sm btn-warning" onclick="updateClearance('{{ user.id }}', false)">
-                Revoke
-              </button>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</div>
+{% block styles %}
+<style>
+  .board-shell {
+    max-width: 1440px;
+    margin: 2rem auto;
+    padding: 0 1rem 2rem;
+    color: var(--text);
+  }
 
-<script>
-async function updateClearance(userId, approve) {
-    const response = await fetch(`/board/api/clearance/${userId}`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({approved: approve})
-    });
-    const result = await response.json();
-    if (result.status === "OK") {
-        alert(result.message);
-        location.reload();
-    } else {
-        alert("Error: " + result.message);
+  .board-hero {
+    background:
+      radial-gradient(circle at top right, rgba(13, 110, 253, 0.18), transparent 28%),
+      linear-gradient(135deg, var(--container-bg), color-mix(in srgb, var(--container-bg) 70%, var(--primary) 30%));
+    border: 1px solid var(--input-border);
+    border-radius: 24px;
+    padding: 2rem;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+    margin-bottom: 1.5rem;
+  }
+
+  .board-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-top: 1rem;
+  }
+
+  .stat-card,
+  .panel {
+    background: var(--container-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 18px;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.05);
+  }
+
+  .stat-card {
+    padding: 1rem 1.1rem;
+  }
+
+  .stat-label {
+    font-size: 0.82rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .stat-value {
+    margin-top: 0.4rem;
+    font-size: 1.45rem;
+    font-weight: 700;
+  }
+
+  .board-panels {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .panel h2 {
+    font-size: 1.3rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .muted {
+    color: var(--muted);
+  }
+
+  .user-table,
+  .request-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+
+  .user-table th,
+  .user-table td,
+  .request-table th,
+  .request-table td {
+    padding: 0.75rem 0.6rem;
+    vertical-align: top;
+    border-bottom: 1px solid var(--input-border);
+  }
+
+  .user-table th,
+  .request-table th {
+    color: var(--muted);
+    font-size: 0.84rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .request-card {
+    border: 1px solid var(--input-border);
+    border-radius: 16px;
+    padding: 1rem;
+    background: color-mix(in srgb, var(--container-bg) 82%, var(--primary) 18%);
+    margin-top: 0.9rem;
+  }
+
+  .request-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.92rem;
+    margin: 0.65rem 0;
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.28rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+
+  .pill-pending { background: #fff3cd; color: #7a5a00; }
+  .pill-approved { background: #d1f0dd; color: #1f6a3a; }
+  .pill-rejected { background: #f8d7da; color: #8a1f2d; }
+  .pill-invalid { background: #212529; color: #f8d7da; }
+
+  .request-actions,
+  .vote-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.8rem;
+  }
+
+  .vote-list {
+    margin-top: 0.8rem;
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .vote-item {
+    padding: 0.65rem 0.8rem;
+    border-radius: 12px;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+  }
+
+  .request-form {
+    margin-top: 0.8rem;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .request-form select,
+  .request-form input,
+  .request-form textarea {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid var(--input-border);
+    background: var(--input-bg);
+    color: var(--text);
+    padding: 0.7rem 0.8rem;
+  }
+
+  @media (max-width: 1040px) {
+    .board-panels {
+      grid-template-columns: 1fr;
     }
+  }
+</style>
+{% endblock %}
+
+{% block scripts %}
+<script>
+async function createBoardRequest(userId, requestType) {
+  const roleField = document.getElementById(`requested_role-${userId}`);
+  const fallbackField = document.getElementById(`fallback_role-${userId}`);
+  const docField = document.getElementById(`approval_document_url-${userId}`);
+  const hashField = document.getElementById(`approval_document_sha256-${userId}`);
+  const reasonField = document.getElementById(`reason-${userId}`);
+
+  const payload = {
+    request_type: requestType,
+    requested_role: roleField ? roleField.value : '',
+    fallback_role: fallbackField ? fallbackField.value : 'admin',
+    approval_document_url: docField ? docField.value.trim() : '',
+    approval_document_sha256: hashField ? hashField.value.trim() : '',
+    reason: reasonField ? reasonField.value.trim() : ''
+  };
+
+  const response = await fetch(`/board/api/clearance/${userId}`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  const result = await response.json();
+  if (result.status === 'OK') {
+    location.reload();
+    return;
+  }
+  alert(result.message || 'Board requestin luonti epäonnistui.');
+}
+
+async function decideBoardRequest(requestId, decision) {
+  const noteField = document.getElementById(`vote-note-${requestId}`);
+  const response = await fetch(`/board/api/clearance/request/${requestId}/decision`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      decision,
+      note: noteField ? noteField.value.trim() : ''
+    })
+  });
+  const result = await response.json();
+  if (result.status === 'OK') {
+    location.reload();
+    return;
+  }
+  alert(result.message || 'Board decisionin tallennus epäonnistui.');
 }
 </script>
+{% endblock %}
+
+{% block main_content %}
+<section class="board-shell">
+  <div class="board-hero">
+    <h1>Board role governance</h1>
+    <p class="muted mb-0">
+      `god` ja `global_admin` syntyvät vain board requestin kautta. Requestiin liitetään lupalappu,
+      ja jokainen aktiivinen `board_member` hyväksyy tai hylkää sen omalla tunnuksellaan.
+    </p>
+    <div class="board-grid">
+      <div class="stat-card">
+        <div class="stat-label">Board members</div>
+        <div class="stat-value">{{ board_member_count }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Open requests</div>
+        <div class="stat-value">{{ requests | selectattr('status', 'equalto', 'pending') | list | length }}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Current user can vote</div>
+        <div class="stat-value">{{ 'Yes' if is_board_member else 'No' }}</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="board-panels">
+    <div class="panel">
+      <h2>Create requests</h2>
+      <p class="muted">Manual role edits do not grant `god` or `global_admin`. Create the board request here instead.</p>
+      <div class="table-responsive">
+        <table class="user-table">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Current role</th>
+              <th>Board status</th>
+              <th>Request</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for user in users %}
+            <tr>
+              <td>{{ user.username }}</td>
+              <td>{{ user.role }}</td>
+              <td>
+                {% if user.has_god_clearance %}<div class="pill pill-approved">god active</div>{% endif %}
+                {% if user.has_global_admin_clearance %}<div class="pill pill-approved">global_admin active</div>{% endif %}
+                {% if not user.has_god_clearance and not user.has_global_admin_clearance %}<span class="muted">No active board-managed role</span>{% endif %}
+              </td>
+              <td>
+                <div class="request-form">
+                  <select id="requested_role-{{ user.id }}">
+                    <option value="global_admin">global_admin</option>
+                    <option value="god">god</option>
+                  </select>
+                  <input id="approval_document_url-{{ user.id }}" type="url" placeholder="Board document URL">
+                  <input id="approval_document_sha256-{{ user.id }}" type="text" placeholder="Board document SHA256">
+                  <textarea id="reason-{{ user.id }}" rows="2" placeholder="Why is this access needed?"></textarea>
+                  <div class="request-actions">
+                    <button class="btn btn-primary btn-sm" type="button" onclick="createBoardRequest('{{ user.id }}', 'assign_role')">Create role request</button>
+                    {% if user.role == 'god' %}
+                    <select id="fallback_role-{{ user.id }}">
+                      <option value="admin">admin</option>
+                      <option value="user">user</option>
+                      <option value="board_member">board_member</option>
+                    </select>
+                    <button class="btn btn-outline-danger btn-sm" type="button" onclick="createBoardRequest('{{ user.id }}', 'revoke_god')">Request god demotion</button>
+                    {% endif %}
+                  </div>
+                </div>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Requests and votes</h2>
+      <p class="muted">Each active board member must log in and confirm the request individually.</p>
+      {% for req in requests %}
+      <div class="request-card">
+        <div class="d-flex justify-content-between align-items-start gap-3">
+          <div>
+            <strong>{{ req.username }}</strong>
+            <div class="muted">{{ req.request_type }} -> {{ req.requested_role }}</div>
+          </div>
+          <div class="pill {% if req.status == 'approved' %}pill-approved{% elif req.status == 'rejected' %}pill-rejected{% else %}pill-pending{% endif %}">
+            {{ req.status }}
+          </div>
+        </div>
+        {% if not req.integrity_valid %}
+        <div class="mt-2 pill pill-invalid">integrity mismatch detected</div>
+        {% endif %}
+        <div class="request-meta">
+          <span>Current role: {{ req.current_role }}</span>
+          <span>Requested by: {{ req.requested_by }}</span>
+          <span>Created: {{ req.created_at or '-' }}</span>
+        </div>
+        {% if req.reason %}
+        <div class="muted">{{ req.reason }}</div>
+        {% endif %}
+        {% if req.approval_document_url %}
+        <div class="mt-2">
+          <a href="{{ req.approval_document_url }}" target="_blank" rel="noopener">{{ req.approval_document_url }}</a>
+          <div class="muted">SHA256: {{ req.approval_document_sha256 or '-' }}</div>
+        </div>
+        {% endif %}
+
+        <div class="vote-list">
+          {% for vote in req.approvals %}
+          <div class="vote-item">
+            <strong>{{ vote.username }}</strong> -> {{ vote.decision }}{% if vote.decided_at %} at {{ vote.decided_at }}{% endif %}
+            {% if vote.note %}<div class="muted">{{ vote.note }}</div>{% endif %}
+          </div>
+          {% endfor %}
+          {% if not req.approvals %}
+          <div class="muted">No board decisions yet.</div>
+          {% endif %}
+        </div>
+
+        {% if req.status == 'pending' and is_board_member and req.integrity_valid %}
+        <div class="vote-actions">
+          <input id="vote-note-{{ req.id }}" type="text" placeholder="Optional board note">
+          <button class="btn btn-success btn-sm" type="button" onclick="decideBoardRequest('{{ req.id }}', 'approve')">Approve</button>
+          <button class="btn btn-outline-danger btn-sm" type="button" onclick="decideBoardRequest('{{ req.id }}', 'reject')">Reject</button>
+        </div>
+        {% elif req.status == 'pending' and is_board_member and not req.integrity_valid %}
+        <div class="muted mt-2">Voting is blocked until the request integrity issue is investigated.</div>
+        {% endif %}
+      </div>
+      {% endfor %}
+      {% if not requests %}
+      <p class="muted mb-0">No board requests yet.</p>
+      {% endif %}
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/mielenosoitukset_fi/users/models.py
+++ b/mielenosoitukset_fi/users/models.py
@@ -14,6 +14,9 @@ mongo = db.get_db()
 
 VALID_WINDOW = 5          # TODO → move to config
 DEFAULT_ROLE = "user"
+ROLE_GLOBAL_PERMISSIONS = {
+    "board_member": {"MANAGE_CLEARANCE", "VIEW_CLEARANCE_AUDIT"},
+}
 
 class User(UserMixin):
     def _perm_in(self, permission: str) -> List[Union[str, ObjectId]]:
@@ -33,7 +36,7 @@ class User(UserMixin):
         """
         
         scopes = []
-        if permission in self.global_permissions:
+        if permission in self.effective_global_permissions:
             scopes.append("global")
         
         scopes.extend(
@@ -180,6 +183,16 @@ class User(UserMixin):
 
     @classmethod
     def from_db(cls, doc: dict) -> "User":
+        role = doc.get("role", DEFAULT_ROLE)
+        god_access = False
+        if role == "god":
+            try:
+                from mielenosoitukset_fi.admin.board_compliance import has_board_clearance
+
+                god_access = bool(has_board_clearance(doc["_id"]))
+            except Exception:
+                god_access = False
+
         return cls(
             user_id         = doc["_id"],
             username        = doc["username"],
@@ -192,10 +205,10 @@ class User(UserMixin):
             following       = doc.get("following", []),
             followed_organizations = doc.get("followed_organizations", []),
             followed_recurring_demos = doc.get("followed_recurring_demos", []),
-            global_admin    = doc.get("global_admin", False) or doc.get("role")=="global_admin",
+            global_admin    = doc.get("global_admin", False) or role == "global_admin" or god_access,
             confirmed       = doc.get("confirmed", False),
             global_permissions = doc.get("global_permissions", []),
-            role            = doc.get("role", DEFAULT_ROLE),
+            role            = role,
             banned          = doc.get("banned", False),
             mfa_enabled     = doc.get("mfa_enabled", False),
             friends         = doc.get("friends", []),
@@ -269,7 +282,7 @@ class User(UserMixin):
         scopes: List[Union[str, ObjectId]] = []
 
         # 1️⃣ global scope
-        if permission in self.global_permissions:
+        if permission in self.effective_global_permissions:
             scopes.append("global")
 
         # 2️⃣ per‑organization scope
@@ -350,14 +363,14 @@ class User(UserMixin):
     def permissions_for(self, organization_id: Optional[Union[str, ObjectId]] = None) -> List[str]:
         if organization_id is None:
             # global scope
-            perms = set(self.global_permissions)
+            perms = set(self.effective_global_permissions)
         else:
             ms = self.membership_for(organization_id)
             perms = set(ms.permissions) if ms else set()
         return list(perms)
 
     def has_permission(self, perm: str, organization_id: Optional[Union[str, ObjectId]]=None, strict=False) -> bool:
-        if perm in self.global_permissions:
+        if perm in self.effective_global_permissions:
             return True
         
         if organization_id:
@@ -369,6 +382,12 @@ class User(UserMixin):
             return bool(ms and perm in ms.permissions)
         # if org not specified, check all org memberships
         return any(perm in m.permissions for m in self.memberships)
+
+    @property
+    def effective_global_permissions(self) -> List[str]:
+        perms = set(self.global_permissions or [])
+        perms.update(ROLE_GLOBAL_PERMISSIONS.get(self.role, set()))
+        return sorted(perms)
 
     # ---------- FOLLOW / BAN / MFA ----------------------------------------------
 

--- a/mielenosoitukset_fi/utils/wrappers.py
+++ b/mielenosoitukset_fi/utils/wrappers.py
@@ -8,6 +8,31 @@ from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.utils.logger import logger
 
 
+def has_board_approved_god_access(user) -> bool:
+    """Return True when a user has board-approved god access."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+
+    if getattr(user, "role", None) != "god":
+        return False
+
+    try:
+        from mielenosoitukset_fi.admin.board_compliance import has_board_clearance
+
+        return has_board_clearance(getattr(user, "id", None) or getattr(user, "_id", None))
+    except Exception:
+        logger.debug("Failed to verify board-approved god access.", exc_info=True)
+        return False
+
+
+def has_superuser_access(user) -> bool:
+    """Return True when a user has any superuser-level access."""
+    return bool(getattr(user, "global_admin", False) or has_board_approved_god_access(user))
+
+
+_has_board_approved_god_access = has_board_approved_god_access
+
+
 def admin_required(f):
     """Decorator to enforce that a user has global admin privileges to access a specific route.
 
@@ -68,9 +93,9 @@ def admin_required(f):
             abort(401)
 
         # Check if the user has global admin privileges
-        if not current_user.role in ["global_admin", "admin"]:
+        if not (current_user.role in ["global_admin", "admin"] or has_board_approved_god_access(current_user)):
             logger.warning(
-                f"User {current_user.username} is not a global admin, access forbidden (403)."
+                f"User {current_user.username} is not an admin or board-approved god user, access forbidden (403)."
             )
             abort(403)
 
@@ -136,7 +161,7 @@ def has_demo_permission(user, _id, permission_name):
         logger.warning("Demo permission denied: no user provided.")
         return False
 
-    if getattr(user, "global_admin", False):
+    if has_superuser_access(user):
         logger.info("Demo permission granted: user is global admin.")
         return True
 
@@ -306,7 +331,7 @@ def permission_required(permission_name: str, _id: str | None = None, _type: str
                 return redirect(url_for("users.auth.login"))
 
             # Allow access if the user is a global admin
-            if current_user.global_admin:
+            if has_superuser_access(current_user):
                 logger.info("Global admin access granted.")
                 return f(*args, **kwargs)
 

--- a/tests/test_board_compliance.py
+++ b/tests/test_board_compliance.py
@@ -1,0 +1,289 @@
+from importlib import import_module
+
+from bson import ObjectId
+
+from tests.conftest import _client_for_user, _seed_database, _user_doc
+from mielenosoitukset_fi.users.models import User
+
+admin_user_module = import_module("mielenosoitukset_fi.admin.admin_user_bp")
+board_compliance = import_module("mielenosoitukset_fi.admin.board_compliance")
+board_audit_module = import_module("mielenosoitukset_fi.admin.board_audit")
+
+
+def _bind_board_modules_to_test_db(monkeypatch, db):
+    monkeypatch.setattr(board_compliance, "mongo", db, raising=False)
+    monkeypatch.setattr(board_audit_module, "mongo", db, raising=False)
+    monkeypatch.setattr(admin_user_module, "mongo", db, raising=False)
+
+
+def _insert_board_member(db, username, email):
+    user_id = ObjectId()
+    db.users.insert_one(
+        _user_doc(
+            username,
+            email,
+            "BoardPass1!",
+            _id=user_id,
+            role="board_member",
+            global_admin=False,
+        )
+    )
+    return user_id
+
+
+def test_board_member_role_gets_clearance_permissions(db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    user_id = ObjectId()
+    db.users.insert_one(
+        _user_doc(
+            "board-alice",
+            "board-alice@example.test",
+            "BoardPass1!",
+            _id=user_id,
+            role="board_member",
+            global_admin=False,
+        )
+    )
+
+    user = User.from_db(db.users.find_one({"_id": user_id}))
+    assert user.has_permission("MANAGE_CLEARANCE") is True
+    assert user.has_permission("VIEW_CLEARANCE_AUDIT") is True
+    assert user.global_admin is False
+
+
+def test_board_member_can_access_board_ui_and_audit_ui(app, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    board_member_id = _insert_board_member(db, "board-ui", "board-ui@example.test")
+    client = _client_for_user(app, board_member_id)
+
+    clearance_response = client.get("/board/ui")
+    audit_response = client.get("/board/audit/ui")
+
+    assert clearance_response.status_code == 200
+    assert audit_response.status_code == 200
+
+
+def test_board_request_approval_auto_assigns_god(app, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    seeded = _seed_database(app, db)
+    target_id = seeded["user_id"]
+    board_a = _insert_board_member(db, "board-a", "board-a@example.test")
+    board_b = _insert_board_member(db, "board-b", "board-b@example.test")
+
+    creator_client = _client_for_user(app, seeded["admin_id"])
+    create_response = creator_client.post(
+        f"/board/api/clearance/{target_id}",
+        json={
+            "request_type": "assign_role",
+            "requested_role": "god",
+            "approval_document_url": "https://example.test/board/god.pdf",
+            "approval_document_sha256": "deadbeef",
+            "reason": "Emergency access for release rollback",
+        },
+    )
+    assert create_response.status_code == 200
+    request_id = create_response.get_json()["request"]["id"]
+
+    board_a_client = _client_for_user(app, board_a)
+    first_vote = board_a_client.post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+    assert first_vote.status_code == 200
+    assert first_vote.get_json()["request"]["status"] == "pending"
+
+    board_b_client = _client_for_user(app, board_b)
+    second_vote = board_b_client.post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+    assert second_vote.status_code == 200
+    assert second_vote.get_json()["request"]["status"] == "approved"
+
+    updated_user = db.users.find_one({"_id": target_id})
+    assert updated_user["role"] == "god"
+    assert board_compliance.has_board_clearance(target_id) is True
+    assert User.from_db(updated_user).global_admin is True
+
+
+def test_board_request_approval_auto_assigns_global_admin(app, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    seeded = _seed_database(app, db)
+    target_id = seeded["user_id"]
+    board_a = _insert_board_member(db, "board-c", "board-c@example.test")
+    board_b = _insert_board_member(db, "board-d", "board-d@example.test")
+
+    creator_client = _client_for_user(app, seeded["admin_id"])
+    create_response = creator_client.post(
+        f"/board/api/clearance/{target_id}",
+        json={
+            "request_type": "assign_role",
+            "requested_role": "global_admin",
+            "approval_document_url": "https://example.test/board/global-admin.pdf",
+            "approval_document_sha256": "cafebabe",
+            "reason": "Permanent senior admin appointment",
+        },
+    )
+    request_id = create_response.get_json()["request"]["id"]
+
+    _client_for_user(app, board_a).post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+    final_vote = _client_for_user(app, board_b).post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+
+    assert final_vote.status_code == 200
+    updated_user = db.users.find_one({"_id": target_id})
+    assert updated_user["role"] == "global_admin"
+    assert User.from_db(updated_user).global_admin is True
+
+
+def test_revoke_god_request_demotes_user_after_all_board_votes(app, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    seeded = _seed_database(app, db)
+    target_id = seeded["user_id"]
+    db.users.update_one({"_id": target_id}, {"$set": {"role": "god", "global_admin": False}})
+
+    board_a = _insert_board_member(db, "board-e", "board-e@example.test")
+    board_b = _insert_board_member(db, "board-f", "board-f@example.test")
+
+    creator_client = _client_for_user(app, seeded["admin_id"])
+    grant_response = creator_client.post(
+        f"/board/api/clearance/{target_id}",
+        json={
+            "request_type": "assign_role",
+            "requested_role": "god",
+            "approval_document_url": "https://example.test/board/god.pdf",
+            "approval_document_sha256": "deadbeef",
+        },
+    )
+    grant_request_id = grant_response.get_json()["request"]["id"]
+    _client_for_user(app, board_a).post(
+        f"/board/api/clearance/request/{grant_request_id}/decision",
+        json={"decision": "approve"},
+    )
+    _client_for_user(app, board_b).post(
+        f"/board/api/clearance/request/{grant_request_id}/decision",
+        json={"decision": "approve"},
+    )
+
+    revoke_response = creator_client.post(
+        f"/board/api/clearance/{target_id}",
+        json={
+            "request_type": "revoke_god",
+            "fallback_role": "admin",
+            "approval_document_url": "https://example.test/board/revoke.pdf",
+            "approval_document_sha256": "beadfeed",
+            "reason": "Emergency access no longer needed",
+        },
+    )
+    revoke_request_id = revoke_response.get_json()["request"]["id"]
+
+    _client_for_user(app, board_a).post(
+        f"/board/api/clearance/request/{revoke_request_id}/decision",
+        json={"decision": "approve"},
+    )
+    final_vote = _client_for_user(app, board_b).post(
+        f"/board/api/clearance/request/{revoke_request_id}/decision",
+        json={"decision": "approve"},
+    )
+
+    assert final_vote.status_code == 200
+    updated_user = db.users.find_one({"_id": target_id})
+    assert updated_user["role"] == "admin"
+    assert board_compliance.has_board_clearance(target_id) is False
+
+
+def test_tampered_board_request_loses_clearance_and_blocks_further_votes(app, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    seeded = _seed_database(app, db)
+    target_id = seeded["user_id"]
+    board_a = _insert_board_member(db, "board-g", "board-g@example.test")
+    board_b = _insert_board_member(db, "board-h", "board-h@example.test")
+
+    creator_client = _client_for_user(app, seeded["admin_id"])
+    create_response = creator_client.post(
+        f"/board/api/clearance/{target_id}",
+        json={
+            "request_type": "assign_role",
+            "requested_role": "god",
+            "approval_document_url": "https://example.test/board/god.pdf",
+            "approval_document_sha256": "deadbeef",
+            "reason": "Temporary emergency access",
+        },
+    )
+    request_id = create_response.get_json()["request"]["id"]
+
+    _client_for_user(app, board_a).post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+    _client_for_user(app, board_b).post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+
+    db.board_clearance_requests.update_one(
+        {"_id": ObjectId(request_id)},
+        {"$set": {"approval_document_sha256": "tampered"}},
+    )
+
+    assert board_compliance.has_board_clearance(target_id) is False
+
+    db.board_clearance_requests.update_one(
+        {"_id": ObjectId(request_id)},
+        {"$set": {"status": "pending"}},
+    )
+    blocked_vote = _client_for_user(app, board_a).post(
+        f"/board/api/clearance/request/{request_id}/decision",
+        json={"decision": "approve"},
+    )
+    assert blocked_vote.status_code == 409
+
+
+def test_manual_god_promotion_is_rejected_from_user_edit(admin_client, db, monkeypatch):
+    _bind_board_modules_to_test_db(monkeypatch, db)
+    target_id = ObjectId()
+    db.users.insert_one(
+        _user_doc(
+            "manual-target",
+            "manual-target@example.test",
+            "UserPass1!",
+            _id=target_id,
+            role="admin",
+            global_admin=False,
+        )
+    )
+
+    response = admin_client.post(
+        f"/admin/user/save_user/{target_id}",
+        data={
+            "username": "manual-target",
+            "email": "manual-target@example.test",
+            "role": "god",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in {302, 303}
+    updated_user = db.users.find_one({"_id": target_id})
+    assert updated_user["role"] == "admin"
+
+
+def test_compare_user_levels_keeps_magic_id_from_bypassing_checks():
+    magic_id = ObjectId("66c25768dad432ad39ce38d5")
+    magic_admin = type(
+        "UserStub",
+        (),
+        {"_id": magic_id, "role": "global_admin", "is_authenticated": True, "global_admin": False},
+    )()
+    peer_admin = type(
+        "UserStub",
+        (),
+        {"_id": ObjectId(), "role": "global_admin", "is_authenticated": True, "global_admin": False},
+    )()
+
+    assert admin_user_module.compare_user_levels(magic_admin, peer_admin) is False


### PR DESCRIPTION
## Summary
- replace manual privileged-role editing with a board-managed request and voting workflow for `god` and `global_admin`
- add tamper-evident integrity signatures for board requests and block further votes on mutated request records
- refresh the board clearance and audit UIs, and add focused regression coverage plus a handoff note for the remaining board-governance work

## Testing
- `python -m pytest -q tests/test_board_compliance.py --maxfail=1`
- `python -m py_compile config.py mielenosoitukset_fi/admin/board_compliance.py tests/test_board_compliance.py`

## Resume Note
- follow-up work is tracked in `docs/board_governance_handoff.md` on this branch