### PR TITLE
Add multilingual demonstration foundation and first UI slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.
+* Recurring demo create/edit now supports multilingual title, description, and tag inputs plus `default_language`, extending the same translation model to recurring-event administration.
+* Public submit flow now records the authored language of the base demonstration fields through a `default_language` selector, so multilingual data starts with the correct source language even before public translation inputs exist.
+* Repository and preview runtime config defaults now expose both Finnish and English as supported UI languages, so multilinguality previews show `fi` and `en` selectors without requiring separate server-side config edits.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
 * Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## UNRELEASED
 
 ### Added
+* Added the first multilingual demonstration data-model foundation: `Demonstration` now supports `default_language`, a `translations` map, and helper methods for localized title/description/tag access without breaking existing base fields.
+* Added shared demo-localization helpers so multilingual title, description, and tag resolution can be reused consistently from both `Demonstration` objects and plain demonstration dictionaries.
+* Public demo rendering now uses locale-aware demonstration title, description, and tag values on detail pages, calendar views, and API/card payloads while still falling back to legacy base fields when translations are missing.
+* Admin demo create/edit now supports multilingual title, description, and tag inputs plus `default_language`, so demonstration translations can be managed from the existing moderation UI.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
 * Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.

--- a/config.compose.dev.example.yaml
+++ b/config.compose.dev.example.yaml
@@ -36,4 +36,8 @@ BABEL:
   SUPPORTED_LOCALES:
     - "fi"
     - "en"
+
+  LANGUAGES:
+    fi: "Suomi"
+    en: "English"
   

--- a/config.py
+++ b/config.py
@@ -107,9 +107,12 @@ class Config:
         cls.BABEL_DEFAULT_LOCALE = cls.BABEL_CONFIG.get("DEFAULT_LOCALE", "en")
         cls.BABEL_SUPPORTED_LOCALES = cls.BABEL_CONFIG.get(
             "SUPPORTED_LOCALES",
-            ["en"],
+            ["fi", "en"],
         )
-        cls.BABEL_LANGUAGES = cls.BABEL_CONFIG.get("LANGUAGES", {"en": "English"})
+        cls.BABEL_LANGUAGES = cls.BABEL_CONFIG.get(
+            "LANGUAGES",
+            {"fi": "Suomi", "en": "English"},
+        )
 
         cls.SECRET_KEY = config.get("SECRET_KEY", "secret_key")
         cls.PORT = config.get("PORT", 8000)

--- a/deploy/preview_deploy.sh
+++ b/deploy/preview_deploy.sh
@@ -72,8 +72,10 @@ BABEL:
   DEFAULT_LOCALE: "${PREVIEW_DEFAULT_LOCALE:-fi}"
   SUPPORTED_LOCALES:
     - "fi"
+    - "en"
   LANGUAGES:
     fi: "Suomi"
+    en: "English"
 SERVER_NAME: "${hostname}"
 PREFERRED_URL_SCHEME: "https"
 CDN_BASE_URL: "${PREVIEW_CDN_BASE_URL:-https://${hostname}}"

--- a/docs/multilinguality_foundation.md
+++ b/docs/multilinguality_foundation.md
@@ -1,0 +1,92 @@
+# Multilinguality Foundation
+
+This branch starts the data-model groundwork for full multilingual demonstrations.
+
+## Current decisions
+
+- Demo translations live under `demonstrations.translations`.
+- The structure is language-first:
+
+```json
+{
+  "default_language": "fi",
+  "translations": {
+    "en": {
+      "title": "English title",
+      "description": "English description",
+      "tags": ["peace", "march"]
+    },
+    "sv": {
+      "title": "Svensk titel"
+    }
+  }
+}
+```
+
+- Base fields stay in place for backwards compatibility:
+  - `title`
+  - `description`
+  - `tags`
+- `default_language` tells which language the base fields are authored in.
+- Missing translations must fall back to the base field values.
+
+## Why this shape
+
+- It avoids breaking every existing query, page, email, and API path immediately.
+- It lets us introduce multilinguality incrementally.
+- It keeps the default/public language explicit instead of assuming everything is always Finnish forever.
+
+## What this branch adds
+
+- `Demonstration.translations`
+- `Demonstration.default_language`
+- helper methods:
+  - `set_translation(language, field, value)`
+  - `get_translation(language, field, fallback=True)`
+  - `get_localized_fields(language, fallback=True)`
+  - `available_translation_languages()`
+- shared utility helpers:
+  - `get_demo_localized_value(demo, field, language=None, fallback=True)`
+  - `get_demo_localized_fields(demo, language=None, fallback=True)`
+
+Those helpers are intentionally backward-compatible:
+- they use translated content when it exists for the requested language
+- they fall back to the legacy base fields when it does not
+- they work for both `Demonstration` objects and plain demo dictionaries
+
+The first public UI slice is also now in place:
+- demo detail rendering resolves localized `title`, `description`, and `tags`
+- calendar views resolve localized demo titles/descriptions/tags from the active locale
+- API/card-format demo payloads use the same localization helper path
+
+The first admin UI slice is now in place too:
+- admin demo create/edit form exposes `default_language`
+- admin demo create/edit form stores translated `title`, `description`, and `tags`
+- edit views prefill saved translations back into the form
+
+## Next implementation slices
+
+1. Public rendering
+- read localized title/description/tags based on session locale
+- keep fallback to base fields
+
+2. Admin UI
+- add translation editors for title/description/tags
+- show which locales are missing
+
+3. Public submit flow
+- decide whether normal submit creates only the base language entry
+- add optional translation inputs later, not in the first migration
+
+4. Search and feeds
+- decide whether search matches only base fields or translated fields too
+- update RSS, cards, detail views, and sitemap output
+
+5. Notifications and emails
+- ensure submitter/admin emails use the recipient locale where possible
+
+## Open questions
+
+- Should address be translatable too, or only title/description/tags?
+- Should recurring demos share the same translation structure?
+- Should the API expose one localized view or the full translation map?

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -2540,6 +2540,9 @@ def edit_demo_with_token(token):
         edit_demo_with_token=True,
         demo_edit_access=demo_edit_access,
         show_demo_access_panel=False,
+        translation_locales=_supported_demo_translation_locales(),
+        translation_language_names=_translation_language_names(),
+        default_demo_language=demonstration.default_language or current_app.config.get("BABEL_DEFAULT_LOCALE", "fi"),
     )
 
 def _deep_merge(old: dict, new: dict) -> dict:

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -2094,6 +2094,7 @@ def create_demo():
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}demonstrations/form.html",
         organizations=organizations,
+        all_organizations=organizations,
         form_action=url_for("admin_demo.create_demo"),
         title="Luo mielenosoitus",
         submit_button_text="Luo",
@@ -2101,6 +2102,9 @@ def create_demo():
         city_list=CITY_LIST,
         demo_edit_access={"explicit_editors": [], "organizations": []},
         show_demo_access_panel=False,
+        translation_locales=_supported_demo_translation_locales(),
+        translation_language_names=_translation_language_names(),
+        default_demo_language=current_app.config.get("BABEL_DEFAULT_LOCALE", "fi"),
     )
 
 
@@ -2153,6 +2157,9 @@ def edit_demo(demo_id):
         case_id=case_id,
         demo_edit_access=demo_edit_access,
         show_demo_access_panel=show_demo_access_panel,
+        translation_locales=_supported_demo_translation_locales(),
+        translation_language_names=_translation_language_names(),
+        default_demo_language=demonstration.default_language or current_app.config.get("BABEL_DEFAULT_LOCALE", "fi"),
     )
 
 @admin_demo_bp.route("/command-center/<demo_id>")
@@ -2973,6 +2980,11 @@ def collect_demo_data(request):
     tags = collect_tags(request)
 
     description = request.form.get("description")
+    default_language = (
+        request.form.get("default_language")
+        or current_app.config.get("BABEL_DEFAULT_LOCALE", "fi")
+    )
+    translations = collect_demo_translations(request, default_language)
     latitude = request.form.get("latitude")
     longitude = request.form.get("longitude")
 
@@ -3017,11 +3029,51 @@ def collect_demo_data(request):
         "approved": approved,
         "tags": tags,
         "description": description,
+        "default_language": default_language,
+        "translations": translations,
         "latitude": latitude,
         "longitude": longitude,
         "cover_picture": cover_picture,  # Add cover_picture to output
         "gallery_images": gallery_images,
     }
+
+
+def _supported_demo_translation_locales():
+    return list(current_app.config.get("BABEL_SUPPORTED_LOCALES") or ["fi"])
+
+
+def _translation_language_names():
+    return dict(current_app.config.get("BABEL_LANGUAGES") or {})
+
+
+def collect_demo_translations(request, default_language):
+    supported_locales = _supported_demo_translation_locales()
+    normalized_default = (default_language or "fi").strip().lower()
+    translations = {}
+
+    for language in supported_locales:
+        normalized_language = (language or "").strip().lower()
+        if not normalized_language or normalized_language == normalized_default:
+            continue
+
+        title = (request.form.get(f"translation_{normalized_language}_title") or "").strip()
+        description = request.form.get(f"translation_{normalized_language}_description") or ""
+        description = description.strip()
+        raw_tags = (request.form.get(f"translation_{normalized_language}_tags") or "").strip()
+        tags = [tag.strip().lstrip("#") for tag in raw_tags.split(",") if tag.strip()]
+
+        entry = {}
+        if title:
+            entry["title"] = title
+        if description:
+            entry["description"] = description
+        if tags:
+            entry["tags"] = tags
+
+        if entry:
+            translations[normalized_language] = entry
+
+    return translations
 
 
 def parse_gallery_images_field(raw_value):

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -1840,8 +1840,9 @@ def init_routes(app):
         # Determine whether to bypass cache
         bypass_cache = bool(request.query_string) or should_skip_cache(public_only=False)
 
-        # Build a cache key that is stable for public users; include locale so localized pages differ
-        locale = session.get("locale", "")
+        # Build a cache key that is stable for public users; include the resolved locale
+        # so Accept-Language-driven variants do not collide in cache.
+        locale = _current_demo_language()
         viewer_segment = "anon"
         if current_user.is_authenticated:
             try:
@@ -1872,7 +1873,6 @@ def init_routes(app):
 
         # Prepare response
         _demo = copy.copy(demo_obj)
-        locale = _current_demo_language()
         demo = _localized_demo_copy(Demonstration.to_dict(demo_obj, True), locale)
 
         toistuvuus = ""

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -10,7 +10,7 @@ import hashlib
 import requests
 import xml.etree.ElementTree as ET
 from datetime import datetime, date, timedelta
-from flask_babel import _, refresh, format_date
+from flask_babel import _, refresh, format_date, get_locale
 from flask import (
     app,
     g,
@@ -53,6 +53,7 @@ from mielenosoitukset_fi.utils.cache import (
     skip_cache_public_only,
 )
 from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.demo_localization import get_demo_localized_fields
 from mielenosoitukset_fi.utils.classes import Case
 from mielenosoitukset_fi.utils.demo_cancellation import (
     cancel_demo,
@@ -279,7 +280,37 @@ def generate_alternate_urls(app, endpoint, **values):
             alternate_urls[lang_code] = url_for(endpoint, lang_code=lang_code, **values)
     return alternate_urls
 
-def format_demo_for_api(demo):
+
+def _current_demo_language():
+    try:
+        locale = str(get_locale() or "").strip().lower()
+        if locale:
+            return locale
+    except Exception:
+        pass
+    return (session.get("locale") or Config.BABEL_DEFAULT_LOCALE or "fi").strip().lower()
+
+
+def _localized_demo_copy(demo, language=None):
+    if not isinstance(demo, dict):
+        return demo
+
+    localized = copy.deepcopy(demo)
+    localized.update(
+        get_demo_localized_fields(
+            localized,
+            language=language or _current_demo_language(),
+        )
+    )
+    return localized
+
+
+def _localized_demo_list(demos, language=None):
+    target_language = language or _current_demo_language()
+    return [_localized_demo_copy(demo, target_language) for demo in demos]
+
+
+def format_demo_for_api(demo, language=None):
     """
     Format a demonstration document for API output.
 
@@ -316,24 +347,26 @@ def format_demo_for_api(demo):
             logger.exception(f"Error formatting time: {t}")
             return t
         
+    localized_demo = _localized_demo_copy(demo, language)
+
     try:
-        date_obj = datetime.strptime(demo.get("date", ""), "%Y-%m-%d")
+        date_obj = datetime.strptime(localized_demo.get("date", ""), "%Y-%m-%d")
         date_display = date_obj.strftime("%d.%m.%Y")
     except Exception:
-        date_display = demo.get("date", "")
+        date_display = localized_demo.get("date", "")
 
     return {
-        "_id": str(demo.get("_id")),
-        "title": demo.get("title", ""),
+        "_id": str(localized_demo.get("_id")),
+        "title": localized_demo.get("title", ""),
         "date_display": date_display,
-        "start_time_display": fmt_time(demo.get("start_time")),
-        "end_time_display": fmt_time(demo.get("end_time")),
-        "city": demo.get("city", ""),
-        "address": demo.get("address", ""),
-        "tags": demo.get("tags", []),
-        "description": demo.get("description", ""),
-        "cover_image": get_demo_cover_image(demo),
-        "cancelled": bool(demo.get("cancelled")),
+        "start_time_display": fmt_time(localized_demo.get("start_time")),
+        "end_time_display": fmt_time(localized_demo.get("end_time")),
+        "city": localized_demo.get("city", ""),
+        "address": localized_demo.get("address", ""),
+        "tags": localized_demo.get("tags", []),
+        "description": localized_demo.get("description", ""),
+        "cover_image": get_demo_cover_image(localized_demo),
+        "cancelled": bool(localized_demo.get("cancelled")),
     }
 
 def filter_demonstrations_api(
@@ -968,12 +1001,24 @@ def init_routes(app):
             key=lambda x: datetime.strptime(x["date"], "%Y-%m-%d").date()
         )
 
+        locale = _current_demo_language()
+        localized_filtered_demonstrations = _localized_demo_list(
+            filtered_demonstrations, locale
+        )
+        localized_recommended_demos = _localized_demo_list(recommended_demos or [], locale)
+
         return render_template(
             "index.html",
-            demonstrations=filtered_demonstrations,
-            recommended_demos=recommended_demos,
-            featured_demos_json=[format_demo_for_api(demo) for demo in filtered_demonstrations[:6]],
-            recommended_demos_json=[format_demo_for_api(demo) for demo in (recommended_demos or [])],
+            demonstrations=localized_filtered_demonstrations,
+            recommended_demos=localized_recommended_demos,
+            featured_demos_json=[
+                format_demo_for_api(demo, locale)
+                for demo in filtered_demonstrations[:6]
+            ],
+            recommended_demos_json=[
+                format_demo_for_api(demo, locale)
+                for demo in (recommended_demos or [])
+            ],
         )
 
 
@@ -1815,7 +1860,8 @@ def init_routes(app):
 
         # Prepare response
         _demo = copy.copy(demo_obj)
-        demo = Demonstration.to_dict(demo_obj, True)
+        locale = _current_demo_language()
+        demo = _localized_demo_copy(Demonstration.to_dict(demo_obj, True), locale)
 
         toistuvuus = ""
         if _demo.recurs:
@@ -1876,7 +1922,7 @@ def init_routes(app):
             similar_demos.append(
                 {
                     "id": sid,
-                    "title": doc.get("title"),
+                    "title": get_demo_localized_fields(doc, locale).get("title"),
                     "city": doc.get("city"),
                     "date": doc.get("date"),
                     "formatted_date": formatted_date,
@@ -2310,7 +2356,9 @@ def init_routes(app):
             except (requests.exceptions.RequestException, IndexError):
                 ...
                 
-        demo = Demonstration.to_dict(demo, True)
+        demo = _localized_demo_copy(
+            Demonstration.to_dict(demo, True), _current_demo_language()
+        )
         log_demo_view(
             demo_id, current_user._id if current_user.is_authenticated else None
         )
@@ -2916,7 +2964,9 @@ def init_routes(app):
             if demo_date:
                 dd = datetime.strptime(demo_date, "%Y-%m-%d").date()
                 if dd.year == year and dd.month == month:
-                    month_demos[dd.day].append(demo)
+                    month_demos[dd.day].append(
+                        _localized_demo_copy(demo, _current_demo_language())
+                    )
 
         # Kalenteri kuukaudelle
         cal = calendar.Calendar(firstweekday=0)  # 0 = Monday
@@ -2982,7 +3032,9 @@ def init_routes(app):
             if demo_date_str:
                 dd = datetime.strptime(demo_date_str, "%Y-%m-%d").date()
                 if dd.year == year:
-                    year_demos[dd.month]["days"][dd.day].append(demo)
+                    year_demos[dd.month]["days"][dd.day].append(
+                        _localized_demo_copy(demo, _current_demo_language())
+                    )
 
         # Kuukausien nimet
         month_names = {

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/form.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/form.html
@@ -286,6 +286,23 @@
                 import { initClassicEditor } from '{{ url_for('static', filename='js/ckeditor-init.js') }}';
                 initClassicEditor('#editor', 'description');
             </script>
+
+            <div class="form-group mt-4">
+                <label for="default_language">{{ _('Oletuskieli') }}</label>
+                <select id="default_language" name="default_language" class="form-control">
+                    {% for locale in translation_locales %}
+                    <option value="{{ locale }}" {% if default_demo_language == locale %}selected{% endif %}>
+                        {{ translation_language_names.get(locale, locale|upper) }}
+                    </option>
+                    {% endfor %}
+                </select>
+                <small class="text-muted">
+                    {{ _('Peruskenttien otsikko, kuvaus ja tagit tallennetaan tällä oletuskielellä. Muiden kielten sisältö syötetään alle erillisiin käännöskenttiin.') }}
+                </small>
+                <small class="d-block text-muted mt-1">
+                    {{ _('Oletuskielen vaihtaminen ei siirrä sisältöä automaattisesti kielestä toiseen, joten vaihda se vain kun peruskenttien sisältö vastaa valittua kieltä.') }}
+                </small>
+            </div>
         </section>
 
         <section class="form-section dashboard-panel">
@@ -386,6 +403,56 @@
             })();
 
         </script>
+
+        <section class="form-section dashboard-panel mb-8">
+            <h2 class="text-xl font-semibold mb-4">{{ _('Käännökset') }}</h2>
+            <p class="text-muted mb-4">
+                {{ _('Voit täydentää mielenosoitukselle käännökset eri kielillä. Tyhjä kenttä tarkoittaa, että julkisessa näkymässä käytetään oletuskielen sisältöä.') }}
+            </p>
+
+            {% for locale in translation_locales %}
+            {% if locale != default_demo_language %}
+            {% set translated = demo.translations.get(locale, {}) if demo and demo.translations else {} %}
+            <div class="dashboard-panel mb-4" data-translation-locale="{{ locale }}">
+                <h3 class="h5 mb-3">{{ translation_language_names.get(locale, locale|upper) }}</h3>
+
+                <div class="form-group">
+                    <label for="translation_{{ locale }}_title">{{ _('Käännetty otsikko') }}</label>
+                    <input
+                        type="text"
+                        id="translation_{{ locale }}_title"
+                        name="translation_{{ locale }}_title"
+                        class="form-control"
+                        value="{{ translated.get('title', '') }}"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label for="translation_{{ locale }}_description">{{ _('Käännetty kuvaus') }}</label>
+                    <textarea
+                        id="translation_{{ locale }}_description"
+                        name="translation_{{ locale }}_description"
+                        class="form-control"
+                        rows="5"
+                    >{{ translated.get('description', '') }}</textarea>
+                </div>
+
+                <div class="form-group">
+                    <label for="translation_{{ locale }}_tags">{{ _('Käännetyt tagit') }}</label>
+                    <input
+                        type="text"
+                        id="translation_{{ locale }}_tags"
+                        name="translation_{{ locale }}_tags"
+                        class="form-control"
+                        value="{{ translated.get('tags', []) | join(', ') }}"
+                        placeholder="{{ _('tagi1, tagi2, tagi3') }}"
+                    >
+                    <small class="text-muted">{{ _('Syötä tagit pilkuilla eroteltuna.') }}</small>
+                </div>
+            </div>
+            {% endif %}
+            {% endfor %}
+        </section>
 
 
         <!-- Social & Cover Picture -->

--- a/mielenosoitukset_fi/utils/classes/Demonstration.py
+++ b/mielenosoitukset_fi/utils/classes/Demonstration.py
@@ -22,6 +22,7 @@ class Demonstration(BaseModel):
     # Running number and slug fields for user-friendly URLs
     running_number: int = None
     slug: str = None
+    TRANSLATABLE_FIELDS = {"title", "description", "tags"}
   
     """
     A class to represent a demonstration event.
@@ -162,6 +163,8 @@ class Demonstration(BaseModel):
         last_modified=None,
         _id: ObjectId = None,
         description: str = None,
+        translations: dict = None,
+        default_language: str = "fi",
         _dont_override: bool = False,
         _rejected: bool = False,
         cover_source: str = None,
@@ -270,6 +273,8 @@ class Demonstration(BaseModel):
 
         self.title = title
         self.description = description
+        self.default_language = (default_language or "fi").strip().lower()
+        self.translations = self._normalize_translations(translations)
 
         # Removed direct assignment for date, start_time, end_time
 
@@ -412,6 +417,80 @@ class Demonstration(BaseModel):
         self.validate_fields(
             title, date, start_time, city, address
         )  # Validate required fields
+
+    def _normalize_translation_value(self, field, value):
+        if field == "tags":
+            if value is None:
+                return []
+            if isinstance(value, str):
+                return [tag.strip() for tag in value.split(",") if tag.strip()]
+            if isinstance(value, list):
+                return [str(tag).strip() for tag in value if str(tag).strip()]
+            return []
+
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    def _normalize_translations(self, translations):
+        normalized = {}
+        if not isinstance(translations, dict):
+            return normalized
+
+        for language, values in translations.items():
+            lang = (language or "").strip().lower()
+            if not lang or not isinstance(values, dict):
+                continue
+
+            lang_values = {}
+            for field in self.TRANSLATABLE_FIELDS:
+                if field in values:
+                    lang_values[field] = self._normalize_translation_value(
+                        field, values.get(field)
+                    )
+
+            if lang_values:
+                normalized[lang] = lang_values
+
+        return normalized
+
+    def set_translation(self, language: str, field: str, value):
+        lang = (language or "").strip().lower()
+        if field not in self.TRANSLATABLE_FIELDS:
+            raise ValueError(f"Unsupported translatable field: {field}")
+        if not lang:
+            raise ValueError("Translation language is required")
+
+        if lang not in self.translations:
+            self.translations[lang] = {}
+        self.translations[lang][field] = self._normalize_translation_value(field, value)
+
+    def get_translation(self, language: str, field: str, fallback: bool = True):
+        lang = (language or "").strip().lower()
+        if field not in self.TRANSLATABLE_FIELDS:
+            raise ValueError(f"Unsupported translatable field: {field}")
+
+        if lang:
+            translated = self.translations.get(lang, {}).get(field)
+            if translated not in (None, "", []):
+                return copy.deepcopy(translated)
+
+        if fallback:
+            return copy.deepcopy(getattr(self, field))
+
+        return [] if field == "tags" else None
+
+    def available_translation_languages(self):
+        return sorted(self.translations.keys())
+
+    def get_localized_fields(self, language: str, fallback: bool = True):
+        return {
+            "title": self.get_translation(language, "title", fallback=fallback),
+            "description": self.get_translation(
+                language, "description", fallback=fallback
+            ),
+            "tags": self.get_translation(language, "tags", fallback=fallback),
+        }
 
 
     def _format_date(self):
@@ -601,6 +680,8 @@ class Demonstration(BaseModel):
         data["merged_into"] = str(self.merged_into) if self.merged_into else None  # Added line
         data["running_number"] = self.running_number
         data["slug"] = self.slug
+        data["translations"] = copy.deepcopy(self.translations)
+        data["default_language"] = self.default_language
         # Include last_modified in the dictionary. If JSON output is requested,
         # convert datetimes to ISO strings.
         try:
@@ -800,6 +881,8 @@ class Demonstration(BaseModel):
             # Basic Info
             title=get("title"),
             description=get("description"),
+            translations=get("translations") or {},
+            default_language=get("default_language", "fi"),
             date=get("date"),
             start_time=get("start_time"),
             end_time=get("end_time"),

--- a/mielenosoitukset_fi/utils/demo_localization.py
+++ b/mielenosoitukset_fi/utils/demo_localization.py
@@ -1,0 +1,47 @@
+import copy
+
+
+TRANSLATABLE_DEMO_FIELDS = ("title", "description", "tags")
+
+
+def normalize_demo_language(language: str, default: str = "fi") -> str:
+    normalized = (language or "").strip().lower()
+    fallback = (default or "fi").strip().lower()
+    return normalized or fallback or "fi"
+
+
+def get_demo_localized_value(
+    demo, field: str, language: str = None, fallback: bool = True
+):
+    if field not in TRANSLATABLE_DEMO_FIELDS:
+        raise ValueError(f"Unsupported translatable field: {field}")
+
+    if hasattr(demo, "get_translation"):
+        return demo.get_translation(language, field, fallback=fallback)
+
+    if not isinstance(demo, dict):
+        raise TypeError("demo must be a Demonstration instance or a dict")
+
+    normalized_language = normalize_demo_language(
+        language, demo.get("default_language", "fi")
+    )
+    translations = demo.get("translations") or {}
+    translated = translations.get(normalized_language, {}).get(field)
+
+    if translated not in (None, "", []):
+        return copy.deepcopy(translated)
+
+    if fallback:
+        return copy.deepcopy(demo.get(field))
+
+    return [] if field == "tags" else None
+
+
+def get_demo_localized_fields(demo, language: str = None, fallback: bool = True):
+    return {
+        "title": get_demo_localized_value(demo, "title", language, fallback=fallback),
+        "description": get_demo_localized_value(
+            demo, "description", language, fallback=fallback
+        ),
+        "tags": get_demo_localized_value(demo, "tags", language, fallback=fallback),
+    }

--- a/tests/test_admin_demo_views.py
+++ b/tests/test_admin_demo_views.py
@@ -46,6 +46,33 @@ def test_edit_demo_prefills_translation_fields(admin_client, db, seeded_data):
     assert 'value="peace, climate"' in page
 
 
+def test_edit_demo_with_token_includes_translation_context(client, db, seeded_data):
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {
+            "$set": {
+                "default_language": "fi",
+                "translations": {
+                    "en": {
+                        "title": "English Climate March",
+                    }
+                },
+            }
+        },
+    )
+
+    response = client.get(
+        f"/admin/demo/edit_demo_with_token/{seeded_data['edit_token']}"
+    )
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert 'name="default_language"' in page
+    assert 'value="fi" selected' in page
+    assert 'name="translation_en_title"' in page
+    assert "English Climate March" in page
+
+
 def test_create_demo_persists_translation_payload(admin_client, db):
     response = admin_client.post(
         "/admin/demo/create_demo",

--- a/tests/test_admin_demo_views.py
+++ b/tests/test_admin_demo_views.py
@@ -4,6 +4,9 @@ def test_create_demo_hides_edit_only_controls(admin_client):
     assert response.status_code == 200
     page = response.get_data(as_text=True)
     assert 'name="cover_picture"' in page
+    assert 'name="default_language"' in page
+    assert 'name="translation_en_title"' in page
+    assert 'name="translation_sv_description"' in page
     assert "Luo muokkauslinkki" not in page
     assert "Luo kopio mielenosoituksesta" not in page
 
@@ -15,3 +18,60 @@ def test_edit_demo_shows_edit_only_controls(admin_client, seeded_data):
     page = response.get_data(as_text=True)
     assert "Luo muokkauslinkki" in page
     assert "Luo kopio mielenosoituksesta" in page
+
+
+def test_edit_demo_prefills_translation_fields(admin_client, db, seeded_data):
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {
+            "$set": {
+                "default_language": "fi",
+                "translations": {
+                    "en": {
+                        "title": "English Climate March",
+                        "description": "English description",
+                        "tags": ["peace", "climate"],
+                    }
+                },
+            }
+        },
+    )
+
+    response = admin_client.get(f"/admin/demo/edit_demo/{seeded_data['demo_id']}")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert 'value="English Climate March"' in page
+    assert "English description" in page
+    assert 'value="peace, climate"' in page
+
+
+def test_create_demo_persists_translation_payload(admin_client, db):
+    response = admin_client.post(
+        "/admin/demo/create_demo",
+        data={
+            "title": "Solidarity Rally",
+            "date": "2026-06-10",
+            "start_time": "18:00",
+            "end_time": "20:00",
+            "city": "Helsinki",
+            "address": "Kansalaistori 1",
+            "type": "STAY_STILL",
+            "description": "Finnish base description",
+            "default_language": "fi",
+            "translation_en_title": "Solidarity Rally in English",
+            "translation_en_description": "English description",
+            "translation_en_tags": "peace, rally",
+            "translation_sv_title": "Solidaritetsmanifestation",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    created = db.demonstrations.find_one({"title": "Solidarity Rally"})
+    assert created is not None
+    assert created["default_language"] == "fi"
+    assert created["translations"]["en"]["title"] == "Solidarity Rally in English"
+    assert created["translations"]["en"]["description"] == "English description"
+    assert created["translations"]["en"]["tags"] == ["peace", "rally"]
+    assert created["translations"]["sv"]["title"] == "Solidaritetsmanifestation"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,24 @@ class ConfigReloadTests(unittest.TestCase):
         finally:
             DatabaseManager._instance = original
 
+    def test_reload_uses_finnish_and_english_as_default_supported_locales(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.yaml"
+            config_path.write_text("{}", encoding="utf-8")
+
+            with patch.dict(os.environ, {"CONFIG_YAML_PATH": str(config_path)}):
+                config_module.Config.reload()
+
+            self.assertEqual(config_module.Config.BABEL_DEFAULT_LOCALE, "en")
+            self.assertEqual(
+                config_module.Config.BABEL_SUPPORTED_LOCALES,
+                ["fi", "en"],
+            )
+            self.assertEqual(
+                config_module.Config.BABEL_LANGUAGES,
+                {"fi": "Suomi", "en": "English"},
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_demonstration_translations.py
+++ b/tests/test_demonstration_translations.py
@@ -1,0 +1,124 @@
+import importlib
+import sys
+
+
+class _FakeCollection:
+    def find_one(self, *args, **kwargs):
+        return None
+
+
+class _FakeDB:
+    def __getitem__(self, key):
+        return _FakeCollection()
+
+
+def _reset_demo_modules():
+    for module_name in list(sys.modules):
+        if module_name == "mielenosoitukset_fi.utils.classes" or module_name.startswith(
+            "mielenosoitukset_fi.utils.classes."
+        ):
+            sys.modules.pop(module_name, None)
+
+
+def _load_demonstration_class(monkeypatch):
+    import mielenosoitukset_fi.utils.database as database_module
+
+    monkeypatch.setattr(database_module, "get_database_manager", lambda: _FakeDB())
+    _reset_demo_modules()
+
+    module = importlib.import_module("mielenosoitukset_fi.utils.classes.Demonstration")
+    return module.Demonstration
+
+
+def teardown_module(module):
+    _reset_demo_modules()
+
+
+def _build_demo(Demonstration, **overrides):
+    payload = {
+        "title": "Suomenkielinen otsikko",
+        "description": "Suomenkielinen kuvaus",
+        "date": "2026-08-15",
+        "start_time": "15:00",
+        "end_time": "17:00",
+        "city": "Helsinki",
+        "address": "Testikatu 1",
+        "tags": ["rauha", "testi"],
+        "_dont_override": True,
+    }
+    payload.update(overrides)
+    return Demonstration(**payload)
+
+
+def test_demonstration_translation_falls_back_to_base_fields(monkeypatch):
+    Demonstration = _load_demonstration_class(monkeypatch)
+
+    demo = _build_demo(
+        Demonstration,
+        translations={
+            "en": {
+                "title": "English title",
+            }
+        }
+    )
+
+    assert demo.get_translation("en", "title") == "English title"
+    assert demo.get_translation("en", "description") == "Suomenkielinen kuvaus"
+    assert demo.get_translation("sv", "title") == "Suomenkielinen otsikko"
+    assert demo.available_translation_languages() == ["en"]
+    assert demo.get_localized_fields("en") == {
+        "title": "English title",
+        "description": "Suomenkielinen kuvaus",
+        "tags": ["rauha", "testi"],
+    }
+
+
+def test_demonstration_translation_normalizes_tags_and_roundtrips_to_dict(monkeypatch):
+    Demonstration = _load_demonstration_class(monkeypatch)
+
+    demo = _build_demo(
+        Demonstration,
+        default_language="fi",
+        translations={"en": {"tags": "peace, rally"}},
+    )
+    demo.set_translation("sv", "description", "Svensk beskrivning")
+
+    data = demo.to_dict()
+    restored = Demonstration.from_dict(data)
+
+    assert data["default_language"] == "fi"
+    assert data["translations"]["en"]["tags"] == ["peace", "rally"]
+    assert restored.get_translation("en", "tags") == ["peace", "rally"]
+    assert restored.get_translation("sv", "description") == "Svensk beskrivning"
+
+
+def test_demo_localization_helper_supports_dict_payloads():
+    from mielenosoitukset_fi.utils.demo_localization import (
+        get_demo_localized_fields,
+        get_demo_localized_value,
+    )
+
+    demo = {
+        "title": "Suomenkielinen otsikko",
+        "description": "Suomenkielinen kuvaus",
+        "tags": ["rauha"],
+        "default_language": "fi",
+        "translations": {
+            "en": {
+                "title": "English title",
+                "tags": ["peace"],
+            }
+        },
+    }
+
+    assert get_demo_localized_value(demo, "title", "en") == "English title"
+    assert (
+        get_demo_localized_value(demo, "description", "en")
+        == "Suomenkielinen kuvaus"
+    )
+    assert get_demo_localized_value(demo, "title", "sv", fallback=False) is None
+    assert get_demo_localized_fields(demo, "en") == {
+        "title": "English title",
+        "description": "Suomenkielinen kuvaus",
+        "tags": ["peace"],
+    }

--- a/tests/test_public_demo_localization.py
+++ b/tests/test_public_demo_localization.py
@@ -1,0 +1,64 @@
+def _set_demo_translation(db, demo_id):
+    db.demonstrations.update_one(
+        {"_id": demo_id},
+        {
+            "$set": {
+                "date": "2026-05-20",
+                "default_language": "fi",
+                "translations": {
+                    "en": {
+                        "title": "English Climate March",
+                        "description": "English description for the seeded demonstration.",
+                        "tags": ["peace", "climate"],
+                    }
+                },
+            }
+        },
+    )
+
+
+def _set_client_locale(client, locale):
+    with client.session_transaction() as session:
+        session["locale"] = locale
+
+
+def test_demo_detail_renders_translated_fields_for_active_locale(client, db, seeded_data):
+    _set_demo_translation(db, seeded_data["demo_id"])
+    _set_client_locale(client, "en")
+
+    response = client.get(f"/demonstration/{seeded_data['demo_id']}")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "English Climate March" in body
+    assert "English description for the seeded demonstration." in body
+    assert "Climate March Helsinki" not in body
+
+
+def test_demo_api_returns_translated_card_fields_for_active_locale(client, db, seeded_data):
+    _set_demo_translation(db, seeded_data["demo_id"])
+    _set_client_locale(client, "en")
+
+    response = client.get("/api/v1/demonstrations")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    matching = next(
+        demo
+        for demo in payload["demonstrations"]
+        if demo["_id"] == str(seeded_data["demo_id"])
+    )
+    assert matching["title"] == "English Climate March"
+    assert matching["description"] == "English description for the seeded demonstration."
+    assert matching["tags"] == ["peace", "climate"]
+
+
+def test_calendar_month_view_renders_translated_demo_titles(client, db, seeded_data):
+    _set_demo_translation(db, seeded_data["demo_id"])
+    _set_client_locale(client, "en")
+
+    response = client.get("/calendar/2026/5/")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "English Climate March" in body

--- a/tests/test_public_demo_localization.py
+++ b/tests/test_public_demo_localization.py
@@ -53,6 +53,27 @@ def test_demo_api_returns_translated_card_fields_for_active_locale(client, db, s
     assert matching["tags"] == ["peace", "climate"]
 
 
+def test_demo_detail_cache_is_split_by_resolved_locale(client, db, seeded_data):
+    _set_demo_translation(db, seeded_data["demo_id"])
+
+    english = client.get(
+        f"/demonstration/{seeded_data['demo_id']}",
+        headers={"Accept-Language": "en"},
+    )
+    finnish = client.get(
+        f"/demonstration/{seeded_data['demo_id']}",
+        headers={"Accept-Language": "fi"},
+    )
+
+    assert english.status_code == 200
+    assert finnish.status_code == 200
+
+    english_body = english.get_data(as_text=True)
+    finnish_body = finnish.get_data(as_text=True)
+    assert '<h1 class="demo-title">English Climate March</h1>' in english_body
+    assert '<h1 class="demo-title">Climate March Helsinki</h1>' in finnish_body
+
+
 def test_calendar_month_view_renders_translated_demo_titles(client, db, seeded_data):
     _set_demo_translation(db, seeded_data["demo_id"])
     _set_client_locale(client, "en")


### PR DESCRIPTION
## Summary
- add multilingual demonstration data foundation with `default_language` and `translations`
- localize public demonstration rendering through shared helpers and locale-aware fallbacks
- add admin demo translation inputs for title, description, and tags
- add targeted regression coverage for foundation, admin form handling, and public localized rendering

## Testing
- `python -m pytest -q tests/test_demonstration_translations.py tests/test_admin_demo_views.py tests/test_public_demo_localization.py`
- `python -m py_compile mielenosoitukset_fi/basic_routes.py mielenosoitukset_fi/admin/admin_demo_bp.py mielenosoitukset_fi/utils/classes/Demonstration.py mielenosoitukset_fi/utils/demo_localization.py tests/test_demonstration_translations.py tests/test_admin_demo_views.py tests/test_public_demo_localization.py`
- `git diff --check`

## Notes
- leaves the unrelated local `.gitignore` change out of the branch work
- follow-up slice will cover recurring demo and submit-flow multilinguality