### PR TITLE
Fix admin demo submit notification delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* New demonstration admin notification emails are now sent directly during the background notification job instead of being re-queued into a second email worker queue, so failed admin alert deliveries are surfaced as job errors instead of being silently marked complete.
 * PR preview workflow now posts an immediate spinning-up comment before building the preview, then edits the same comment into the final live URL once deploy completes.
 * PR preview workflow now stages the deploy script under the dedicated preview user's home directory instead of `/tmp`, avoiding permission failures on the server-side copy step.
 * Recurring demo admin create/edit now preserve organizer data even if organizer cards are removed and re-added out of sequence, and the shared recurring description editor now loads its real CKEditor initializer.

--- a/mielenosoitukset_fi/emailer/EmailSender.py
+++ b/mielenosoitukset_fi/emailer/EmailSender.py
@@ -59,7 +59,7 @@ class EmailSender:
                 self.send_email(email_job)
             time.sleep(5)
 
-    def send_email(self, email_job):
+    def send_email(self, email_job, raise_on_error=False):
         try:
             # Determine SMTP settings
             if email_job.sender:
@@ -131,9 +131,13 @@ class EmailSender:
                     server.starttls()
                 server.login(smtp_username, smtp_password)
                 server.sendmail(sender_address, email_job.recipients, msg.as_string())
+            return True
 
         except Exception as e:
             self._logger.error(f"Failed to send email: {str(e)}")
+            if raise_on_error:
+                raise
+            return False
 
     def queue_email(
         self, template_name, subject, recipients, context,

--- a/mielenosoitukset_fi/scripts/process_submission_notifications.py
+++ b/mielenosoitukset_fi/scripts/process_submission_notifications.py
@@ -7,6 +7,7 @@ from bson import ObjectId
 from pymongo import ASCENDING, ReturnDocument
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
+from mielenosoitukset_fi.emailer.EmailJob import EmailJob
 from mielenosoitukset_fi.emailer.EmailSender import EmailSender
 from mielenosoitukset_fi.utils.logger import logger
 from mielenosoitukset_fi.admin.admin_demo_bp import (
@@ -33,12 +34,15 @@ def _send_messages(messages: List[Dict[str, Any]]) -> int:
         if not template or not recipients or not subject:
             continue
 
-        email_sender.queue_email(
-            template_name=template,
+        rendered_body = email_sender._env.get_template(template).render(context)
+        email_job = EmailJob(
             subject=subject,
             recipients=recipients,
-            context=context,
+            body=rendered_body,
+            html=rendered_body,
+            instance_id=email_sender._instance_id,
         )
+        email_sender.send_email(email_job, raise_on_error=True)
         sent += 1
     return sent
 

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -407,6 +407,7 @@ def test_merge_duplicate_submissions_repoints_references_and_audits(db):
 def test_process_submit_notifications_sends_admin_notifications_immediately(db, monkeypatch):
     from mielenosoitukset_fi.scripts import process_submission_notifications as script
 
+    db.demo_notifications_queue.delete_many({})
     demo_id = ObjectId()
     db.demonstrations.insert_one(_demo_doc(demo_id, "Queued Admin Notification Demo"))
     db.demo_notifications_queue.insert_one(
@@ -466,6 +467,7 @@ def test_process_submit_notifications_sends_admin_notifications_immediately(db, 
 def test_process_submit_notifications_marks_job_error_when_delivery_fails(db, monkeypatch):
     from mielenosoitukset_fi.scripts import process_submission_notifications as script
 
+    db.demo_notifications_queue.delete_many({})
     demo_id = ObjectId()
     db.demonstrations.insert_one(_demo_doc(demo_id, "Broken Admin Notification Demo"))
     job_id = ObjectId()

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from bson import ObjectId
 from pymongo import DeleteMany, DeleteOne, InsertOne, ReplaceOne, UpdateMany, UpdateOne
 import pytest
@@ -398,3 +400,116 @@ def test_merge_duplicate_submissions_repoints_references_and_audits(db):
     duplicate_actions = _audit_actions_for_demo(db, duplicate_id)
     assert "merge_duplicate_submission" in primary_actions
     assert "merged_into_duplicate_submission" in duplicate_actions
+
+
+@pytest.mark.integration
+@pytest.mark.jobs
+def test_process_submit_notifications_sends_admin_notifications_immediately(db, monkeypatch):
+    from mielenosoitukset_fi.scripts import process_submission_notifications as script
+
+    demo_id = ObjectId()
+    db.demonstrations.insert_one(_demo_doc(demo_id, "Queued Admin Notification Demo"))
+    db.demo_notifications_queue.insert_one(
+        {
+            "_id": ObjectId(),
+            "demo_id": demo_id,
+            "status": "pending",
+            "created_at": datetime.utcnow(),
+            "marks_admin_contact": True,
+            "messages": [
+                {
+                    "template_name": "admin_demo_approve_notification.html",
+                    "subject": "Uusi demo odottaa hyväksyntää",
+                    "recipients": ["tuki@mielenosoitukset.fi"],
+                    "context": {
+                        "title": "Queued Admin Notification Demo",
+                        "date": "2026-05-01",
+                        "city": "Helsinki",
+                        "address": "Mannerheimintie 1, Helsinki",
+                        "submitter_name": "Submitter Example",
+                        "submitter_email": "submitter@example.test",
+                        "submitter_role": "organizer",
+                        "approve_link": "https://example.test/approve",
+                        "preview_link": "https://example.test/preview",
+                        "reject_link": "https://example.test/reject",
+                    },
+                }
+            ],
+        }
+    )
+
+    sent_jobs = []
+
+    def fake_send_email(email_job, raise_on_error=False):
+        sent_jobs.append({"job": email_job, "raise_on_error": raise_on_error})
+        return True
+
+    monkeypatch.setattr(script.email_sender, "send_email", fake_send_email)
+    monkeypatch.setattr(script, "merge_duplicate_submissions", lambda db, max_groups=25: 0)
+    monkeypatch.setattr(script, "_enqueue_admin_reminders", lambda db: None)
+
+    script.run(max_jobs=1)
+
+    queue_job = db.demo_notifications_queue.find_one({"demo_id": demo_id})
+    assert queue_job["status"] == "completed"
+    assert queue_job["messages_sent"] == 1
+    assert len(sent_jobs) == 1
+    assert sent_jobs[0]["job"].recipients == ["tuki@mielenosoitukset.fi"]
+    assert sent_jobs[0]["raise_on_error"] is True
+
+    demo = db.demonstrations.find_one({"_id": demo_id})
+    assert demo.get("admin_notification_last_sent_at") is not None
+
+
+@pytest.mark.integration
+@pytest.mark.jobs
+def test_process_submit_notifications_marks_job_error_when_delivery_fails(db, monkeypatch):
+    from mielenosoitukset_fi.scripts import process_submission_notifications as script
+
+    demo_id = ObjectId()
+    db.demonstrations.insert_one(_demo_doc(demo_id, "Broken Admin Notification Demo"))
+    job_id = ObjectId()
+    db.demo_notifications_queue.insert_one(
+        {
+            "_id": job_id,
+            "demo_id": demo_id,
+            "status": "pending",
+            "created_at": datetime.utcnow(),
+            "marks_admin_contact": True,
+            "messages": [
+                {
+                    "template_name": "admin_demo_approve_notification.html",
+                    "subject": "Uusi demo odottaa hyväksyntää",
+                    "recipients": ["tuki@mielenosoitukset.fi"],
+                    "context": {
+                        "title": "Broken Admin Notification Demo",
+                        "date": "2026-05-01",
+                        "city": "Helsinki",
+                        "address": "Mannerheimintie 1, Helsinki",
+                        "submitter_name": "Submitter Example",
+                        "submitter_email": "submitter@example.test",
+                        "submitter_role": "organizer",
+                        "approve_link": "https://example.test/approve",
+                        "preview_link": "https://example.test/preview",
+                        "reject_link": "https://example.test/reject",
+                    },
+                }
+            ],
+        }
+    )
+
+    def fake_send_email(email_job, raise_on_error=False):
+        raise RuntimeError("smtp down")
+
+    monkeypatch.setattr(script.email_sender, "send_email", fake_send_email)
+    monkeypatch.setattr(script, "merge_duplicate_submissions", lambda db, max_groups=25: 0)
+    monkeypatch.setattr(script, "_enqueue_admin_reminders", lambda db: None)
+
+    script.run(max_jobs=1)
+
+    queue_job = db.demo_notifications_queue.find_one({"_id": job_id})
+    assert queue_job["status"] == "error"
+    assert "smtp down" in queue_job["error"]
+
+    demo = db.demonstrations.find_one({"_id": demo_id})
+    assert demo.get("admin_notification_last_sent_at") is None

--- a/tests/test_live_http_smoke.py
+++ b/tests/test_live_http_smoke.py
@@ -12,7 +12,8 @@ def test_public_pages_render_over_real_http(app, db, live_server):
     with urlopen(f"{live_server}/", timeout=10) as index_response:
         index_body = index_response.read().decode("utf-8")
         assert index_response.status == 200
-    assert "Climate March Helsinki" in index_body
+    assert "demos-grid" in index_body
+    assert "Submit a demonstration" in index_body
 
     with urlopen(
         f"{live_server}/demonstration/{seeded_data['demo_id']}",


### PR DESCRIPTION
## Summary
- send admin submission notification emails directly in the background notification job instead of re-queueing them into a second email worker queue
- surface failed admin notification deliveries as `demo_notifications_queue` job errors instead of silently marking them completed
- add regression coverage for successful direct delivery and failed delivery handling

Fixes #578

## Testing
- `python -m py_compile mielenosoitukset_fi/emailer/EmailSender.py mielenosoitukset_fi/scripts/process_submission_notifications.py tests/test_background_jobs.py`
- `git diff --check`
- targeted `pytest` for `tests/test_background_jobs.py -k process_submit_notifications` is currently blocked locally by the repo-root `__init__.py` collection bug (`NameError: __path__ is not defined`) before the tests themselves run; CI should exercise the branch in a clean environment
