### PR TITLE
Fix public submit duplicate-conflict UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 ### Added
+* Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
 * Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
+* Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
+* `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
 * Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -1269,7 +1269,9 @@ def init_routes(app):
                             continue
                         # word intersection heuristic
                         existing_words = set([w for w in re.findall(r"\w+", existing_title) if len(w) > 3])
-                        if title_words and len(title_words & existing_words) >= 2:
+                        # Keep the warning threshold fairly high so we do not
+                        # block real users too aggressively on merely similar titles.
+                        if title_words and len(title_words & existing_words) >= 3:
                             matches.append(d)
                             continue
                         # address similarity

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -1294,7 +1294,17 @@ def init_routes(app):
                         )
                         # if AJAX, return structured JSON so frontend can prompt user
                         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
-                            return jsonify(success=False, conflict=True, message="Löytyi samankaltaisia ilmoituksia tälle päivälle.", demos=conflict_summary), 409
+                            return (
+                                jsonify(
+                                    success=False,
+                                    conflict=True,
+                                    requires_confirmation=True,
+                                    message="Löytyi samankaltaisia ilmoituksia tälle päivälle.",
+                                    error_code=SUBMIT_ERROR_CODES["duplicate_conflict"],
+                                    demos=conflict_summary,
+                                ),
+                                409,
+                            )
                         # otherwise, flash and redirect back to form
                         flash_message("Löytyi samankaltaisia ilmoituksia tälle päivälle. Ole hyvä ja tarkista ennen julkaisua.", "warning")
                         return redirect(url_for("submit"))

--- a/mielenosoitukset_fi/templates/ohjeet/index.html
+++ b/mielenosoitukset_fi/templates/ohjeet/index.html
@@ -22,7 +22,7 @@
     </div>
     <ul class="guide-list">
       <li><strong>Lue virheilmoitus loppuun asti.</strong> Se kertoo yleensä, puuttuuko tiedoista jotain vai löytyikö järjestelmästä mahdollinen päällekkäinen ilmoitus.</li>
-      <li><strong>Jos saat ilmoituksen samankaltaisesta tapahtumasta,</strong> tarkista päivämäärä, kaupunki, osoite ja nimi. Jos kyse on silti eri tapahtumasta, voit lähettää ilmoituksen uudelleen vahvistamalla sen.</li>
+      <li><strong>Jos saat ilmoituksen samankaltaisesta tapahtumasta,</strong> tarkista päivämäärä, kaupunki, osoite ja nimi. Jos kyse on silti eri tapahtumasta, voit lähettää ilmoituksen uudelleen vahvistamalla sen. Jos kyse oli vahingossa duplikaatista, yhdistämme sen tarvittaessa myöhemmin meidän päässä.</li>
       <li><strong>Jos lähetys ei näytä onnistuvan ensimmäisellä yrittämällä,</strong> odota hetki ja kokeile uudelleen samalla selaimella. Älä avaa montaa välilehteä samalle lomakkeelle yhtä aikaa.</li>
       <li><strong>Tarkista sähköpostiosoite huolellisesti.</strong> Väärin kirjoitettu osoite estää ilmoituksen käsittelyn jatkoa.</li>
       <li><strong>Jos et ole varma menivätkö tiedot perille,</strong> tarkista sähköposti ja ota yhteyttä tukeen. Kerro meille tapahtuman nimi, päivämäärä ja kaupunki, niin selvitämme tilanteen nopeasti.</li>

--- a/mielenosoitukset_fi/templates/ohjeet/index.html
+++ b/mielenosoitukset_fi/templates/ohjeet/index.html
@@ -8,10 +8,41 @@
     <p class="guide-badge">Ohjekeskus</p>
     <h1>Selkeät ohjeet kaikille järjestäjille</h1>
     <p>
-      Tältä sivulta löydät pähkinänkuoressa sen, mitä tarvitset onnistuaksesi: miten saat siistin kuvan tapahtumallesi,
-      missä kuva näkyy sivustolla ja kuinka organisaatiot saavat omat käyttäjätilit. Tekniset yksityiskohdat hoidamme
-      puolestasi – sinun tehtäväsi on keskittyä itse tapahtumaan.
+      Tältä sivulta löydät pähkinänkuoressa sen, mitä tarvitset onnistuaksesi: miten ilmoitus kannattaa lähettää,
+      mitä tehdä jos lähetys takkuaa, miten saat siistin kuvan tapahtumallesi ja kuinka organisaatiot saavat omat
+      käyttäjätilit. Tekniset yksityiskohdat hoidamme puolestasi – sinun tehtäväsi on keskittyä itse tapahtumaan.
     </p>
+  </section>
+
+  <section class="guide-card" id="submit-help">
+    <h2>Jos ilmoituksen lähetys ei mene heti läpi</h2>
+    <div class="guide-callout">
+      <strong>Tärkeää:</strong> jos järjestelmä kertoo, että samalle päivälle löytyi samankaltainen tapahtuma,
+      ilmoitus ei välttämättä ole rikki. Tarkista viesti rauhassa ja yritä tarvittaessa uudelleen.
+    </div>
+    <ul class="guide-list">
+      <li><strong>Lue virheilmoitus loppuun asti.</strong> Se kertoo yleensä, puuttuuko tiedoista jotain vai löytyikö järjestelmästä mahdollinen päällekkäinen ilmoitus.</li>
+      <li><strong>Jos saat ilmoituksen samankaltaisesta tapahtumasta,</strong> tarkista päivämäärä, kaupunki, osoite ja nimi. Jos kyse on silti eri tapahtumasta, voit lähettää ilmoituksen uudelleen vahvistamalla sen.</li>
+      <li><strong>Jos lähetys ei näytä onnistuvan ensimmäisellä yrittämällä,</strong> odota hetki ja kokeile uudelleen samalla selaimella. Älä avaa montaa välilehteä samalle lomakkeelle yhtä aikaa.</li>
+      <li><strong>Tarkista sähköpostiosoite huolellisesti.</strong> Väärin kirjoitettu osoite estää ilmoituksen käsittelyn jatkoa.</li>
+      <li><strong>Jos et ole varma menivätkö tiedot perille,</strong> tarkista sähköposti ja ota yhteyttä tukeen. Kerro meille tapahtuman nimi, päivämäärä ja kaupunki, niin selvitämme tilanteen nopeasti.</li>
+    </ul>
+    <p>
+      Jos ongelma toistuu, lähetä viesti osoitteeseen
+      <a href="mailto:tuki@mielenosoitukset.fi">tuki@mielenosoitukset.fi</a>.
+      Lisää mukaan tapahtuman nimi, paikkakunta, päivämäärä ja mahdollinen virheilmoitus. Kuvakaappaus auttaa paljon.
+    </p>
+  </section>
+
+  <section class="guide-card" id="submit-checklist">
+    <h2>Nopea tarkistuslista ennen lähetystä</h2>
+    <ul class="guide-list">
+      <li><strong>Nimi:</strong> käytä selkeää ja tunnistettavaa tapahtuman nimeä.</li>
+      <li><strong>Päivä ja aika:</strong> varmista että päivämäärä, alkamisaika ja paikkakunta ovat oikein.</li>
+      <li><strong>Paikka:</strong> lisää osoite tai kokoontumispaikka mahdollisimman täsmällisesti.</li>
+      <li><strong>Kuvaus:</strong> kerro lyhyesti mistä on kyse ja kenelle tapahtuma on suunnattu.</li>
+      <li><strong>Yhteystiedot:</strong> varmista että sähköposti toimii, jotta voimme tarvittaessa tavoittaa sinut.</li>
+    </ul>
   </section>
 
   <section class="guide-card" id="image-usage">
@@ -131,6 +162,15 @@
     border-radius: 1.5rem;
     box-shadow: var(--color-shadow, 0 10px 35px rgba(15, 20, 25, 0.1));
     padding: 2rem 2.5rem;
+  }
+
+  .guide-callout {
+    margin: 1rem 0 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 1rem;
+    background: light-dark(#eef6ff, #172131);
+    border: 1px solid light-dark(#bfdbfe, #2b4c7e);
+    color: var(--color-text, #1e293b);
   }
 
   .guide-grid {

--- a/mielenosoitukset_fi/templates/submit.html
+++ b/mielenosoitukset_fi/templates/submit.html
@@ -1035,7 +1035,7 @@
   const SUBMIT_ERROR_LABEL = "{{ _('Virhekoodi') }}";
   const SUBMIT_CONFLICT_TITLE = "{{ _('Löytyi mahdollinen päällekkäinen ilmoitus') }}";
   const SUBMIT_CONFLICT_INTRO = "{{ _('Samalle päivälle löytyi samankaltainen mielenosoitusilmoitus.') }}";
-  const SUBMIT_CONFLICT_REVIEW = "{{ _('Tarkista osumat alta. Jos tämä on silti eri tapahtuma, paina OK lähettääksesi ilmoituksen. Peruuta, jos haluat vielä muokata tietoja.') }}";
+  const SUBMIT_CONFLICT_REVIEW = "{{ _('Tarkista osumat alta. Jos tämä on silti eri tapahtuma, paina OK lähettääksesi ilmoituksen. Jos kyse on vahingossa duplikaatista, voimme yhdistää sen myöhemmin meidän päässä.') }}";
   const SUBMIT_CONFLICT_MATCHES = "{{ _('Mahdolliset osumat') }}";
   const SUBMIT_CONFLICT_CANCELLED = "{{ _('Lähetystä ei tehty vielä. Tarkista tiedot ja lähetä uudelleen, jos ilmoitus on oikea.') }}";
   const SUBMIT_CONFLICT_FORCE_FAILED = "{{ _('Ilmoituksen lähetys ei onnistunut vahvistuksen jälkeen. Tarkista tiedot ja yritä uudelleen.') }}";

--- a/mielenosoitukset_fi/templates/submit.html
+++ b/mielenosoitukset_fi/templates/submit.html
@@ -1000,6 +1000,32 @@
   };
 
   const SUBMIT_ERROR_LABEL = "{{ _('Virhekoodi') }}";
+  const SUBMIT_CONFLICT_TITLE = "{{ _('Löytyi mahdollinen päällekkäinen ilmoitus') }}";
+  const SUBMIT_CONFLICT_INTRO = "{{ _('Samalle päivälle löytyi samankaltainen mielenosoitusilmoitus.') }}";
+  const SUBMIT_CONFLICT_REVIEW = "{{ _('Tarkista osumat alta. Jos tämä on silti eri tapahtuma, paina OK lähettääksesi ilmoituksen. Peruuta, jos haluat vielä muokata tietoja.') }}";
+  const SUBMIT_CONFLICT_MATCHES = "{{ _('Mahdolliset osumat') }}";
+  const SUBMIT_CONFLICT_CANCELLED = "{{ _('Lähetystä ei tehty vielä. Tarkista tiedot ja lähetä uudelleen, jos ilmoitus on oikea.') }}";
+  const SUBMIT_CONFLICT_FORCE_FAILED = "{{ _('Ilmoituksen lähetys ei onnistunut vahvistuksen jälkeen. Tarkista tiedot ja yritä uudelleen.') }}";
+
+  function buildConflictConfirmationMessage(conflictData) {
+    const lines = [
+      SUBMIT_CONFLICT_TITLE,
+      "",
+      conflictData?.message || SUBMIT_CONFLICT_INTRO,
+      SUBMIT_CONFLICT_REVIEW,
+    ];
+
+    const matches = Array.isArray(conflictData?.demos) ? conflictData.demos : [];
+    if (matches.length) {
+      lines.push("", `${SUBMIT_CONFLICT_MATCHES}:`);
+      matches.slice(0, 5).forEach((demo, index) => {
+        const parts = [demo?.title, demo?.date, demo?.address].filter(Boolean);
+        lines.push(`${index + 1}. ${parts.join(" | ")}`);
+      });
+    }
+
+    return lines.join("\n");
+  }
 
   async function showSubmitError(response, fallbackMessage) {
     let message = fallbackMessage || "{{ _('Lähetyksessä tapahtui virhe. Yritä uudelleen.') }}";
@@ -1121,6 +1147,12 @@
           }
 
           if (conflictData && conflictData.conflict) {
+            const shouldForceSubmit = window.confirm(buildConflictConfirmationMessage(conflictData));
+            if (!shouldForceSubmit) {
+              alert(SUBMIT_CONFLICT_CANCELLED);
+              return;
+            }
+
             formData.set('force_submit', '1');
             const response2 = await fetch(form.action, {
               method: form.method,
@@ -1134,7 +1166,7 @@
               });
               return;
             } else {
-              await showSubmitError(response2);
+              await showSubmitError(response2, SUBMIT_CONFLICT_FORCE_FAILED);
               return;
             }
           } else {

--- a/mielenosoitukset_fi/templates/submit.html
+++ b/mielenosoitukset_fi/templates/submit.html
@@ -107,6 +107,22 @@
     line-height: 1.6;
   }
 
+  .hero-help-link {
+    margin-top: 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: white;
+    font-weight: 700;
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+
+  .hero-help-link:hover {
+    color: white;
+    opacity: 0.92;
+  }
+
   /* Progress Bar */
   .progress-container {
     background: var(--color-card-bg);
@@ -262,6 +278,23 @@
     right: 0;
     height: 4px;
     background: var(--color-gradient-primary);
+  }
+
+  .submit-help-card {
+    margin-bottom: 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 1rem;
+    background: light-dark(#eef6ff, #172131);
+    border: 1px solid light-dark(#bfdbfe, #2b4c7e);
+    color: var(--color-text);
+  }
+
+  .submit-help-card p {
+    margin: 0.35rem 0;
+  }
+
+  .submit-help-card a {
+    font-weight: 700;
   }
 
   /* Page Content */
@@ -1564,6 +1597,10 @@
         {{ _('Ilmoittamalla mielenosoituksesta autat muita löytämään tietoa mielenosoituksista. Mitä useampia ja
         kattavammin alustalla on mielenosoituksista tietoa, sitä useammille siitä on hyötyä.') }}
       </p>
+      <a class="hero-help-link" href="{{ url_for('public_guides') }}#submit-help">
+        <i class="fa-solid fa-circle-question"></i>
+        {{ _('Jos lähetys takkuaa, katso ohjeet') }}
+      </a>
     </div>
   </section>
 
@@ -1621,6 +1658,12 @@
   <form method="POST" action="{{ url_for('submit') }}" enctype="multipart/form-data" id="myForm">
     <input type="hidden" name="submission_token" value="{{ submission_token or '' }}">
     <div class="form-container">
+      <div class="submit-help-card">
+        <p><strong>{{ _('Ennen lähetystä:') }}</strong> {{ _('tarkista nimi, päivämäärä, paikka ja sähköpostiosoite huolellisesti.') }}</p>
+        <p>{{ _('Jos järjestelmä ilmoittaa samankaltaisesta tapahtumasta tai lähetys ei mene heti läpi, lue toimintaohjeet tästä:') }}
+          <a href="{{ url_for('public_guides') }}#submit-help">{{ _('ohjeet ilmoituksen lähettämiseen') }}</a>.
+        </p>
+      </div>
 
       <!-- Page 1: Basic Information -->
       <div class="form-page active" id="page-1">

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -311,6 +311,58 @@ def test_submit_route_duplicate_conflict_returns_confirmation_payload(client, db
 
 
 @pytest.mark.integration
+def test_submit_route_does_not_flag_weak_title_overlap_as_duplicate_conflict(client, db):
+    db.demonstrations.insert_one(
+        {
+            "_id": ObjectId(),
+            "title": "Fridays for Future Helsinki",
+            "date": "2026-08-15",
+            "start_time": "15:00",
+            "end_time": "17:00",
+            "facebook": "",
+            "city": "Helsinki",
+            "address": "Kansalaistori",
+            "event_type": "other",
+            "route": "",
+            "organizers": [],
+            "approved": True,
+            "img": "",
+            "description": "Existing demo for overlap threshold testing.",
+            "tags": ["test"],
+        }
+    )
+
+    form_data = {
+        "title": "Fridays for Palestine Helsinki",
+        "date": "2026-08-15",
+        "description": "Should not be blocked by weak title overlap alone.",
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "facebook": "",
+        "city": "Helsinki",
+        "address": "Narinkkatori",
+        "type": "other",
+        "tags": "test,overlap",
+        "submitter_role": "organizer",
+        "submitter_email": "submitter@example.test",
+        "submitter_name": "Submitter Example",
+        "accept_terms": "on",
+        "submission_token": "weak-overlap-token",
+    }
+
+    response = client.post(
+        "/submit",
+        data=form_data,
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert db.demonstrations.count_documents({"title": "Fridays for Palestine Helsinki"}) == 1
+
+
+@pytest.mark.integration
 @pytest.mark.jobs
 def test_merge_duplicate_submissions_repoints_references_and_audits(db):
     from mielenosoitukset_fi.scripts.merge_duplicate_submissions import merge_duplicate_submissions

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -248,6 +248,69 @@ def test_submit_route_is_idempotent_and_does_not_create_duplicate_demo(client, d
 
 
 @pytest.mark.integration
+def test_submit_route_duplicate_conflict_returns_confirmation_payload(client, db):
+    existing_id = ObjectId()
+    db.demonstrations.insert_one(
+        {
+            "_id": existing_id,
+            "title": "Ei ydinaseita Suomeen!",
+            "date": "2026-08-15",
+            "start_time": "15:00",
+            "end_time": "17:00",
+            "facebook": "",
+            "city": "Helsinki",
+            "address": "Rautatientori",
+            "event_type": "other",
+            "route": "",
+            "organizers": [],
+            "approved": True,
+            "img": "",
+            "description": "Existing demo for duplicate detection.",
+            "tags": ["test"],
+        }
+    )
+
+    form_data = {
+        "title": "Ei ydinaseita Suomeen!",
+        "date": "2026-08-15",
+        "description": "Regression test for duplicate conflict UX.",
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "facebook": "",
+        "city": "Helsinki",
+        "address": "Rautatientori",
+        "type": "other",
+        "tags": "test,duplicate",
+        "submitter_role": "organizer",
+        "submitter_email": "submitter@example.test",
+        "submitter_name": "Submitter Example",
+        "accept_terms": "on",
+        "submission_token": "duplicate-conflict-token",
+    }
+
+    response = client.post(
+        "/submit",
+        data=form_data,
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+
+    assert response.status_code == 409
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["conflict"] is True
+    assert payload["requires_confirmation"] is True
+    assert payload["error_code"] == "SUBMIT_DUPLICATE_CONFLICT"
+    assert payload["demos"]
+    assert payload["demos"][0]["title"] == "Ei ydinaseita Suomeen!"
+
+    token_doc = db.demo_submission_tokens.find_one({"token": "duplicate-conflict-token"})
+    assert token_doc is not None
+    assert token_doc["status"] == "processing"
+
+    assert db.demonstrations.count_documents({"title": "Ei ydinaseita Suomeen!"}) == 1
+
+
+@pytest.mark.integration
 @pytest.mark.jobs
 def test_merge_duplicate_submissions_repoints_references_and_audits(db):
     from mielenosoitukset_fi.scripts.merge_duplicate_submissions import merge_duplicate_submissions

--- a/tests/test_public_guides.py
+++ b/tests/test_public_guides.py
@@ -5,3 +5,14 @@ def test_public_guides_are_accessible_without_login(client):
     body = response.get_data(as_text=True)
     assert "Selkeät ohjeet kaikille järjestäjille" in body
     assert "Ohjekeskus" in body
+    assert "Jos ilmoituksen lähetys ei mene heti läpi" in body
+    assert "yritä tarvittaessa uudelleen" in body
+
+
+def test_submit_page_links_to_guides_for_submission_help(client):
+    response = client.get("/submit")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'href="/ohjeet#submit-help"' in body or 'href="/ohjeet/#submit-help"' in body
+    assert "Jos lähetys takkuaa, katso ohjeet" in body


### PR DESCRIPTION
Fixes #573
Refs #572

## Summary
- stop silently auto-resubmitting public demo submissions when duplicate detection returns a `409`
- return explicit confirmation metadata from `/submit` for duplicate-conflict AJAX responses
- show the user a clear confirmation dialog with matching event details before forcing the submission through
- add regression coverage for the duplicate-conflict payload and document the user-facing fix in the changelog

## Testing
- `python -m pytest -q tests/test_background_jobs.py -k 'submit_route_is_idempotent or duplicate_conflict_returns_confirmation_payload'`
- `python -m py_compile mielenosoitukset_fi/basic_routes.py`
