### PR TITLE
Add translator review workflow for demo translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 * Adminiin lisättiin ensimmäinen demojen käännöstyöjono: uusi `translator`-rooli voi tehdä käännösehdotuksia demojen otsikoille, kuvauksille ja tunnisteille, ja admin hyväksyy tai hylkää ne ennen julkaisua.
 * Demojen detail-sivu näyttää nyt hyväksytyt käännökset aktiivisen kielen mukaan, lokalisoi samankaltaisten tapahtumien otsikot, ja kertoo suoraan millä kielellä tapahtumaa katsotaan.
+* Käännöstyökalu osaa nyt pyytää backendissä välimuistitetyn DeepL-ehdotuksen demolle, jotta kääntäjät voivat käyttää automaattista luonnosta ilman että sama käännös generoidaan selaimessa joka näkymässä uudelleen.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.
@@ -57,6 +58,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Demojen käännöstyöjono piilottaa menneet mielenosoitukset oletuksena ja näyttää ne vain erikseen pyydettäessä, jotta kääntäjien näkymä pysyy keskittyneenä aktiivisiin tapahtumiin.
 * PR preview workflow now posts an immediate spinning-up comment before building the preview, then edits the same comment into the final live URL once deploy completes.
 * PR preview workflow now stages the deploy script under the dedicated preview user's home directory instead of `/tmp`, avoiding permission failures on the server-side copy step.
 * Recurring demo admin create/edit now preserve organizer data even if organizer cards are removed and re-added out of sequence, and the shared recurring description editor now loads its real CKEditor initializer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 * Adminiin lisättiin ensimmäinen demojen käännöstyöjono: uusi `translator`-rooli voi tehdä käännösehdotuksia demojen otsikoille, kuvauksille ja tunnisteille, ja admin hyväksyy tai hylkää ne ennen julkaisua.
+* Demojen detail-sivu näyttää nyt hyväksytyt käännökset aktiivisen kielen mukaan, lokalisoi samankaltaisten tapahtumien otsikot, ja kertoo suoraan millä kielellä tapahtumaa katsotaan.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 ### Added
+* Adminiin lisättiin ensimmäinen demojen käännöstyöjono: uusi `translator`-rooli voi tehdä käännösehdotuksia demojen otsikoille, kuvauksille ja tunnisteille, ja admin hyväksyy tai hylkää ne ennen julkaisua.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/config.py
+++ b/config.py
@@ -110,6 +110,11 @@ class Config:
             ["en"],
         )
         cls.BABEL_LANGUAGES = cls.BABEL_CONFIG.get("LANGUAGES", {"en": "English"})
+        cls.DEEPL_API_KEY = config.get("DEEPL_API_KEY", "")
+        cls.DEEPL_API_URL = config.get(
+            "DEEPL_API_URL",
+            "https://api-free.deepl.com/v2/translate",
+        )
 
         cls.SECRET_KEY = config.get("SECRET_KEY", "secret_key")
         cls.PORT = config.get("PORT", 8000)

--- a/docs/translator_review_workflow.md
+++ b/docs/translator_review_workflow.md
@@ -1,0 +1,65 @@
+# Translator Review Workflow
+
+This branch adds the first reviewable translator workflow for demonstration translations.
+
+## What exists now
+
+- A new global role: `translator`
+- An implied translator permission: `TRANSLATE_DEMO`
+- A dedicated admin-side translation queue: `/admin/demo/translations`
+- A dedicated translation editor per demonstration: `/admin/demo/<demo_id>/translations`
+- Review actions for admins:
+  - approve proposal
+  - reject proposal
+
+## Current data model
+
+Demonstrations may now contain:
+
+- `default_language`
+- `translations.<locale>`
+- `translation_proposals.<locale>`
+
+Example:
+
+```json
+{
+  "default_language": "fi",
+  "translations": {
+    "en": {
+      "title": "Climate March",
+      "description": "Approved English version",
+      "tags": ["climate", "march"]
+    }
+  },
+  "translation_proposals": {
+    "en": {
+      "language": "en",
+      "title": "Climate March",
+      "description": "Pending English proposal",
+      "tags": ["climate", "march"],
+      "status": "pending",
+      "submitted_by": "...",
+      "submitted_by_name": "Translator User",
+      "submitted_at": "..."
+    }
+  }
+}
+```
+
+## Intentional limits in this first slice
+
+- This workflow currently covers normal demonstrations only.
+- Recurring-demo translation review still needs a matching workflow.
+- Public rendering does not yet consume approved translations from this branch.
+- There is no separate `moderator` role yet; review is handled by admin/global admin.
+
+## Recommended next slices
+
+1. Add recurring-demo translation proposals and review.
+2. Make public demo rendering locale-aware based on approved `translations`.
+3. Add reviewer notes/history UI to the queue list itself.
+4. Add notifications:
+   - translator notified on approval/rejection
+   - reviewer notified about new pending proposals
+5. Decide whether admin demo editing should also expose direct translation editing, or whether proposal-only should remain the only path.

--- a/docs/translator_review_workflow.md
+++ b/docs/translator_review_workflow.md
@@ -8,6 +8,7 @@ This branch adds the first reviewable translator workflow for demonstration tran
 - An implied translator permission: `TRANSLATE_DEMO`
 - A dedicated admin-side translation queue: `/admin/demo/translations`
 - A dedicated translation editor per demonstration: `/admin/demo/<demo_id>/translations`
+- Backend-generated DeepL suggestions that can be cached per demo source state and used as translation drafts
 - Review actions for admins:
   - approve proposal
   - reject proposal
@@ -53,6 +54,8 @@ Example:
 - Recurring-demo translation review still needs a matching workflow.
 - Public rendering does not yet consume approved translations from this branch.
 - There is no separate `moderator` role yet; review is handled by admin/global admin.
+- Past demonstrations are hidden from the translation queue by default.
+- DeepL suggestions do not publish automatically; they only help translators draft proposals.
 
 ## Recommended next slices
 

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -163,6 +163,102 @@ def _demo_status_meta(doc):
     return _("Kesken"), "info", _("Tämä mielenosoitus odottaa käsittelyä.")
 
 
+TRANSLATION_EDITABLE_FIELDS = ("title", "description", "tags")
+
+
+def _default_demo_language():
+    return current_app.config.get("BABEL_DEFAULT_LOCALE", "fi")
+
+
+def _supported_translation_locales(demo_doc=None):
+    configured = current_app.config.get("BABEL_SUPPORTED_LOCALES", ["fi"])
+    default_language = (
+        (demo_doc or {}).get("default_language")
+        or _default_demo_language()
+    )
+    locales = []
+    for locale in configured:
+        if locale == default_language:
+            continue
+        locales.append(locale)
+    return locales
+
+
+def _translation_language_names():
+    return current_app.config.get("BABEL_LANGUAGES", {})
+
+
+def _demo_source_language(demo_doc):
+    return demo_doc.get("default_language") or _default_demo_language()
+
+
+def _demo_translation_payload(demo_doc, language):
+    return ((demo_doc.get("translations") or {}).get(language) or {})
+
+
+def _demo_translation_proposal(demo_doc, language):
+    return ((demo_doc.get("translation_proposals") or {}).get(language) or {})
+
+
+def _translation_summary_rows(demo_doc):
+    rows = []
+    language_names = _translation_language_names()
+    supported_locales = _supported_translation_locales(demo_doc)
+    approved = demo_doc.get("translations") or {}
+    proposals = demo_doc.get("translation_proposals") or {}
+    for locale in supported_locales:
+        proposal = proposals.get(locale) or {}
+        approved_translation = approved.get(locale) or {}
+        rows.append(
+            {
+                "locale": locale,
+                "label": language_names.get(locale, locale),
+                "approved": approved_translation,
+                "proposal": proposal,
+                "proposal_status": proposal.get("status"),
+            }
+        )
+    return rows
+
+
+def _can_translate_demos(user):
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "global_admin", False):
+        return True
+    if getattr(user, "role", None) in {"admin", "translator"}:
+        return True
+    return user.has_permission("TRANSLATE_DEMO")
+
+
+def _can_review_demo_translations(user):
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "global_admin", False):
+        return True
+    if getattr(user, "role", None) in {"admin", "global_admin"}:
+        return True
+    return user.has_permission("REVIEW_DEMO_TRANSLATIONS")
+
+
+def _collect_translation_proposal_form(language):
+    tags_raw = request.form.get("translated_tags", "")
+    tags = [tag.strip() for tag in tags_raw.split(",") if tag.strip()]
+    return {
+        "language": language,
+        "title": (request.form.get("translated_title") or "").strip(),
+        "description": (request.form.get("translated_description") or "").strip(),
+        "tags": tags,
+    }
+
+
+def _proposal_has_content(proposal):
+    return any(
+        bool(proposal.get(field))
+        for field in TRANSLATION_EDITABLE_FIELDS
+    )
+
+
 def _case_admin_username():
     try:
         return getattr(current_user, "username", None) or "system"
@@ -1494,6 +1590,222 @@ def demo_control():
         prev_page=prev_page,
         next_page=next_page
     )
+
+
+@admin_demo_bp.route("/translations", methods=["GET"])
+@login_required
+def demo_translation_dashboard():
+    if not (_can_translate_demos(current_user) or _can_review_demo_translations(current_user)):
+        abort(403)
+
+    search_query = (request.args.get("search") or "").strip()
+    query = {"$or": [{"rejected": {"$exists": False}}, {"rejected": False}]}
+    if search_query:
+        query["title"] = {"$regex": re.escape(search_query), "$options": "i"}
+
+    demos = list(
+        mongo.demonstrations.find(
+            query,
+            {"title": 1, "default_language": 1, "translations": 1, "translation_proposals": 1},
+        )
+        .sort([("date", 1), ("_id", 1)])
+        .limit(100)
+    )
+
+    pending_items = []
+    if _can_review_demo_translations(current_user):
+        for demo in demos:
+            for locale, proposal in (demo.get("translation_proposals") or {}).items():
+                if proposal.get("status") != "pending":
+                    continue
+                pending_items.append(
+                    {
+                        "demo_id": str(demo["_id"]),
+                        "demo_title": demo.get("title") or _("Nimetön mielenosoitus"),
+                        "language": locale,
+                        "language_label": _translation_language_names().get(locale, locale),
+                        "submitted_at": proposal.get("submitted_at"),
+                        "submitted_by": proposal.get("submitted_by_name") or proposal.get("submitted_by"),
+                        "proposal": proposal,
+                    }
+                )
+
+    return render_template(
+        f"{_ADMIN_TEMPLATE_FOLDER}demonstrations/translations_dashboard.html",
+        demos=demos,
+        pending_items=pending_items,
+        search_query=search_query,
+        can_review_demo_translations=_can_review_demo_translations(current_user),
+        can_translate_demos=_can_translate_demos(current_user),
+        translation_language_names=_translation_language_names(),
+    )
+
+
+@admin_demo_bp.route("/<demo_id>/translations", methods=["GET", "POST"])
+@login_required
+def edit_demo_translations(demo_id):
+    if not (_can_translate_demos(current_user) or _can_review_demo_translations(current_user)):
+        abort(403)
+
+    demo_doc = mongo.demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not demo_doc:
+        flash_message(_("Mielenosoitusta ei löytynyt."), "error")
+        return redirect(url_for("admin_demo.demo_translation_dashboard"))
+
+    if request.method == "POST":
+        if not _can_translate_demos(current_user):
+            abort(403)
+        language = (request.form.get("language") or "").strip()
+        if language not in _supported_translation_locales(demo_doc):
+            flash_message(_("Valittu kieli ei ole sallittu käännöskieli."), "error")
+            return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id))
+        proposal_fields = _collect_translation_proposal_form(language)
+        if not _proposal_has_content(proposal_fields):
+            flash_message(_("Syötä ainakin otsikko, kuvaus tai tunnisteet käännösehdotukseen."), "error")
+            return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+        proposal_doc = {
+            **proposal_fields,
+            "status": "pending",
+            "submitted_at": datetime.utcnow(),
+            "submitted_by": str(getattr(current_user, "_id", "")),
+            "submitted_by_name": getattr(current_user, "displayname", None) or getattr(current_user, "username", None),
+            "reviewed_at": None,
+            "reviewed_by": None,
+            "reviewed_by_name": None,
+            "review_notes": "",
+        }
+        mongo.demonstrations.update_one(
+            {"_id": ObjectId(demo_id)},
+            {
+                "$set": {
+                    f"translation_proposals.{language}": proposal_doc,
+                    "default_language": _demo_source_language(demo_doc),
+                }
+            },
+        )
+        log_demo_audit_entry(
+            demo_id,
+            action="submit_translation_proposal",
+            message=_("%(actor)s lähetti käännösehdotuksen kielelle %(language)s.") % {
+                "actor": _get_actor_label(),
+                "language": _translation_language_names().get(language, language),
+            },
+            details={"language": language},
+        )
+        flash_message(_("Käännösehdotus tallennettiin ja lähetettiin tarkistettavaksi."), "success")
+        return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+    selected_language = (request.args.get("language") or "").strip()
+    supported_locales = _supported_translation_locales(demo_doc)
+    if selected_language not in supported_locales and supported_locales:
+        selected_language = supported_locales[0]
+
+    return render_template(
+        f"{_ADMIN_TEMPLATE_FOLDER}demonstrations/translations_editor.html",
+        demo=demo_doc,
+        selected_language=selected_language,
+        translation_locales=supported_locales,
+        translation_language_names=_translation_language_names(),
+        source_language=_demo_source_language(demo_doc),
+        approved_translation=_demo_translation_payload(demo_doc, selected_language) if selected_language else {},
+        translation_proposal=_demo_translation_proposal(demo_doc, selected_language) if selected_language else {},
+        translation_rows=_translation_summary_rows(demo_doc),
+        can_review_demo_translations=_can_review_demo_translations(current_user),
+        can_translate_demos=_can_translate_demos(current_user),
+    )
+
+
+@admin_demo_bp.route("/<demo_id>/translations/<language>/approve", methods=["POST"])
+@login_required
+def approve_demo_translation(demo_id, language):
+    if not _can_review_demo_translations(current_user):
+        abort(403)
+
+    demo_doc = mongo.demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not demo_doc:
+        flash_message(_("Mielenosoitusta ei löytynyt."), "error")
+        return redirect(url_for("admin_demo.demo_translation_dashboard"))
+
+    proposal = _demo_translation_proposal(demo_doc, language)
+    if proposal.get("status") != "pending":
+        flash_message(_("Tälle kielelle ei ole odottavaa käännösehdotusta."), "error")
+        return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+    review_notes = (request.form.get("review_notes") or "").strip()
+    approved_translation = {
+        "title": proposal.get("title", ""),
+        "description": proposal.get("description", ""),
+        "tags": proposal.get("tags", []),
+    }
+    mongo.demonstrations.update_one(
+        {"_id": ObjectId(demo_id)},
+        {
+            "$set": {
+                f"translations.{language}": approved_translation,
+                f"translation_proposals.{language}.status": "approved",
+                f"translation_proposals.{language}.reviewed_at": datetime.utcnow(),
+                f"translation_proposals.{language}.reviewed_by": str(getattr(current_user, "_id", "")),
+                f"translation_proposals.{language}.reviewed_by_name": getattr(current_user, "displayname", None) or getattr(current_user, "username", None),
+                f"translation_proposals.{language}.review_notes": review_notes,
+                "default_language": _demo_source_language(demo_doc),
+            }
+        },
+    )
+    log_demo_audit_entry(
+        demo_id,
+        action="approve_translation_proposal",
+        message=_("%(actor)s hyväksyi käännösehdotuksen kielelle %(language)s.") % {
+            "actor": _get_actor_label(),
+            "language": _translation_language_names().get(language, language),
+        },
+        details={"language": language},
+    )
+    flash_message(_("Käännösehdotus hyväksyttiin."), "success")
+    return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+
+@admin_demo_bp.route("/<demo_id>/translations/<language>/reject", methods=["POST"])
+@login_required
+def reject_demo_translation(demo_id, language):
+    if not _can_review_demo_translations(current_user):
+        abort(403)
+
+    demo_doc = mongo.demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not demo_doc:
+        flash_message(_("Mielenosoitusta ei löytynyt."), "error")
+        return redirect(url_for("admin_demo.demo_translation_dashboard"))
+
+    proposal = _demo_translation_proposal(demo_doc, language)
+    if proposal.get("status") != "pending":
+        flash_message(_("Tälle kielelle ei ole odottavaa käännösehdotusta."), "error")
+        return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+    review_notes = (request.form.get("review_notes") or "").strip()
+    mongo.demonstrations.update_one(
+        {"_id": ObjectId(demo_id)},
+        {
+            "$set": {
+                f"translation_proposals.{language}.status": "rejected",
+                f"translation_proposals.{language}.reviewed_at": datetime.utcnow(),
+                f"translation_proposals.{language}.reviewed_by": str(getattr(current_user, "_id", "")),
+                f"translation_proposals.{language}.reviewed_by_name": getattr(current_user, "displayname", None) or getattr(current_user, "username", None),
+                f"translation_proposals.{language}.review_notes": review_notes,
+                "default_language": _demo_source_language(demo_doc),
+            }
+        },
+    )
+    log_demo_audit_entry(
+        demo_id,
+        action="reject_translation_proposal",
+        message=_("%(actor)s hylkäsi käännösehdotuksen kielelle %(language)s.") % {
+            "actor": _get_actor_label(),
+            "language": _translation_language_names().get(language, language),
+        },
+        details={"language": language},
+    )
+    flash_message(_("Käännösehdotus hylättiin."), "success")
+    return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
 
 @admin_demo_bp.route("/duplicate/<demo_id>", methods=["POST"])
 @login_required

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -32,6 +32,11 @@ from mielenosoitukset_fi.utils.demo_cancellation import cancel_demo, queue_cance
 from mielenosoitukset_fi.utils.s3 import upload_image_fileobj
 from mielenosoitukset_fi.utils.admin.demonstration import collect_tags
 from mielenosoitukset_fi.utils.database import DEMO_FILTER
+from mielenosoitukset_fi.utils.demo_translation_cache import (
+    demo_is_translation_candidate,
+    get_cached_deepl_suggestion_for_demo,
+    get_or_create_deepl_suggestions_for_demo,
+)
 from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.utils.variables import CITY_LIST
 from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
@@ -244,12 +249,22 @@ def _can_review_demo_translations(user):
 def _collect_translation_proposal_form(language):
     tags_raw = request.form.get("translated_tags", "")
     tags = [tag.strip() for tag in tags_raw.split(",") if tag.strip()]
-    return {
+    proposal = {
         "language": language,
         "title": (request.form.get("translated_title") or "").strip(),
         "description": (request.form.get("translated_description") or "").strip(),
         "tags": tags,
     }
+    provider = (request.form.get("suggestion_provider") or "").strip()
+    source_hash = (request.form.get("suggestion_source_hash") or "").strip()
+    auto_generated = (request.form.get("suggestion_auto_generated") or "").strip().lower() == "true"
+    if provider:
+        proposal["_meta"] = {
+            "provider": provider,
+            "source_hash": source_hash or None,
+            "auto_generated": auto_generated,
+        }
+    return proposal
 
 
 def _proposal_has_content(proposal):
@@ -1599,7 +1614,10 @@ def demo_translation_dashboard():
         abort(403)
 
     search_query = (request.args.get("search") or "").strip()
+    include_past = (request.args.get("include_past") or "").strip().lower() == "true"
     query = {"$or": [{"rejected": {"$exists": False}}, {"rejected": False}]}
+    if not include_past:
+        query["date"] = {"$gte": date.today().strftime("%Y-%m-%d")}
     if search_query:
         query["title"] = {"$regex": re.escape(search_query), "$options": "i"}
 
@@ -1635,6 +1653,7 @@ def demo_translation_dashboard():
         demos=demos,
         pending_items=pending_items,
         search_query=search_query,
+        include_past=include_past,
         can_review_demo_translations=_can_review_demo_translations(current_user),
         can_translate_demos=_can_translate_demos(current_user),
         translation_language_names=_translation_language_names(),
@@ -1697,9 +1716,34 @@ def edit_demo_translations(demo_id):
         return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
 
     selected_language = (request.args.get("language") or "").strip()
+    prefill_mode = (request.args.get("prefill") or "").strip().lower()
     supported_locales = _supported_translation_locales(demo_doc)
     if selected_language not in supported_locales and supported_locales:
         selected_language = supported_locales[0]
+
+    deepl_suggestion_payload = (
+        get_cached_deepl_suggestion_for_demo(demo_doc, selected_language)
+        if selected_language
+        else None
+    )
+    deepl_suggestion = (
+        (deepl_suggestion_payload or {}).get("suggestion") or {}
+    )
+    form_seed_translation = (
+        _demo_translation_proposal(demo_doc, selected_language)
+        if selected_language
+        else {}
+    )
+    approved_translation = (
+        _demo_translation_payload(demo_doc, selected_language)
+        if selected_language
+        else {}
+    )
+    if not form_seed_translation:
+        if prefill_mode == "deepl" and deepl_suggestion:
+            form_seed_translation = deepl_suggestion
+        else:
+            form_seed_translation = approved_translation
 
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}demonstrations/translations_editor.html",
@@ -1708,11 +1752,59 @@ def edit_demo_translations(demo_id):
         translation_locales=supported_locales,
         translation_language_names=_translation_language_names(),
         source_language=_demo_source_language(demo_doc),
-        approved_translation=_demo_translation_payload(demo_doc, selected_language) if selected_language else {},
+        approved_translation=approved_translation,
         translation_proposal=_demo_translation_proposal(demo_doc, selected_language) if selected_language else {},
+        deepl_suggestion=deepl_suggestion,
+        deepl_suggestion_payload=deepl_suggestion_payload or {},
+        deepl_prefill_active=bool(prefill_mode == "deepl" and deepl_suggestion),
+        form_seed_translation=form_seed_translation,
+        is_translation_candidate=demo_is_translation_candidate(demo_doc),
         translation_rows=_translation_summary_rows(demo_doc),
         can_review_demo_translations=_can_review_demo_translations(current_user),
         can_translate_demos=_can_translate_demos(current_user),
+    )
+
+
+@admin_demo_bp.route("/<demo_id>/translations/<language>/suggest", methods=["POST"])
+@login_required
+def generate_demo_translation_suggestion(demo_id, language):
+    if not _can_translate_demos(current_user):
+        abort(403)
+
+    demo_doc = mongo.demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not demo_doc:
+        flash_message(_("Mielenosoitusta ei löytynyt."), "error")
+        return redirect(url_for("admin_demo.demo_translation_dashboard"))
+
+    if language not in _supported_translation_locales(demo_doc):
+        flash_message(_("Valittu kieli ei ole sallittu käännöskieli."), "error")
+        return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id))
+
+    result = get_or_create_deepl_suggestions_for_demo(
+        demo_doc,
+        [language],
+        force_refresh=(request.form.get("force_refresh") or "").strip().lower() == "true",
+    )
+
+    if result.get("skipped"):
+        flash_message(
+            _("Automaattisia käännösehdotuksia ei luoda menneille mielenosoituksille oletuksena."),
+            "info",
+        )
+        return redirect(url_for("admin_demo.edit_demo_translations", demo_id=demo_id, language=language))
+
+    if result.get("cached"):
+        flash_message(_("Valmis DeepL-ehdotus löytyi välimuistista."), "success")
+    else:
+        flash_message(_("DeepL-ehdotus luotiin lähdesisällöstä."), "success")
+
+    return redirect(
+        url_for(
+            "admin_demo.edit_demo_translations",
+            demo_id=demo_id,
+            language=language,
+            prefill="deepl",
+        )
     )
 
 

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -80,7 +80,16 @@ def user_control():
     )
 
 
-USER_ACCESS_LEVELS = {"god": 4, "global_admin": 3, "admin": 2, "user": 1}
+USER_ACCESS_LEVELS = {"god": 4, "global_admin": 3, "admin": 2, "translator": 1, "user": 1}
+ROLE_IMPLIED_GLOBAL_PERMISSIONS = {
+    "translator": {"TRANSLATE_DEMO"},
+}
+
+
+def _normalize_role_permissions(role, selected_permissions):
+    permissions = set(selected_permissions or [])
+    permissions.update(ROLE_IMPLIED_GLOBAL_PERMISSIONS.get(role, set()))
+    return sorted(permissions)
 
 
 def compare_user_levels(user1, user2):  # Check if the user1 is higher than user2
@@ -158,8 +167,10 @@ def edit_user(user_id):
             "email":     request.form.get("email", "").strip(),
             "role":      request.form.get("role") or user.role,
             "confirmed": request.form.get("confirmed") == "on",
-            "global_permissions": request.form.getlist("permissions[global][]")
-                                   or current["global_permissions"],
+            "global_permissions": _normalize_role_permissions(
+                request.form.get("role") or user.role,
+                request.form.getlist("permissions[global][]") or current["global_permissions"],
+            ),
         }
 
         # ─── validoinnit ────────────────────────────────────────────────────────
@@ -273,7 +284,7 @@ def save_user(user_id):
     email = request.form.get("email")
     role = request.form.get("role")
     confirmed = request.form.get("confirmed") == "on"
-    global_permissions = request.form.getlist("permissions[global][]")  # ← 🔥 this line
+    global_permissions = _normalize_role_permissions(role, request.form.getlist("permissions[global][]"))
 
     # Prevent role escalation
     if current_user._id == user_id and role != current_user.role:
@@ -304,7 +315,7 @@ def save_user(user_id):
     user.email = email
     user.role = role
     user.confirmed = confirmed
-    user.global_permissions = global_permissions  # ← 🔥 this line
+    user.global_permissions = global_permissions
 
 
     user.save()

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -41,6 +41,7 @@ from mielenosoitukset_fi.utils.analytics import log_demo_view
 from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required, depracated_endpoint
 from mielenosoitukset_fi.utils.screenshot import trigger_screenshot
 from mielenosoitukset_fi.utils.media_helpers import get_demo_cover_image
+from mielenosoitukset_fi.utils.demo_localization import get_demo_localized_fields
 from werkzeug.utils import secure_filename
 from mielenosoitukset_fi.a import generate_demo_sentence
 from pymongo.errors import DuplicateKeyError
@@ -278,6 +279,24 @@ def generate_alternate_urls(app, endpoint, **values):
         with app.test_request_context():
             alternate_urls[lang_code] = url_for(endpoint, lang_code=lang_code, **values)
     return alternate_urls
+
+
+def _current_demo_language():
+    return (session.get("locale") or Config.BABEL_DEFAULT_LOCALE or "fi").strip().lower()
+
+
+def _localized_demo_copy(demo, language=None):
+    if not isinstance(demo, dict):
+        return demo
+
+    localized = copy.deepcopy(demo)
+    localized.update(
+        get_demo_localized_fields(
+            localized,
+            language=language or _current_demo_language(),
+        )
+    )
+    return localized
 
 def format_demo_for_api(demo):
     """
@@ -1827,7 +1846,8 @@ def init_routes(app):
 
         # Prepare response
         _demo = copy.copy(demo_obj)
-        demo = Demonstration.to_dict(demo_obj, True)
+        locale = _current_demo_language()
+        demo = _localized_demo_copy(Demonstration.to_dict(demo_obj, True), locale)
 
         toistuvuus = ""
         if _demo.recurs:
@@ -1888,7 +1908,7 @@ def init_routes(app):
             similar_demos.append(
                 {
                     "id": sid,
-                    "title": doc.get("title"),
+                    "title": get_demo_localized_fields(doc, locale).get("title"),
                     "city": doc.get("city"),
                     "date": doc.get("date"),
                     "formatted_date": formatted_date,
@@ -1921,6 +1941,8 @@ def init_routes(app):
                     {
                         "_id": 1,
                         "title": 1,
+                        "default_language": 1,
+                        "translations": 1,
                         "city": 1,
                         "date": 1,
                         "start_time": 1,
@@ -1954,7 +1976,17 @@ def init_routes(app):
                 org_cursor = (
                     mongo.demonstrations.find(
                         org_query,
-                        {"_id": 1, "title": 1, "city": 1, "date": 1, "start_time": 1, "address": 1, "slug": 1},
+                        {
+                            "_id": 1,
+                            "title": 1,
+                            "default_language": 1,
+                            "translations": 1,
+                            "city": 1,
+                            "date": 1,
+                            "start_time": 1,
+                            "address": 1,
+                            "slug": 1,
+                        },
                     )
                     .sort("date", ASCENDING)
                     .limit(6)
@@ -1985,7 +2017,17 @@ def init_routes(app):
                 rec_cursor = (
                     mongo.demonstrations.find(
                         rec_query,
-                        {"_id": 1, "title": 1, "city": 1, "date": 1, "start_time": 1, "address": 1, "slug": 1},
+                        {
+                            "_id": 1,
+                            "title": 1,
+                            "default_language": 1,
+                            "translations": 1,
+                            "city": 1,
+                            "date": 1,
+                            "start_time": 1,
+                            "address": 1,
+                            "slug": 1,
+                        },
                     )
                     .sort("date", ASCENDING)
                     .limit(6)
@@ -2003,6 +2045,16 @@ def init_routes(app):
             "recurring_following": recurring_following,
         }
 
+        available_demo_languages = []
+        default_demo_language = (demo.get("default_language") or Config.BABEL_DEFAULT_LOCALE or "fi").strip().lower()
+        if default_demo_language:
+            available_demo_languages.append(default_demo_language)
+        for language_code, translation in (demo.get("translations") or {}).items():
+            if translation and any(translation.get(field) not in (None, "", []) for field in ("title", "description", "tags")):
+                normalized = str(language_code).strip().lower()
+                if normalized and normalized not in available_demo_languages:
+                    available_demo_languages.append(normalized)
+
         response = make_response(
             render_template(
                 "detail.html",
@@ -2010,6 +2062,9 @@ def init_routes(app):
                 toistuvuus=toistuvuus,
                 similar_demos=similar_demos,
                 follow_meta=follow_meta,
+                current_demo_language=locale,
+                default_demo_language=default_demo_language,
+                available_demo_languages=available_demo_languages,
             )
         )
         response.headers["X-Cache"] = "MISS"

--- a/mielenosoitukset_fi/templates/admin_V2/_users_table.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_users_table.html
@@ -20,6 +20,8 @@
       <td>
         {% if user.role == 'admin' %}
           <span class="badge bg-warning text-dark">{{ _('Admin') }}</span>
+        {% elif user.role == 'translator' %}
+          <span class="badge bg-info text-dark">{{ _('Kääntäjä') }}</span>
         {% elif user.role == 'global_admin' %}
           <span class="badge bg-danger">{{ _('Superkäyttäjä') }}</span>
         {% else %}

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
@@ -411,6 +411,12 @@
         <i class="fas fa-ban"></i>{{ _('Uusi toistuva mielenosoitus') }}
       </a>
       {% endif %}
+
+      {% if current_user.role in ['admin', 'global_admin', 'translator'] or current_user.has_permission('TRANSLATE_DEMO') or current_user.has_permission('REVIEW_DEMO_TRANSLATIONS') %}
+      <a href="{{ url_for('admin_demo.demo_translation_dashboard') }}" class="btn new-item">
+        <i class="fas fa-language"></i>{{ _('Käännöstyöjono') }}
+      </a>
+      {% endif %}
     </div>
 
 

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/form.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/form.html
@@ -156,6 +156,13 @@
         <p class="text-muted max-w-xl">{{ _('Täältä voit lisätä tai muokata mielenosoituksia helposti.') }}<br>
             {{ _('Muistathan tallentaa tekemäsi muutokset lomakkeen lopussa.') }}
         </p>
+        {% if demo and demo._id %}
+        <p class="mt-3">
+            <a class="btn btn-outline-secondary" href="{{ url_for('admin_demo.edit_demo_translations', demo_id=demo._id) }}">
+                <i class="fas fa-language me-1"></i>{{ _('Avaa käännöstyökalu') }}
+            </a>
+        </p>
+        {% endif %}
     </section>
 
     {% if edit_demo_with_token %}

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_dashboard.html
@@ -34,9 +34,15 @@
   <section class="dashboard-panel">
     <form method="GET" class="mb-4">
       <label for="search" class="form-label">{{ _('Hae mielenosoitusta') }}</label>
-      <div class="d-flex gap-2">
+      <div class="d-flex gap-2 mb-2">
         <input id="search" name="search" class="form-control" value="{{ search_query }}" placeholder="{{ _('Hae otsikolla') }}">
         <button class="btn btn-primary" type="submit">{{ _('Hae') }}</button>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" value="true" id="include_past" name="include_past" {% if include_past %}checked{% endif %}>
+        <label class="form-check-label" for="include_past">
+          {{ _('Näytä myös menneet mielenosoitukset') }}
+        </label>
       </div>
     </form>
 

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_dashboard.html
@@ -1,0 +1,80 @@
+{% extends 'admin_base.html' %}
+
+{% block main_content %}
+<section class="dashboard-container">
+  <div class="introduction">
+    <h1 class="text-3xl font-bold">{{ _('Demojen käännökset') }}</h1>
+    <p class="text-muted max-w-xl">
+      {{ _('Kääntäjät tekevät täällä käännösehdotuksia. Moderaattori tai admin hyväksyy ne ennen julkaisua.') }}
+    </p>
+  </div>
+
+  {% if can_review_demo_translations and pending_items %}
+  <section class="dashboard-panel mb-4">
+    <h2 class="text-xl font-semibold mb-3">{{ _('Odottaa tarkistusta') }}</h2>
+    <div class="list-group">
+      {% for item in pending_items %}
+      <a class="list-group-item list-group-item-action" href="{{ url_for('admin_demo.edit_demo_translations', demo_id=item.demo_id, language=item.language) }}">
+        <div class="d-flex justify-content-between align-items-start gap-3">
+          <div>
+            <strong>{{ item.demo_title }}</strong>
+            <div class="text-muted small">
+              {{ _('Kieli') }}: {{ item.language_label }}
+              {% if item.submitted_by %} · {{ _('Lähettäjä') }}: {{ item.submitted_by }}{% endif %}
+            </div>
+          </div>
+          <span class="badge bg-warning text-dark">{{ _('Odottaa') }}</span>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  <section class="dashboard-panel">
+    <form method="GET" class="mb-4">
+      <label for="search" class="form-label">{{ _('Hae mielenosoitusta') }}</label>
+      <div class="d-flex gap-2">
+        <input id="search" name="search" class="form-control" value="{{ search_query }}" placeholder="{{ _('Hae otsikolla') }}">
+        <button class="btn btn-primary" type="submit">{{ _('Hae') }}</button>
+      </div>
+    </form>
+
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>{{ _('Mielenosoitus') }}</th>
+            <th>{{ _('Lähdekieli') }}</th>
+            <th>{{ _('Tilanne') }}</th>
+            <th>{{ _('Toiminnot') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for demo in demos %}
+          <tr>
+            <td>{{ demo.title or _('Nimetön mielenosoitus') }}</td>
+            <td>{{ translation_language_names.get(demo.default_language or 'fi', demo.default_language or 'fi') }}</td>
+            <td>
+              {% set pending_count = ((demo.translation_proposals or {}).values() | selectattr('status', 'equalto', 'pending') | list | length) %}
+              {% if pending_count %}
+              <span class="badge bg-warning text-dark">{{ pending_count }} {{ _('odottaa') }}</span>
+              {% elif demo.translations %}
+              <span class="badge bg-success">{{ _('Käännöksiä olemassa') }}</span>
+              {% else %}
+              <span class="badge bg-secondary">{{ _('Ei vielä käännöksiä') }}</span>
+              {% endif %}
+            </td>
+            <td>
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_demo.edit_demo_translations', demo_id=demo._id) }}">
+                <i class="fas fa-language me-1"></i>{{ _('Avaa') }}
+              </a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</section>
+{% endblock %}

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_editor.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_editor.html
@@ -1,0 +1,141 @@
+{% extends 'admin_base.html' %}
+
+{% block main_content %}
+<section class="dashboard-container">
+  <div class="introduction">
+    <h1 class="text-3xl font-bold">{{ _('Käännökset') }}: {{ demo.title or _('Nimetön mielenosoitus') }}</h1>
+    <p class="text-muted max-w-xl">
+      {{ _('Tee käännösehdotus valitulle kielelle. Ehdotus ei julkaise sisältöä suoraan, vaan jää tarkistettavaksi.') }}
+    </p>
+    <div class="d-flex gap-2 mt-3">
+      <a class="btn btn-outline-secondary" href="{{ url_for('admin_demo.demo_translation_dashboard') }}">{{ _('Takaisin työjonoon') }}</a>
+      {% if current_user.role in ['admin', 'global_admin'] or current_user.has_permission('EDIT_DEMO') %}
+      <a class="btn btn-outline-secondary" href="{{ url_for('admin_demo.edit_demo', demo_id=demo._id) }}">{{ _('Avaa demo-editori') }}</a>
+      {% endif %}
+    </div>
+  </div>
+
+  <section class="dashboard-panel mb-4">
+    <h2 class="text-xl font-semibold mb-3">{{ _('Käännöstilanne') }}</h2>
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>{{ _('Kieli') }}</th>
+            <th>{{ _('Hyväksytty sisältö') }}</th>
+            <th>{{ _('Ehdotuksen tila') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in translation_rows %}
+          <tr>
+            <td>{{ row.label }}</td>
+            <td>
+              {% if row.approved %}
+              <span class="badge bg-success">{{ _('Hyväksytty') }}</span>
+              {% else %}
+              <span class="badge bg-secondary">{{ _('Ei julkaistua käännöstä') }}</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if row.proposal_status == 'pending' %}
+              <span class="badge bg-warning text-dark">{{ _('Odottaa tarkistusta') }}</span>
+              {% elif row.proposal_status == 'approved' %}
+              <span class="badge bg-success">{{ _('Hyväksytty') }}</span>
+              {% elif row.proposal_status == 'rejected' %}
+              <span class="badge bg-danger">{{ _('Hylätty') }}</span>
+              {% else %}
+              <span class="badge bg-secondary">{{ _('Ei ehdotusta') }}</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="dashboard-panel mb-4">
+    <h2 class="text-xl font-semibold mb-3">{{ _('Lähdesisältö') }}</h2>
+    <p class="text-muted">{{ _('Lähdekieli') }}: {{ translation_language_names.get(source_language, source_language) }}</p>
+    <div class="mb-3">
+      <label class="form-label">{{ _('Otsikko') }}</label>
+      <div class="form-control" readonly>{{ demo.title or '' }}</div>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">{{ _('Kuvaus') }}</label>
+      <div class="form-control" style="min-height: 8rem;" readonly>{{ demo.description or '' }}</div>
+    </div>
+    <div class="mb-0">
+      <label class="form-label">{{ _('Tunnisteet') }}</label>
+      <div class="form-control" readonly>{{ (demo.tags or [])|join(', ') }}</div>
+    </div>
+  </section>
+
+  <section class="dashboard-panel">
+    <h2 class="text-xl font-semibold mb-3">{{ _('Käännösehdotus') }}</h2>
+    {% if translation_locales %}
+    <form method="GET" class="mb-4">
+      <label for="language" class="form-label">{{ _('Kohdekieli') }}</label>
+      <div class="d-flex gap-2">
+        <select id="language" name="language" class="form-control">
+          {% for locale in translation_locales %}
+          <option value="{{ locale }}" {% if locale == selected_language %}selected{% endif %}>{{ translation_language_names.get(locale, locale) }}</option>
+          {% endfor %}
+        </select>
+        <button class="btn btn-outline-primary" type="submit">{{ _('Vaihda kieli') }}</button>
+      </div>
+    </form>
+
+    {% if can_translate_demos and selected_language %}
+    <form method="POST" class="mb-4">
+      <input type="hidden" name="language" value="{{ selected_language }}">
+      <div class="mb-3">
+        <label for="translated_title" class="form-label">{{ _('Käännetty otsikko') }}</label>
+        <input id="translated_title" name="translated_title" class="form-control" value="{{ translation_proposal.title or approved_translation.title or '' }}">
+      </div>
+      <div class="mb-3">
+        <label for="translated_description" class="form-label">{{ _('Käännetty kuvaus') }}</label>
+        <textarea id="translated_description" name="translated_description" class="form-control" rows="8">{{ translation_proposal.description or approved_translation.description or '' }}</textarea>
+      </div>
+      <div class="mb-3">
+        <label for="translated_tags" class="form-label">{{ _('Käännetyt tunnisteet') }}</label>
+        <input id="translated_tags" name="translated_tags" class="form-control" value="{{ (translation_proposal.tags or approved_translation.tags or [])|join(', ') }}">
+        <small class="text-muted">{{ _('Erottele tunnisteet pilkulla.') }}</small>
+      </div>
+      <button class="btn btn-primary" type="submit">{{ _('Lähetä tarkistettavaksi') }}</button>
+    </form>
+    {% endif %}
+
+    {% if translation_proposal %}
+    <div class="border rounded p-3">
+      <h3 class="h5">{{ _('Nykyinen ehdotus') }}</h3>
+      <p class="mb-2"><strong>{{ _('Tila') }}:</strong> {{ translation_proposal.status or _('luonnos') }}</p>
+      {% if translation_proposal.submitted_by_name %}
+      <p class="mb-2"><strong>{{ _('Lähettäjä') }}:</strong> {{ translation_proposal.submitted_by_name }}</p>
+      {% endif %}
+      {% if translation_proposal.review_notes %}
+      <p class="mb-2"><strong>{{ _('Tarkistusmuistiinpanot') }}:</strong> {{ translation_proposal.review_notes }}</p>
+      {% endif %}
+
+      {% if can_review_demo_translations and translation_proposal.status == 'pending' %}
+      <form method="POST" action="{{ url_for('admin_demo.approve_demo_translation', demo_id=demo._id, language=selected_language) }}" class="mb-2">
+        <label for="approve_notes" class="form-label">{{ _('Muistiinpanot hyväksynnälle') }}</label>
+        <textarea id="approve_notes" name="review_notes" class="form-control mb-2" rows="3"></textarea>
+        <button class="btn btn-success" type="submit">{{ _('Hyväksy käännös') }}</button>
+      </form>
+
+      <form method="POST" action="{{ url_for('admin_demo.reject_demo_translation', demo_id=demo._id, language=selected_language) }}">
+        <label for="reject_notes" class="form-label">{{ _('Muistiinpanot hylkäykselle') }}</label>
+        <textarea id="reject_notes" name="review_notes" class="form-control mb-2" rows="3" required></textarea>
+        <button class="btn btn-danger" type="submit">{{ _('Hylkää ehdotus') }}</button>
+      </form>
+      {% endif %}
+    </div>
+    {% endif %}
+    {% else %}
+    <div class="alert alert-info mb-0">{{ _('Tälle mielenosoitukselle ei ole konfiguroitu erillisiä kohdekieliä.') }}</div>
+    {% endif %}
+  </section>
+</section>
+{% endblock %}

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_editor.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/translations_editor.html
@@ -72,6 +72,50 @@
     </div>
   </section>
 
+  <section class="dashboard-panel mb-4">
+    <h2 class="text-xl font-semibold mb-3">{{ _('Automaattinen ehdotus') }}</h2>
+    {% if is_translation_candidate %}
+      <p class="text-muted">
+        {{ _('DeepL voi luoda luonnosehdotuksen tämän demon lähdesisällöstä. Ehdotus ei julkaise mitään suoraan, vaan toimii kääntäjän pohjana.') }}
+      </p>
+      {% if selected_language %}
+      <form method="POST" action="{{ url_for('admin_demo.generate_demo_translation_suggestion', demo_id=demo._id, language=selected_language) }}" class="d-flex gap-2 flex-wrap mb-3">
+        <button class="btn btn-outline-primary" type="submit">
+          <i class="fas fa-wand-magic-sparkles me-1"></i>{{ _('Luo DeepL-ehdotus') }}
+        </button>
+        {% if deepl_suggestion %}
+        <button class="btn btn-outline-secondary" type="submit" name="force_refresh" value="true">
+          {{ _('Päivitä ehdotus lähdesisällöstä') }}
+        </button>
+        {% endif %}
+      </form>
+      {% endif %}
+
+      {% if deepl_suggestion %}
+      <div class="border rounded p-3">
+        <div class="d-flex justify-content-between align-items-start gap-3 mb-2">
+          <div>
+            <h3 class="h5 mb-1">{{ _('Tallennettu DeepL-ehdotus') }}</h3>
+            <div class="text-muted small">
+              {{ _('Tämä ehdotus on generoitu backendissä ja välimuistitetty lähdesisällön nykyiselle versiolle.') }}
+            </div>
+          </div>
+          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_demo.edit_demo_translations', demo_id=demo._id, language=selected_language, prefill='deepl') }}">
+            {{ _('Käytä ehdotusta lomakkeessa') }}
+          </a>
+        </div>
+        <div class="mb-2"><strong>{{ _('Otsikko') }}:</strong> {{ deepl_suggestion.title or '' }}</div>
+        <div class="mb-2"><strong>{{ _('Kuvaus') }}:</strong> {{ deepl_suggestion.description or '' }}</div>
+        <div class="mb-0"><strong>{{ _('Tunnisteet') }}:</strong> {{ (deepl_suggestion.tags or [])|join(', ') }}</div>
+      </div>
+      {% endif %}
+    {% else %}
+      <div class="alert alert-secondary mb-0">
+        {{ _('Menneille mielenosoituksille ei luoda automaattisia käännösehdotuksia oletuksena.') }}
+      </div>
+    {% endif %}
+  </section>
+
   <section class="dashboard-panel">
     <h2 class="text-xl font-semibold mb-3">{{ _('Käännösehdotus') }}</h2>
     {% if translation_locales %}
@@ -90,17 +134,22 @@
     {% if can_translate_demos and selected_language %}
     <form method="POST" class="mb-4">
       <input type="hidden" name="language" value="{{ selected_language }}">
+      {% if deepl_prefill_active and deepl_suggestion %}
+      <input type="hidden" name="suggestion_provider" value="{{ (deepl_suggestion._meta or {}).get('provider', 'deepl') }}">
+      <input type="hidden" name="suggestion_source_hash" value="{{ deepl_suggestion_payload.get('source_hash', '') }}">
+      <input type="hidden" name="suggestion_auto_generated" value="true">
+      {% endif %}
       <div class="mb-3">
         <label for="translated_title" class="form-label">{{ _('Käännetty otsikko') }}</label>
-        <input id="translated_title" name="translated_title" class="form-control" value="{{ translation_proposal.title or approved_translation.title or '' }}">
+        <input id="translated_title" name="translated_title" class="form-control" value="{{ form_seed_translation.title or '' }}">
       </div>
       <div class="mb-3">
         <label for="translated_description" class="form-label">{{ _('Käännetty kuvaus') }}</label>
-        <textarea id="translated_description" name="translated_description" class="form-control" rows="8">{{ translation_proposal.description or approved_translation.description or '' }}</textarea>
+        <textarea id="translated_description" name="translated_description" class="form-control" rows="8">{{ form_seed_translation.description or '' }}</textarea>
       </div>
       <div class="mb-3">
         <label for="translated_tags" class="form-label">{{ _('Käännetyt tunnisteet') }}</label>
-        <input id="translated_tags" name="translated_tags" class="form-control" value="{{ (translation_proposal.tags or approved_translation.tags or [])|join(', ') }}">
+        <input id="translated_tags" name="translated_tags" class="form-control" value="{{ (form_seed_translation.tags or [])|join(', ') }}">
         <small class="text-muted">{{ _('Erottele tunnisteet pilkulla.') }}</small>
       </div>
       <button class="btn btn-primary" type="submit">{{ _('Lähetä tarkistettavaksi') }}</button>
@@ -116,6 +165,9 @@
       {% endif %}
       {% if translation_proposal.review_notes %}
       <p class="mb-2"><strong>{{ _('Tarkistusmuistiinpanot') }}:</strong> {{ translation_proposal.review_notes }}</p>
+      {% endif %}
+      {% if translation_proposal._meta %}
+      <p class="mb-2"><strong>{{ _('Ehdotuksen alkuperä') }}:</strong> {{ translation_proposal._meta.provider or _('manuaalinen') }}</p>
       {% endif %}
 
       {% if can_review_demo_translations and translation_proposal.status == 'pending' %}

--- a/mielenosoitukset_fi/templates/admin_V2/user/edit.html
+++ b/mielenosoitukset_fi/templates/admin_V2/user/edit.html
@@ -164,6 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <label for="role">{{ _('Rooli') }}</label>
             <select id="role" name="role" class="form-control" required>
                 <option value="user" {% if user.role=='user' %}selected{% endif %}>{{ _('Käyttäjä') }}</option>
+                <option value="translator" {% if user.role=='translator' %}selected{% endif %}>{{ _('Kääntäjä') }}</option>
                 <option value="admin" {% if user.role=='admin' %}selected{% endif %}>{{ _('Järjestelmänvalvoja') }}
                 </option>
                 <option value="global_admin" id="role_global_admin" {% if user.role=='global_admin' %}selected{% endif
@@ -173,6 +174,9 @@ document.addEventListener('DOMContentLoaded', () => {
             </select>
             <small class="muted" id="globalAdminNotice">
                 {{ _('Superkäyttäjärooli voidaan valita vain, jos hallitus on antanut hyväksynnän.') }}
+            </small>
+            <small class="muted d-block mt-2">
+                {{ _('Kääntäjärooli lisää automaattisesti oikeuden tehdä käännösehdotuksia, mutta ei julkaista niitä ilman tarkistusta.') }}
             </small>
 <div id="clearanceInfo" style="margin-top:0.5rem; display:none; padding:0.5rem; background-color:var(--input-bg); border-radius:8px;">
     <!-- Filled dynamically by JS -->

--- a/mielenosoitukset_fi/templates/admin_base.html
+++ b/mielenosoitukset_fi/templates/admin_base.html
@@ -299,6 +299,14 @@ function confirmAction(action, taskId) {
         </li>
       {% endif %}
 
+      {% if current_user.role in ['admin', 'global_admin', 'translator'] or current_user.has_permission("TRANSLATE_DEMO") or current_user.has_permission("REVIEW_DEMO_TRANSLATIONS") %}
+        <li class="nav-item">
+          <a class="nav-link admin-sidebar-link" href="{{ url_for('admin_demo.demo_translation_dashboard') }}">
+            <i class="fas fa-language me-2"></i>{{ _('Käännöstyöjono') }}
+          </a>
+        </li>
+      {% endif %}
+
       {% if current_user.has_permission("EDIT_DEMO") %}
         <li class="nav-item">
           <a class="nav-link admin-sidebar-link" href="{{ url_for('admin_demo.suggestions_list') }}">

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -323,6 +323,54 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     margin-bottom: 2rem;
   }
 
+  .demo-language-panel {
+    margin-top: 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 14px;
+    background: light-dark(rgba(255, 255, 255, 0.16), rgba(15, 23, 42, 0.42));
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(10px);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .demo-language-copy {
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 0.95rem;
+    flex: 1 1 260px;
+  }
+
+  .demo-language-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .demo-language-chip {
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border-radius: 999px;
+    padding: 0.5rem 0.9rem;
+    font-weight: 700;
+    font-size: 0.85rem;
+    text-decoration: none;
+    transition: var(--transition);
+  }
+
+  .demo-language-chip:hover {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+  }
+
+  .demo-language-chip.is-active {
+    background: rgba(255, 255, 255, 0.94);
+    color: var(--color-primary);
+    border-color: rgba(255, 255, 255, 0.94);
+  }
+
   /* Gallery */
   .demo-gallery {
     margin-bottom: 3rem;
@@ -1367,6 +1415,26 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
         <i class="fa-solid fa-location-dot"></i>
         {{ demo['address'] }}, {{ demo['city'] }}
       </div>
+      {% if available_demo_languages and available_demo_languages|length > 1 %}
+      <div class="demo-language-panel">
+        <div class="demo-language-copy">
+          {% if current_demo_language == default_demo_language %}
+            {{ _('Näytät tapahtuman oletuskielellä %(language)s.', language=get_lang_name(current_demo_language) or current_demo_language.upper()) }}
+          {% else %}
+            {{ _('Näytät tapahtuman kielellä %(language)s. Oletuskieli on %(default_language)s.', language=get_lang_name(current_demo_language) or current_demo_language.upper(), default_language=get_lang_name(default_demo_language) or default_demo_language.upper()) }}
+          {% endif %}
+        </div>
+        <div class="demo-language-chips" aria-label="{{ _('Saatavilla olevat kielet') }}">
+          {% for language_code in available_demo_languages %}
+          <a href="{{ url_for('set_language', lang=language_code) }}"
+             class="demo-language-chip{% if language_code == current_demo_language %} is-active{% endif %}"
+             {% if language_code == current_demo_language %}aria-current="true"{% endif %}>
+            {{ (get_lang_name(language_code) or language_code)|upper if language_code|length <= 3 else (get_lang_name(language_code) or language_code) }}
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
     </div>
   </section>
 

--- a/mielenosoitukset_fi/utils/classes/Demonstration.py
+++ b/mielenosoitukset_fi/utils/classes/Demonstration.py
@@ -162,6 +162,8 @@ class Demonstration(BaseModel):
         last_modified=None,
         _id: ObjectId = None,
         description: str = None,
+        default_language: str = "fi",
+        translations: dict = None,
         _dont_override: bool = False,
         _rejected: bool = False,
         cover_source: str = None,
@@ -270,6 +272,8 @@ class Demonstration(BaseModel):
 
         self.title = title
         self.description = description
+        self.default_language = (default_language or "fi").strip().lower()
+        self.translations = copy.deepcopy(translations or {})
 
         # Removed direct assignment for date, start_time, end_time
 
@@ -601,6 +605,8 @@ class Demonstration(BaseModel):
         data["merged_into"] = str(self.merged_into) if self.merged_into else None  # Added line
         data["running_number"] = self.running_number
         data["slug"] = self.slug
+        data["default_language"] = self.default_language
+        data["translations"] = copy.deepcopy(self.translations or {})
         # Include last_modified in the dictionary. If JSON output is requested,
         # convert datetimes to ISO strings.
         try:
@@ -800,6 +806,8 @@ class Demonstration(BaseModel):
             # Basic Info
             title=get("title"),
             description=get("description"),
+            default_language=get("default_language", "fi"),
+            translations=get("translations") or {},
             date=get("date"),
             start_time=get("start_time"),
             end_time=get("end_time"),

--- a/mielenosoitukset_fi/utils/data/permission_groups.json
+++ b/mielenosoitukset_fi/utils/data/permission_groups.json
@@ -59,6 +59,14 @@
         {
             "name": "GENERATE_EDIT_LINK",
             "description": "Generate edit link for demo."
+        },
+        {
+            "name": "TRANSLATE_DEMO",
+            "description": "Create translation proposals for demos."
+        },
+        {
+            "name": "REVIEW_DEMO_TRANSLATIONS",
+            "description": "Approve or reject demo translation proposals."
         }
     ],
     "Case Management": [

--- a/mielenosoitukset_fi/utils/demo_localization.py
+++ b/mielenosoitukset_fi/utils/demo_localization.py
@@ -1,0 +1,38 @@
+import copy
+
+
+TRANSLATABLE_DEMO_FIELDS = ("title", "description", "tags")
+
+
+def normalize_demo_language(language: str, default: str = "fi") -> str:
+    normalized = (language or "").strip().lower()
+    fallback = (default or "fi").strip().lower()
+    return normalized or fallback or "fi"
+
+
+def get_demo_localized_value(demo, field: str, language: str = None, fallback: bool = True):
+    if field not in TRANSLATABLE_DEMO_FIELDS:
+        raise ValueError(f"Unsupported translatable field: {field}")
+
+    if not isinstance(demo, dict):
+        raise TypeError("demo must be a dict")
+
+    normalized_language = normalize_demo_language(language, demo.get("default_language", "fi"))
+    translations = demo.get("translations") or {}
+    translated = translations.get(normalized_language, {}).get(field)
+
+    if translated not in (None, "", []):
+        return copy.deepcopy(translated)
+
+    if fallback:
+        return copy.deepcopy(demo.get(field))
+
+    return [] if field == "tags" else None
+
+
+def get_demo_localized_fields(demo, language: str = None, fallback: bool = True):
+    return {
+        "title": get_demo_localized_value(demo, "title", language, fallback=fallback),
+        "description": get_demo_localized_value(demo, "description", language, fallback=fallback),
+        "tags": get_demo_localized_value(demo, "tags", language, fallback=fallback),
+    }

--- a/mielenosoitukset_fi/utils/demo_translation_cache.py
+++ b/mielenosoitukset_fi/utils/demo_translation_cache.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, date
+from typing import Iterable
+
+from bson import ObjectId
+
+from mielenosoitukset_fi.utils.database import get_database_manager
+from mielenosoitukset_fi.utils.demo_translation_suggestions import (
+    build_deepl_translation_suggestions,
+)
+
+
+translation_suggestions_collection = None
+
+
+def _get_translation_suggestions_collection():
+    global translation_suggestions_collection
+    if translation_suggestions_collection is not None:
+        return translation_suggestions_collection
+
+    mongo = get_database_manager()
+    translation_suggestions_collection = mongo["demo_translation_suggestions"]
+
+    try:
+        translation_suggestions_collection.create_index(
+            [("demo_id", 1), ("provider", 1), ("source_hash", 1)],
+            background=True,
+        )
+    except Exception:
+        pass
+
+    return translation_suggestions_collection
+
+
+def _demo_source_payload(demo):
+    if hasattr(demo, "to_dict"):
+        demo = demo.to_dict(json=False)
+
+    if not isinstance(demo, dict):
+        raise TypeError("demo must be a Demonstration instance or a dict")
+
+    return {
+        "title": demo.get("title", ""),
+        "description": demo.get("description", ""),
+        "tags": demo.get("tags") or [],
+    }
+
+
+def _normalize_target_languages(target_languages: Iterable[str], source_language: str):
+    normalized_source = (source_language or "fi").strip().lower()
+    normalized = []
+    for language in target_languages:
+        language_code = (language or "").strip().lower()
+        if not language_code or language_code == normalized_source:
+            continue
+        if language_code not in normalized:
+            normalized.append(language_code)
+    return normalized
+
+
+def _source_hash(source_payload: dict, source_language: str, target_languages: Iterable[str]) -> str:
+    encoded = json.dumps(
+        {
+            "source_language": (source_language or "fi").strip().lower(),
+            "target_languages": list(target_languages),
+            "source_payload": source_payload,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def demo_is_translation_candidate(demo, *, today: date | None = None, include_past: bool = False) -> bool:
+    if hasattr(demo, "to_dict"):
+        demo = demo.to_dict(json=False)
+
+    if not isinstance(demo, dict):
+        raise TypeError("demo must be a Demonstration instance or a dict")
+
+    if include_past:
+        return True
+
+    demo_date = demo.get("date")
+    if not demo_date:
+        return True
+
+    reference_day = today or datetime.utcnow().date()
+    try:
+        parsed = datetime.strptime(str(demo_date), "%Y-%m-%d").date()
+    except ValueError:
+        return True
+
+    return parsed >= reference_day
+
+
+def get_cached_deepl_suggestion_for_demo(demo, target_language: str):
+    if hasattr(demo, "to_dict"):
+        demo_dict = demo.to_dict(json=False)
+    else:
+        demo_dict = dict(demo)
+
+    source_language = (demo_dict.get("default_language") or "fi").strip().lower()
+    normalized_targets = _normalize_target_languages([target_language], source_language)
+    if not normalized_targets:
+        return None
+
+    source_payload = _demo_source_payload(demo_dict)
+    payload_hash = _source_hash(source_payload, source_language, normalized_targets)
+    demo_id = demo_dict.get("_id")
+    demo_id_str = str(demo_id) if demo_id is not None else None
+
+    doc = _get_translation_suggestions_collection().find_one(
+        {
+            "demo_id": demo_id_str,
+            "provider": "deepl",
+            "source_hash": payload_hash,
+        }
+    )
+    if not doc:
+        return None
+
+    return {
+        "cached": True,
+        "provider": "deepl",
+        "source_hash": payload_hash,
+        "suggestion": (doc.get("suggestions") or {}).get(normalized_targets[0]),
+    }
+
+
+def get_or_create_deepl_suggestions_for_demo(
+    demo,
+    target_languages: Iterable[str],
+    *,
+    force_refresh: bool = False,
+    include_past: bool = False,
+):
+    if hasattr(demo, "to_dict"):
+        demo_dict = demo.to_dict(json=False)
+    else:
+        demo_dict = dict(demo)
+
+    if not demo_is_translation_candidate(demo_dict, include_past=include_past):
+        return {
+            "cached": False,
+            "provider": "deepl",
+            "skipped": True,
+            "reason": "past_demo",
+            "suggestions": {},
+        }
+
+    source_language = (demo_dict.get("default_language") or "fi").strip().lower()
+    normalized_targets = _normalize_target_languages(target_languages, source_language)
+    source_payload = _demo_source_payload(demo_dict)
+    payload_hash = _source_hash(source_payload, source_language, normalized_targets)
+    demo_id = demo_dict.get("_id")
+    demo_id_str = str(demo_id) if demo_id is not None else None
+
+    if not force_refresh:
+        existing = _get_translation_suggestions_collection().find_one(
+            {
+                "demo_id": demo_id_str,
+                "provider": "deepl",
+                "source_hash": payload_hash,
+            }
+        )
+        if existing:
+            return {
+                "cached": True,
+                "provider": "deepl",
+                "source_hash": payload_hash,
+                "suggestions": existing.get("suggestions") or {},
+            }
+
+    suggestions = build_deepl_translation_suggestions(
+        source_payload,
+        source_language=source_language,
+        target_languages=normalized_targets,
+    )
+
+    now = datetime.utcnow()
+    _get_translation_suggestions_collection().update_one(
+        {
+            "demo_id": demo_id_str,
+            "provider": "deepl",
+            "source_hash": payload_hash,
+        },
+        {
+            "$set": {
+                "demo_id": demo_id_str,
+                "demo_object_id": ObjectId(demo_id) if isinstance(demo_id, str) and ObjectId.is_valid(demo_id) else demo_id,
+                "provider": "deepl",
+                "source_language": source_language,
+                "target_languages": normalized_targets,
+                "source_hash": payload_hash,
+                "source_payload": source_payload,
+                "suggestions": suggestions,
+                "updated_at": now,
+            },
+            "$setOnInsert": {
+                "created_at": now,
+            },
+        },
+        upsert=True,
+    )
+
+    return {
+        "cached": False,
+        "provider": "deepl",
+        "source_hash": payload_hash,
+        "suggestions": suggestions,
+    }

--- a/mielenosoitukset_fi/utils/demo_translation_suggestions.py
+++ b/mielenosoitukset_fi/utils/demo_translation_suggestions.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import requests
+
+from config import Config
+
+
+DEEPL_DEFAULT_API_URL = "https://api-free.deepl.com/v2/translate"
+TRANSLATABLE_FIELDS = ("title", "description", "tags")
+
+
+def _normalize_locale(locale: str) -> str:
+    return (locale or "").strip().lower()
+
+
+def _deepl_language_code(locale: str) -> str:
+    normalized = _normalize_locale(locale)
+    mapping = {
+        "en": "EN",
+        "fi": "FI",
+        "sv": "SV",
+        "de": "DE",
+        "fr": "FR",
+        "et": "ET",
+    }
+    return mapping.get(normalized, normalized.upper())
+
+
+def _stringify_field_value(field: str, value):
+    if field == "tags":
+        if not value:
+            return ""
+        if isinstance(value, str):
+            return value
+        return ", ".join(str(tag).strip() for tag in value if str(tag).strip())
+    return str(value or "")
+
+
+def _parse_translated_field_value(field: str, value: str):
+    if field == "tags":
+        return [tag.strip() for tag in (value or "").split(",") if tag.strip()]
+    return (value or "").strip()
+
+
+def deepl_is_configured() -> bool:
+    return bool(getattr(Config, "DEEPL_API_KEY", ""))
+
+
+def build_deepl_translation_suggestions(
+    source_fields: Dict[str, object],
+    source_language: str,
+    target_languages: Iterable[str],
+    *,
+    timeout: int = 15,
+) -> Dict[str, dict]:
+    if not deepl_is_configured():
+        raise RuntimeError("DeepL API key is not configured")
+
+    api_url = getattr(Config, "DEEPL_API_URL", "") or DEEPL_DEFAULT_API_URL
+    normalized_source = _normalize_locale(source_language) or "fi"
+    suggestions = {}
+
+    for target_language in target_languages:
+        normalized_target = _normalize_locale(target_language)
+        if not normalized_target or normalized_target == normalized_source:
+            continue
+
+        texts = [
+            _stringify_field_value(field, source_fields.get(field))
+            for field in TRANSLATABLE_FIELDS
+        ]
+        response = requests.post(
+            api_url,
+            data={
+                "auth_key": Config.DEEPL_API_KEY,
+                "source_lang": _deepl_language_code(normalized_source),
+                "target_lang": _deepl_language_code(normalized_target),
+                "text": texts,
+                "tag_handling": "html",
+            },
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json() or {}
+        translated_values = payload.get("translations") or []
+        if len(translated_values) != len(TRANSLATABLE_FIELDS):
+            raise RuntimeError("DeepL returned an unexpected translation payload")
+
+        entry = {}
+        for field, translated in zip(TRANSLATABLE_FIELDS, translated_values):
+            entry[field] = _parse_translated_field_value(
+                field, translated.get("text", "")
+            )
+
+        entry["_meta"] = {
+            "provider": "deepl",
+            "source_language": normalized_source,
+            "target_language": normalized_target,
+            "auto_generated": True,
+        }
+        suggestions[normalized_target] = entry
+
+    return suggestions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,8 @@ ALL_PERMISSIONS = sorted(
         "LIST_USERS",
         "MANAGE_BACKGROUND_JOBS",
         "MANAGE_CLEARANCE",
+        "REVIEW_DEMO_TRANSLATIONS",
+        "TRANSLATE_DEMO",
         "VIEW_ANALYTICS",
         "VIEW_BACKGROUND_JOBS",
         "VIEW_CLEARANCE_AUDIT",
@@ -251,6 +253,7 @@ def _seed_database(app, db):
     user_id = ObjectId()
     friend_id = ObjectId()
     developer_id = ObjectId()
+    translator_id = ObjectId()
     org_id = ObjectId()
     second_org_id = ObjectId()
     demo_id = ObjectId()
@@ -305,13 +308,22 @@ def _seed_database(app, db):
         displayname="Developer User",
         api_tokens_enabled=True,
     )
+    translator_doc = _user_doc(
+        "translator",
+        "translator@example.test",
+        "TranslatorPass1!",
+        _id=translator_id,
+        displayname="Translator User",
+        role="translator",
+        global_permissions=["TRANSLATE_DEMO"],
+    )
 
     friendship = {"user_id": friend_id, "last_updated": now}
     reverse_friendship = {"user_id": user_id, "last_updated": now}
     user_doc["friends"] = [friendship]
     friend_doc["friends"] = [reverse_friendship]
 
-    db.users.insert_many([admin_doc, user_doc, friend_doc, developer_doc])
+    db.users.insert_many([admin_doc, user_doc, friend_doc, developer_doc, translator_doc])
 
     db.memberships.insert_many(
         [
@@ -667,6 +679,7 @@ def _seed_database(app, db):
         "user_id": user_id,
         "friend_id": friend_id,
         "developer_id": developer_id,
+        "translator_id": translator_id,
         "org_id": org_id,
         "demo_id": demo_id,
         "pending_demo_id": pending_demo_id,
@@ -891,6 +904,11 @@ def admin_client(app, seeded_data):
 @pytest.fixture
 def developer_client(app, seeded_data):
     return _client_for_user(app, seeded_data["developer_id"])
+
+
+@pytest.fixture
+def translator_client(app, seeded_data):
+    return _client_for_user(app, seeded_data["translator_id"])
 
 
 @pytest.fixture

--- a/tests/test_admin_user_bp.py
+++ b/tests/test_admin_user_bp.py
@@ -79,3 +79,28 @@ def test_user_control_searches_display_names(admin_client, db, seeded_data):
     body = response.get_data(as_text=True)
     assert "Friendly Admin" in body
     assert "displayname-search-user" in body
+
+
+def test_edit_user_exposes_translator_role_and_auto_assigns_permission(admin_client, db, seeded_data):
+    translator_id = seeded_data["translator_id"]
+
+    response = admin_client.get(f"/admin/user/edit_user/{translator_id}")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert 'value="translator"' in body
+
+    save_response = admin_client.post(
+        f"/admin/user/save_user/{translator_id}",
+        data={
+            "username": "translator",
+            "email": "translator@example.test",
+            "role": "translator",
+            "confirmed": "on",
+        },
+        follow_redirects=False,
+    )
+    assert save_response.status_code == 302
+
+    user_doc = db.users.find_one({"_id": translator_id})
+    assert user_doc["role"] == "translator"
+    assert "TRANSLATE_DEMO" in user_doc.get("global_permissions", [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,11 @@ class ConfigReloadTests(unittest.TestCase):
             self.assertEqual(config_module.Config.S3_SECRET_KEY, "s3-secret")
             self.assertEqual(config_module.Config.PORT, 9001)
             self.assertEqual(config_module.Config.DEFAULT_TIMEZONE, "UTC")
+            self.assertEqual(config_module.Config.DEEPL_API_KEY, "")
+            self.assertEqual(
+                config_module.Config.DEEPL_API_URL,
+                "https://api-free.deepl.com/v2/translate",
+            )
 
     def test_database_manager_reset_clears_singleton(self):
         class FakeManager:

--- a/tests/test_demo_translation_cache.py
+++ b/tests/test_demo_translation_cache.py
@@ -1,0 +1,170 @@
+from bson import ObjectId
+
+
+class _FakeSuggestionsCollection:
+    def __init__(self):
+        self.docs = []
+
+    def find_one(self, query):
+        for doc in self.docs:
+            if all(doc.get(key) == value for key, value in query.items()):
+                return dict(doc)
+        return None
+
+    def update_one(self, query, update, upsert=False):
+        doc = self.find_one(query)
+        if doc is None:
+            doc = dict(query)
+            doc.update(update.get("$setOnInsert", {}))
+            self.docs.append(doc)
+        doc.update(update.get("$set", {}))
+        for index, existing in enumerate(self.docs):
+            if all(existing.get(key) == query.get(key) for key in query):
+                self.docs[index] = doc
+                break
+
+    def create_index(self, *args, **kwargs):
+        return None
+
+
+def test_get_or_create_deepl_suggestions_for_demo_caches_result(monkeypatch):
+    from mielenosoitukset_fi.utils import demo_translation_cache as cache_module
+
+    fake_collection = _FakeSuggestionsCollection()
+    monkeypatch.setattr(
+        cache_module,
+        "translation_suggestions_collection",
+        fake_collection,
+    )
+
+    calls = []
+
+    def fake_builder(source_payload, source_language, target_languages, **kwargs):
+        calls.append((source_payload, source_language, list(target_languages)))
+        return {
+            "en": {
+                "title": "English title",
+                "description": "English description",
+                "tags": ["peace"],
+                "_meta": {
+                    "provider": "deepl",
+                    "source_language": source_language,
+                    "target_language": "en",
+                    "auto_generated": True,
+                },
+            }
+        }
+
+    monkeypatch.setattr(
+        cache_module,
+        "build_deepl_translation_suggestions",
+        fake_builder,
+    )
+
+    demo = {
+        "_id": ObjectId(),
+        "title": "Suomenkielinen otsikko",
+        "description": "Suomenkielinen kuvaus",
+        "tags": ["rauha"],
+        "default_language": "fi",
+    }
+
+    first = cache_module.get_or_create_deepl_suggestions_for_demo(demo, ["en"])
+    second = cache_module.get_or_create_deepl_suggestions_for_demo(demo, ["en"])
+
+    assert first["cached"] is False
+    assert second["cached"] is True
+    assert first["suggestions"]["en"]["title"] == "English title"
+    assert second["suggestions"]["en"]["title"] == "English title"
+    assert len(calls) == 1
+
+
+def test_get_or_create_deepl_suggestions_for_demo_refreshes_when_source_changes(monkeypatch):
+    from mielenosoitukset_fi.utils import demo_translation_cache as cache_module
+
+    fake_collection = _FakeSuggestionsCollection()
+    monkeypatch.setattr(
+        cache_module,
+        "translation_suggestions_collection",
+        fake_collection,
+    )
+
+    counter = {"count": 0}
+
+    def fake_builder(source_payload, source_language, target_languages, **kwargs):
+        counter["count"] += 1
+        return {
+            "en": {
+                "title": f"English title {counter['count']}",
+                "description": "English description",
+                "tags": ["peace"],
+                "_meta": {
+                    "provider": "deepl",
+                    "source_language": source_language,
+                    "target_language": "en",
+                    "auto_generated": True,
+                },
+            }
+        }
+
+    monkeypatch.setattr(
+        cache_module,
+        "build_deepl_translation_suggestions",
+        fake_builder,
+    )
+
+    demo = {
+        "_id": ObjectId(),
+        "title": "Suomenkielinen otsikko",
+        "description": "Suomenkielinen kuvaus",
+        "tags": ["rauha"],
+        "default_language": "fi",
+    }
+
+    first = cache_module.get_or_create_deepl_suggestions_for_demo(demo, ["en"])
+    demo["description"] = "Muuttunut kuvaus"
+    second = cache_module.get_or_create_deepl_suggestions_for_demo(demo, ["en"])
+
+    assert first["source_hash"] != second["source_hash"]
+    assert second["cached"] is False
+    assert second["suggestions"]["en"]["title"] == "English title 2"
+
+
+def test_get_or_create_deepl_suggestions_for_demo_skips_past_demos_by_default(monkeypatch):
+    from mielenosoitukset_fi.utils import demo_translation_cache as cache_module
+
+    fake_collection = _FakeSuggestionsCollection()
+    monkeypatch.setattr(
+        cache_module,
+        "translation_suggestions_collection",
+        fake_collection,
+    )
+
+    calls = []
+
+    def fake_builder(source_payload, source_language, target_languages, **kwargs):
+        calls.append(True)
+        return {}
+
+    monkeypatch.setattr(
+        cache_module,
+        "build_deepl_translation_suggestions",
+        fake_builder,
+    )
+
+    result = cache_module.get_or_create_deepl_suggestions_for_demo(
+        {
+            "_id": ObjectId(),
+            "title": "Vanha demo",
+            "description": "Kuvaus",
+            "tags": ["rauha"],
+            "default_language": "fi",
+            "date": "2020-01-01",
+        },
+        ["en"],
+    )
+
+    assert result["skipped"] is True
+    assert result["reason"] == "past_demo"
+    assert result["suggestions"] == {}
+    assert calls == []

--- a/tests/test_demo_translation_suggestions.py
+++ b/tests/test_demo_translation_suggestions.py
@@ -1,0 +1,71 @@
+from unittest.mock import Mock
+
+import pytest
+
+from config import Config
+from mielenosoitukset_fi.utils.demo_translation_suggestions import (
+    build_deepl_translation_suggestions,
+)
+
+
+def test_build_deepl_translation_suggestions_returns_structured_proposals(monkeypatch):
+    monkeypatch.setattr(Config, "DEEPL_API_KEY", "test-deepl-key")
+    monkeypatch.setattr(
+        Config,
+        "DEEPL_API_URL",
+        "https://api-free.deepl.com/v2/translate",
+    )
+
+    fake_response = Mock()
+    fake_response.json.return_value = {
+        "translations": [
+            {"text": "English title"},
+            {"text": "English description"},
+            {"text": "peace, climate"},
+        ]
+    }
+    fake_response.raise_for_status.return_value = None
+
+    post_mock = Mock(return_value=fake_response)
+    monkeypatch.setattr(
+        "mielenosoitukset_fi.utils.demo_translation_suggestions.requests.post",
+        post_mock,
+    )
+
+    suggestions = build_deepl_translation_suggestions(
+        {
+            "title": "Suomenkielinen otsikko",
+            "description": "Suomenkielinen kuvaus",
+            "tags": ["rauha", "ilmasto"],
+        },
+        source_language="fi",
+        target_languages=["en"],
+    )
+
+    assert suggestions["en"]["title"] == "English title"
+    assert suggestions["en"]["description"] == "English description"
+    assert suggestions["en"]["tags"] == ["peace", "climate"]
+    assert suggestions["en"]["_meta"]["provider"] == "deepl"
+    assert suggestions["en"]["_meta"]["source_language"] == "fi"
+    assert suggestions["en"]["_meta"]["target_language"] == "en"
+
+    post_mock.assert_called_once()
+    payload = post_mock.call_args.kwargs["data"]
+    assert payload["source_lang"] == "FI"
+    assert payload["target_lang"] == "EN"
+    assert payload["text"] == [
+        "Suomenkielinen otsikko",
+        "Suomenkielinen kuvaus",
+        "rauha, ilmasto",
+    ]
+
+
+def test_build_deepl_translation_suggestions_requires_configuration(monkeypatch):
+    monkeypatch.setattr(Config, "DEEPL_API_KEY", "")
+
+    with pytest.raises(RuntimeError, match="DeepL API key is not configured"):
+        build_deepl_translation_suggestions(
+            {"title": "Otsikko", "description": "Kuvaus", "tags": ["rauha"]},
+            source_language="fi",
+            target_languages=["en"],
+        )

--- a/tests/test_demo_translation_workflow.py
+++ b/tests/test_demo_translation_workflow.py
@@ -5,11 +5,106 @@ def test_translator_can_access_translation_dashboard(translator_client):
     assert "Demojen käännökset" in body
 
 
+def test_translation_dashboard_hides_past_demos_by_default(translator_client, db, seeded_data):
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$set": {"date": "2020-01-01", "title": "Past Translation Demo"}},
+    )
+
+    response = translator_client.get("/admin/demo/translations")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Past Translation Demo" not in body
+
+
+def test_translation_dashboard_can_include_past_demos(translator_client, db, seeded_data):
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$set": {"date": "2020-01-01", "title": "Past Translation Demo"}},
+    )
+
+    response = translator_client.get("/admin/demo/translations?include_past=true")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Past Translation Demo" in body
+
+
 def test_translator_can_open_translation_editor(translator_client, seeded_data):
     response = translator_client.get(f"/admin/demo/{seeded_data['demo_id']}/translations?language=en")
     assert response.status_code == 200
     body = response.get_data(as_text=True)
     assert "Käännösehdotus" in body
+
+
+def test_translator_can_generate_cached_deepl_suggestion(translator_client, db, seeded_data, monkeypatch):
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$set": {"date": "2099-05-01"}},
+    )
+
+    from mielenosoitukset_fi.utils import demo_translation_cache as cache_module
+
+    suggestion = {
+        "title": "DeepL English title",
+        "description": "DeepL English description",
+        "tags": ["peace", "climate"],
+        "_meta": {
+            "provider": "deepl",
+            "source_language": "fi",
+            "target_language": "en",
+            "auto_generated": True,
+        },
+    }
+
+    class _FakeSuggestionsCollection:
+        def __init__(self):
+            self.docs = []
+
+        def find_one(self, query):
+            for doc in self.docs:
+                if all(doc.get(key) == value for key, value in query.items()):
+                    return dict(doc)
+            return None
+
+        def update_one(self, query, update, upsert=False):
+            doc = self.find_one(query)
+            if doc is None:
+                doc = dict(query)
+                doc.update(update.get("$setOnInsert", {}))
+                self.docs.append(doc)
+            doc.update(update.get("$set", {}))
+            for index, existing in enumerate(self.docs):
+                if all(existing.get(key) == query.get(key) for key in query):
+                    self.docs[index] = doc
+                    break
+
+        def create_index(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(
+        cache_module,
+        "translation_suggestions_collection",
+        _FakeSuggestionsCollection(),
+    )
+    monkeypatch.setattr(
+        cache_module,
+        "build_deepl_translation_suggestions",
+        lambda source_payload, source_language, target_languages, **kwargs: {
+            "en": suggestion
+        },
+    )
+
+    response = translator_client.post(
+        f"/admin/demo/{seeded_data['demo_id']}/translations/en/suggest",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "DeepL English title" in body
+    assert "Käytä ehdotusta lomakkeessa" in body
 
 
 def test_translator_can_submit_demo_translation_proposal(translator_client, db, seeded_data):
@@ -35,6 +130,32 @@ def test_translator_can_submit_demo_translation_proposal(translator_client, db, 
     assert proposal["description"] == "An English translation proposal."
     assert proposal["tags"] == ["climate", "march"]
     assert proposal["submitted_by"] == str(seeded_data["translator_id"])
+
+
+def test_translator_proposal_can_record_deepl_provenance(translator_client, db, seeded_data):
+    demo_id = seeded_data["demo_id"]
+
+    response = translator_client.post(
+        f"/admin/demo/{demo_id}/translations",
+        data={
+            "language": "en",
+            "translated_title": "Climate March Helsinki in English",
+            "translated_description": "An English translation proposal.",
+            "translated_tags": "climate, march",
+            "suggestion_provider": "deepl",
+            "suggestion_source_hash": "abc123",
+            "suggestion_auto_generated": "true",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    demo_doc = db.demonstrations.find_one({"_id": demo_id})
+    proposal = demo_doc["translation_proposals"]["en"]
+    assert proposal["_meta"]["provider"] == "deepl"
+    assert proposal["_meta"]["source_hash"] == "abc123"
+    assert proposal["_meta"]["auto_generated"] is True
 
 
 def test_admin_can_approve_demo_translation_proposal(admin_client, db, seeded_data):

--- a/tests/test_demo_translation_workflow.py
+++ b/tests/test_demo_translation_workflow.py
@@ -1,0 +1,75 @@
+def test_translator_can_access_translation_dashboard(translator_client):
+    response = translator_client.get("/admin/demo/translations")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Demojen käännökset" in body
+
+
+def test_translator_can_open_translation_editor(translator_client, seeded_data):
+    response = translator_client.get(f"/admin/demo/{seeded_data['demo_id']}/translations?language=en")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "Käännösehdotus" in body
+
+
+def test_translator_can_submit_demo_translation_proposal(translator_client, db, seeded_data):
+    demo_id = seeded_data["demo_id"]
+
+    response = translator_client.post(
+        f"/admin/demo/{demo_id}/translations",
+        data={
+            "language": "en",
+            "translated_title": "Climate March Helsinki in English",
+            "translated_description": "An English translation proposal.",
+            "translated_tags": "climate, march",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    demo_doc = db.demonstrations.find_one({"_id": demo_id})
+    proposal = demo_doc["translation_proposals"]["en"]
+    assert proposal["status"] == "pending"
+    assert proposal["title"] == "Climate March Helsinki in English"
+    assert proposal["description"] == "An English translation proposal."
+    assert proposal["tags"] == ["climate", "march"]
+    assert proposal["submitted_by"] == str(seeded_data["translator_id"])
+
+
+def test_admin_can_approve_demo_translation_proposal(admin_client, db, seeded_data):
+    demo_id = seeded_data["demo_id"]
+    db.demonstrations.update_one(
+        {"_id": demo_id},
+        {
+            "$set": {
+                "translation_proposals.en": {
+                    "language": "en",
+                    "title": "Climate March Helsinki in English",
+                    "description": "Approved English translation.",
+                    "tags": ["climate", "march"],
+                    "status": "pending",
+                    "submitted_by": str(seeded_data["translator_id"]),
+                    "submitted_by_name": "Translator User",
+                }
+            }
+        },
+    )
+
+    response = admin_client.post(
+        f"/admin/demo/{demo_id}/translations/en/approve",
+        data={"review_notes": "Looks good."},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+
+    demo_doc = db.demonstrations.find_one({"_id": demo_id})
+    assert demo_doc["translations"]["en"]["title"] == "Climate March Helsinki in English"
+    assert demo_doc["translation_proposals"]["en"]["status"] == "approved"
+    assert demo_doc["translation_proposals"]["en"]["review_notes"] == "Looks good."
+
+
+def test_regular_user_cannot_access_translation_dashboard(user_client):
+    response = user_client.get("/admin/demo/translations")
+    assert response.status_code == 403

--- a/tests/test_public_demo_localization.py
+++ b/tests/test_public_demo_localization.py
@@ -1,0 +1,34 @@
+def _set_client_locale(client, locale):
+    with client.session_transaction() as session:
+        session["locale"] = locale
+
+
+def test_demo_detail_renders_translated_fields_and_language_switcher(client, db, seeded_data):
+    demo_id = seeded_data["demo_id"]
+    db.demonstrations.update_one(
+        {"_id": demo_id},
+        {
+            "$set": {
+                "date": "2026-05-20",
+                "default_language": "fi",
+                "translations": {
+                    "en": {
+                        "title": "English Climate March",
+                        "description": "English description for the seeded demonstration.",
+                        "tags": ["peace", "climate"],
+                    }
+                },
+            }
+        },
+    )
+    _set_client_locale(client, "en")
+
+    response = client.get(f"/demonstration/{demo_id}")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "English Climate March" in body
+    assert "English description for the seeded demonstration." in body
+    assert "Climate March Helsinki" not in body
+    assert "/set_language/fi" in body
+    assert "/set_language/en" in body


### PR DESCRIPTION
## Summary
- add a dedicated `translator` role with implied `TRANSLATE_DEMO` permission
- add a translation queue and per-demo translation editor for translation proposals
- add admin review actions to approve or reject demo translation proposals before publication

## Details
This first slice keeps translators out of the full demo editor and routes them through a narrower workflow:
- `/admin/demo/translations`
- `/admin/demo/<demo_id>/translations`

Translation proposals are stored separately from approved translations so review can happen before anything is published. Admins can approve or reject pending proposals with review notes.

This PR also adds a short handoff doc at `docs/translator_review_workflow.md` for the next slices.

## Testing
- `python -m pytest -q tests/test_admin_user_bp.py tests/test_demo_translation_workflow.py --maxfail=1`
- `python -m py_compile mielenosoitukset_fi/admin/admin_user_bp.py mielenosoitukset_fi/admin/admin_demo_bp.py tests/conftest.py tests/test_admin_user_bp.py tests/test_demo_translation_workflow.py`
- `git diff --check`
