### PR TITLE
Add repo-managed agent workflow hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.
+* Repository now includes versioned agent workflow hooks, branch handoff scaffolding, and a documented operating model so long-running AI/human work stays organized across branches and resumable sessions.
 * Added `scripts/setup_preview_environment.sh` so preview repository variables and secrets can be printed or written through `gh` after the preview server is provisioned.
 * Added automated PR preview environments that build same-repository branches in isolated Docker containers on a dedicated preview server, post a sticky preview URL comment on the PR, and tear the preview down when the PR closes.
 * Preview Caddy snippets now use per-PR matcher names, so multiple active previews no longer collide when Caddy reloads the imported routes.

--- a/docs/agent_operating_model.md
+++ b/docs/agent_operating_model.md
@@ -1,0 +1,75 @@
+# Agent Operating Model
+
+This repository uses a simple operating model so long-running work stays organized across branches, PRs, and agent sessions.
+
+## Goals
+
+- Keep branch context easy to resume.
+- Prevent user-facing changes from bypassing `CHANGELOG.md`.
+- Make handoff notes first-class project artifacts instead of scattered chat history.
+- Keep hooks lightweight enough that they help without blocking normal work unnecessarily.
+
+## Required Branch Ritual
+
+For every active work branch:
+
+1. Keep a handoff note in `docs/handoffs/`.
+2. Update `CHANGELOG.md` for user-facing changes.
+3. Leave the branch in a state where the next person can answer:
+   - what changed
+   - what is still broken
+   - what should happen next
+
+## Handoff Files
+
+Branch handoff files live in:
+
+- `docs/handoffs/<branch-name>.md`
+
+Branch names are sanitized for filesystem safety:
+
+- `/` becomes `__`
+
+Example:
+
+- branch `feature/my-work`
+- file `docs/handoffs/feature__my-work.md`
+
+Each handoff should contain at least:
+
+- current scope
+- current state
+- validation run
+- open issues / blockers
+- next steps
+
+## Hooks
+
+This repo ships versioned hooks in `hooks/`.
+
+- `pre-commit`
+  - ensures a branch handoff file exists
+  - blocks commits that change user-facing code without touching `CHANGELOG.md`
+- `pre-push`
+  - ensures a branch handoff file exists before pushing
+  - prints the handoff file path so the pusher sees the expected resume note
+
+Hooks are installed with:
+
+```bash
+./scripts/install_agent_hooks.sh
+```
+
+## Local Memory
+
+Project-specific Codex memory is stored outside the repo in:
+
+- `~/.codex/memories/mielenosoitukset_fi_workflow.md`
+
+That memory is intentionally high-level:
+
+- workflow conventions
+- branch hygiene
+- where durable handoff notes live
+
+The repo remains the source of truth for branch-specific status.

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,37 @@
+# Handoffs
+
+Keep one resumable handoff note per active branch.
+
+## Naming
+
+Use the current branch name, with `/` replaced by `__`.
+
+Examples:
+
+- `main` -> `docs/handoffs/main.md`
+- `feature/foo` -> `docs/handoffs/feature__foo.md`
+
+## Minimum Structure
+
+```md
+# Branch Handoff: <branch>
+
+## Scope
+
+## Current State
+
+## Validation
+
+## Open Issues
+
+## Next Steps
+```
+
+## Purpose
+
+These files are meant to answer, quickly:
+
+- what this branch is for
+- what already changed
+- what is risky or unfinished
+- what the next person should do next

--- a/docs/handoffs/chore-agent-workflow-hooks.md
+++ b/docs/handoffs/chore-agent-workflow-hooks.md
@@ -1,0 +1,33 @@
+# Branch Handoff: chore-agent-workflow-hooks
+
+## Scope
+
+- Add a lightweight but enforceable workflow for long-running AI/human collaboration.
+- Version hooks in the repository instead of relying on ad hoc local git hook state.
+- Keep branch handoffs durable and reviewable.
+
+## Current State
+
+- Added a documented operating model in `docs/agent_operating_model.md`.
+- Added `docs/handoffs/README.md` plus branch-scoped handoff generation.
+- Added versioned `pre-commit` and `pre-push` hooks in `hooks/`.
+- Added helper scripts to create/check handoffs and install the repo hooks.
+
+## Validation
+
+- `bash -n scripts/ensure_agent_handoff.sh scripts/install_agent_hooks.sh hooks/pre-commit hooks/pre-push`
+- `git diff --check`
+
+## Open Issues
+
+- Hooks are versioned in the repo, but each clone still needs `./scripts/install_agent_hooks.sh` once to activate them.
+- The project-level Codex memory file is intentionally local and not part of this PR.
+
+## Next Steps
+
+- Push this branch and open a small infra PR.
+- Merge it once reviewed so future work branches inherit the repo-managed workflow.
+
+## Updated
+
+- 2026-05-12

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+./scripts/ensure_agent_handoff.sh --check
+
+staged_files="$(git diff --cached --name-only)"
+[ -z "$staged_files" ] && exit 0
+
+if ! printf '%s\n' "$staged_files" | grep -q '^CHANGELOG\.md$'; then
+  if printf '%s\n' "$staged_files" | grep -Eq '^(mielenosoitukset_fi/|templates/|static/|config\.py|docs/.*|tests/)'; then
+    printf 'User-facing or behavioral changes detected without CHANGELOG.md staged.\n' >&2
+    exit 1
+  fi
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+./scripts/ensure_agent_handoff.sh --check
+printf 'Handoff note: %s\n' "$(./scripts/ensure_agent_handoff.sh --path)"

--- a/scripts/ensure_agent_handoff.sh
+++ b/scripts/ensure_agent_handoff.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:---check}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+safe_branch="${branch//\//__}"
+handoff_path="docs/handoffs/${safe_branch}.md"
+today="$(date +%F)"
+
+create_template() {
+  mkdir -p "$(dirname "$handoff_path")"
+  cat >"$handoff_path" <<EOF
+# Branch Handoff: ${branch}
+
+## Scope
+
+- Describe the branch goal here.
+
+## Current State
+
+- Summarize the implemented work.
+
+## Validation
+
+- List the latest checks run here.
+
+## Open Issues
+
+- Note blockers, caveats, or review concerns.
+
+## Next Steps
+
+- Write the next concrete actions here.
+
+## Updated
+
+- ${today}
+EOF
+}
+
+case "$MODE" in
+  --create)
+    if [ ! -f "$handoff_path" ]; then
+      create_template
+      printf 'Created %s\n' "$handoff_path"
+    else
+      printf '%s\n' "$handoff_path"
+    fi
+    ;;
+  --path)
+    printf '%s\n' "$handoff_path"
+    ;;
+  --check)
+    if [ ! -f "$handoff_path" ]; then
+      printf 'Missing branch handoff: %s\n' "$handoff_path" >&2
+      printf 'Run ./scripts/ensure_agent_handoff.sh --create\n' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    printf 'Unknown mode: %s\n' "$MODE" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/install_agent_hooks.sh
+++ b/scripts/install_agent_hooks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath hooks
+./scripts/ensure_agent_handoff.sh --create >/dev/null
+
+printf 'Installed repo hooks from %s/hooks\n' "$repo_root"
+printf 'Current branch handoff: %s\n' "$(./scripts/ensure_agent_handoff.sh --path)"


### PR DESCRIPTION
## Summary
- add a documented operating model for long-running agent/human work in this repository
- version lightweight pre-commit and pre-push hooks in-repo and install them via a helper script
- add branch-scoped handoff scaffolding so active work stays resumable across sessions

## Testing
- 
- 

## Notes
- each clone still needs Installed repo hooks from /tmp/agent-workflow-finish/hooks
Current branch handoff: docs/handoffs/chore-agent-workflow-hooks.md once to activate the versioned hooks
- the Codex local memory file remains local-only and is not part of this PR