### PR TITLE
Add token-protected admin MCP foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.
 * Admin MCP now also accepts the repository's existing API tokens directly, so the easiest supported login path is to create a normal user/app API token and pass it to OpenAI as the MCP bearer token.
+* Admin MCP now exposes OAuth discovery, dynamic client registration, an admin consent screen, and PKCE-backed authorization-code token exchange, so ChatGPT developer mode can connect with the OpenAI-supported OAuth login flow instead of requiring only manual bearer token provisioning.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.
+* Admin MCP now also accepts the repository's existing API tokens directly, so the easiest supported login path is to create a normal user/app API token and pass it to OpenAI as the MCP bearer token.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## UNRELEASED
 
 ### Added
+* Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
+* Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 * Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
+* Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.
 * Public demo submission now asks for explicit confirmation when a possible duplicate is detected, instead of silently retrying the submission and making successful sends look broken.
 * Public demo submission duplicate warnings are now less trigger-happy on weak title similarity, so real users are less likely to get blocked by false duplicate alarms.
 * `/ohjeet/` now includes clearer submission troubleshooting advice, including when to retry and what details to send to support, and the public submit form now links directly to that help.

--- a/config.py
+++ b/config.py
@@ -134,6 +134,7 @@ class Config:
         cls.ENFORCE_RATELIMIT = config.get("ENFORCE_RATELIMIT", True)
 
         cls.ADMIN_EMAIL = config.get("ADMIN_EMAIL", "itc@luova.club")
+        cls.ADMIN_MCP = config.get("ADMIN_MCP", {})
 
         cls.CACHE_TYPE = config.get("CACHE_TYPE", "SimpleCache")
         cls.CACHE_DEFAULT_TIMEOUT = config.get("CACHE_DEFAULT_TIMEOUT", 300)

--- a/docs/admin_mcp.md
+++ b/docs/admin_mcp.md
@@ -1,6 +1,6 @@
 # Admin MCP
 
-This repository now includes a token-protected MCP-compatible admin endpoint at:
+This repository now includes an MCP-compatible admin endpoint at:
 
 - `POST /api/admin/mcp`
 
@@ -22,7 +22,18 @@ ADMIN_MCP:
     REQUIRED_SCOPES: ["mcp.admin"]
 ```
 
-This is the recommended mode for OpenAI-compatible remote MCP authentication: OpenAI can pass your OAuth access token to the MCP server as a bearer token, and the server validates the JWT claims locally.
+By default, once `ADMIN_MCP.ENABLED` is on, the server now exposes a full OAuth authorization-code flow for ChatGPT / remote MCP clients:
+
+- `GET /.well-known/oauth-authorization-server`
+- `GET /.well-known/openid-configuration`
+- `GET /.well-known/oauth-protected-resource/api/admin/mcp`
+- `POST /api/admin/mcp/oauth/register`
+- `GET|POST /api/admin/mcp/oauth/authorize`
+- `POST /api/admin/mcp/oauth/token`
+
+ChatGPT developer mode can use these endpoints directly with dynamic client registration, consent, and PKCE.
+
+If you already have your own issuer, you can still configure the JWT validation fields above so MCP accepts externally issued bearer tokens too.
 
 ## Easiest login path right now
 
@@ -78,6 +89,19 @@ Then send the token as:
 ```http
 Authorization: Bearer <your-token>
 ```
+
+## ChatGPT OAuth flow
+
+For the easiest ChatGPT setup:
+
+1. Turn on developer mode in ChatGPT.
+2. Add your MCP server URL:
+   - `https://your-host/api/admin/mcp`
+3. Pick `OAuth` authentication.
+4. Leave static client credentials empty and let ChatGPT use dynamic client registration.
+5. ChatGPT will register a public OAuth client, send the user to `/api/admin/mcp/oauth/authorize`, and exchange the resulting authorization code at `/api/admin/mcp/oauth/token`.
+
+The consent screen requires a logged-in admin-capable account (`global_admin`, `admin`, `superuser`, or `god`), so regular users cannot grant MCP admin access.
 
 ## Supported MCP methods
 
@@ -135,13 +159,8 @@ It does not yet expose every admin-dashboard action. The intended next expansion
 - translator/admin review workflows
 - audit log reads and selected write actions
 
-## Important limitation
+## Current limitations
 
-This foundation implements the **resource server** side of OAuth bearer-token validation. It does **not** yet implement a full authorization server, consent UI, or dynamic client registration flow by itself.
-
-That means:
-
-- it is ready to accept OAuth access tokens issued by your auth system
-- it is ready to accept this repo's existing API tokens directly
-- it is compatible with the OpenAI-side bearer-token pattern
-- but a complete end-user "Sign in with OpenAI/ChatGPT connector" flow still requires the surrounding OAuth issuer setup
+- Dynamic client registration is implemented, but CIMD is not advertised.
+- OAuth access tokens are short-lived bearer JWTs intended for MCP use; refresh tokens are not issued yet.
+- The first tool slice still covers only demonstrations, organizations, and support/admin cases, not the full admin dashboard surface.

--- a/docs/admin_mcp.md
+++ b/docs/admin_mcp.md
@@ -13,13 +13,29 @@ Admin MCP is disabled by default. Enable it in `config.yaml`:
 ```yaml
 ADMIN_MCP:
   ENABLED: true
+  OAUTH:
+    ENABLED: true
+    ISSUER: "https://auth.example.test"
+    AUDIENCE: "mielenosoitukset-admin-mcp"
+    JWT_ALGORITHMS: ["HS256"]
+    JWT_SHARED_SECRET: "replace-with-oauth-resource-secret"
+    REQUIRED_SCOPES: ["mcp.admin"]
+```
+
+This is the recommended mode for OpenAI-compatible remote MCP authentication: OpenAI can pass your OAuth access token to the MCP server as a bearer token, and the server validates the JWT claims locally.
+
+For bootstrap or private local use, the legacy static-token mode is still supported:
+
+```yaml
+ADMIN_MCP:
+  ENABLED: true
   TOKENS:
     - name: codex
       sha256: "paste_sha256_here"
       scopes: ["read", "write"]
 ```
 
-Use `scripts/hash_admin_mcp_token.py` to generate a SHA-256 hash for a token:
+Use `scripts/hash_admin_mcp_token.py` to generate a SHA-256 hash for a legacy static token:
 
 ```bash
 python scripts/hash_admin_mcp_token.py
@@ -86,3 +102,13 @@ It does not yet expose every admin-dashboard action. The intended next expansion
 - organization membership/invite actions
 - translator/admin review workflows
 - audit log reads and selected write actions
+
+## Important limitation
+
+This foundation implements the **resource server** side of OAuth bearer-token validation. It does **not** yet implement a full authorization server, consent UI, or dynamic client registration flow by itself.
+
+That means:
+
+- it is ready to accept OAuth access tokens issued by your auth system
+- it is compatible with the OpenAI-side bearer-token pattern
+- but a complete end-user "Sign in with OpenAI/ChatGPT connector" flow still requires the surrounding OAuth issuer setup

--- a/docs/admin_mcp.md
+++ b/docs/admin_mcp.md
@@ -1,0 +1,88 @@
+# Admin MCP
+
+This repository now includes a token-protected MCP-compatible admin endpoint at:
+
+- `POST /api/admin/mcp`
+
+It exposes a first foundation slice for AI-driven admin work without going through the browser dashboard.
+
+## Security model
+
+Admin MCP is disabled by default. Enable it in `config.yaml`:
+
+```yaml
+ADMIN_MCP:
+  ENABLED: true
+  TOKENS:
+    - name: codex
+      sha256: "paste_sha256_here"
+      scopes: ["read", "write"]
+```
+
+Use `scripts/hash_admin_mcp_token.py` to generate a SHA-256 hash for a token:
+
+```bash
+python scripts/hash_admin_mcp_token.py
+```
+
+Then send the token as:
+
+```http
+Authorization: Bearer <your-token>
+```
+
+## Supported MCP methods
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+## Tools in the first slice
+
+- `list_demos`
+- `get_demo`
+- `create_demo`
+- `update_demo`
+- `list_organizations`
+- `get_organization`
+- `create_organization`
+- `update_organization`
+- `list_cases`
+- `get_case`
+- `add_case_note`
+- `close_case`
+- `reopen_case`
+
+## Example request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "list_demos",
+    "arguments": {
+      "search": "helsinki",
+      "per_page": 10
+    }
+  }
+}
+```
+
+## Scope of this foundation
+
+This first MCP slice covers the highest-value dashboard actions for:
+
+- demonstrations
+- organizations
+- support/admin cases
+
+It does not yet expose every admin-dashboard action. The intended next expansions are:
+
+- recurring demos
+- moderation tokens and approval actions
+- organization membership/invite actions
+- translator/admin review workflows
+- audit log reads and selected write actions

--- a/docs/admin_mcp.md
+++ b/docs/admin_mcp.md
@@ -24,6 +24,38 @@ ADMIN_MCP:
 
 This is the recommended mode for OpenAI-compatible remote MCP authentication: OpenAI can pass your OAuth access token to the MCP server as a bearer token, and the server validates the JWT claims locally.
 
+## Easiest login path right now
+
+The easiest supported way to use this MCP server is to reuse the repository's **existing API token system**.
+
+That means you do **not** need a separate MCP-specific login product before trying it.
+
+Practical flow:
+
+1. Get API token access approved for your user in the existing developer/API-token flow.
+2. Create a token with the scopes you need.
+3. Pass that token to OpenAI as the MCP `authorization` bearer token.
+
+Examples:
+
+- personal user token: create from `/users/auth/api_token`
+- developer app token: create from `/developer/apps/<app_id>/token`
+
+If you need admin dashboard control through MCP, the token must include at least:
+
+- `admin`
+
+Usually you also want:
+
+- `read`
+- `write`
+
+So the practical MCP token scope set is usually:
+
+- `["read", "write", "admin"]`
+
+Then use it in OpenAI's MCP tool config as the `authorization` bearer token.
+
 For bootstrap or private local use, the legacy static-token mode is still supported:
 
 ```yaml
@@ -110,5 +142,6 @@ This foundation implements the **resource server** side of OAuth bearer-token va
 That means:
 
 - it is ready to accept OAuth access tokens issued by your auth system
+- it is ready to accept this repo's existing API tokens directly
 - it is compatible with the OpenAI-side bearer-token pattern
 - but a complete end-user "Sign in with OpenAI/ChatGPT connector" flow still requires the surrounding OAuth issuer setup

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -144,6 +144,7 @@ def create_app(config_overrides=None) -> Flask:
     from users import _BLUEPRINT_ as user_bp
     from api import api_bp
     from developer_bp import developer_bp
+    from mielenosoitukset_fi.mcp_admin_bp import mcp_admin_bp
 
     app.register_blueprint(admin_bp)
     app.register_blueprint(admin_demo_bp)
@@ -160,6 +161,7 @@ def create_app(config_overrides=None) -> Flask:
     
     app.register_blueprint(user_bp, url_prefix="/users/")
     app.register_blueprint(api_bp, url_prefix="/api/")
+    app.register_blueprint(mcp_admin_bp)
     app.register_blueprint(developer_bp, url_prefix="/developer")
     
     

--- a/mielenosoitukset_fi/mcp_admin_bp.py
+++ b/mielenosoitukset_fi/mcp_admin_bp.py
@@ -1,0 +1,749 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime
+from typing import Any
+
+from bson import ObjectId
+from flask import Blueprint, current_app, jsonify, request
+
+from mielenosoitukset_fi.database_manager import DatabaseManager
+from mielenosoitukset_fi.utils.classes.Case import Case
+from mielenosoitukset_fi.utils.classes.Demonstration import Demonstration
+from mielenosoitukset_fi.utils.classes.Organization import Organization
+from mielenosoitukset_fi.utils.database import stringify_object_ids
+
+
+mcp_admin_bp = Blueprint("admin_mcp", __name__, url_prefix="/api/admin/mcp")
+
+
+def _mongo():
+    return DatabaseManager().get_instance().get_db()
+
+
+def _normalize_tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, list):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return []
+
+
+def _normalize_organizers(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _jsonrpc_response(result: Any, request_id: Any, http_status: int = 200):
+    return (
+        jsonify({"jsonrpc": "2.0", "id": request_id, "result": result}),
+        http_status,
+    )
+
+
+def _jsonrpc_error(request_id: Any, code: int, message: str, data: Any = None, http_status: int = 200):
+    payload = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+    if data is not None:
+        payload["error"]["data"] = data
+    return jsonify(payload), http_status
+
+
+def _get_mcp_config() -> dict[str, Any]:
+    config = current_app.config.get("ADMIN_MCP") or {}
+    return config if isinstance(config, dict) else {}
+
+
+def _token_entries() -> list[dict[str, Any]]:
+    raw_entries = _get_mcp_config().get("TOKENS") or []
+    normalized: list[dict[str, Any]] = []
+    for entry in raw_entries:
+        if isinstance(entry, str):
+            normalized.append({"name": "token", "token": entry, "scopes": ["read", "write"]})
+        elif isinstance(entry, dict):
+            normalized.append(
+                {
+                    "name": entry.get("name", "token"),
+                    "token": entry.get("token"),
+                    "sha256": entry.get("sha256"),
+                    "scopes": entry.get("scopes") or ["read", "write"],
+                }
+            )
+    return normalized
+
+
+def _authenticate() -> dict[str, Any] | None:
+    if not _get_mcp_config().get("ENABLED", False):
+        return None
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+
+    supplied_token = auth_header.split(" ", 1)[1].strip()
+    if not supplied_token:
+        return None
+
+    supplied_hash = hashlib.sha256(supplied_token.encode("utf-8")).hexdigest()
+    for entry in _token_entries():
+        entry_token = entry.get("token")
+        entry_hash = entry.get("sha256")
+        if entry_token and hmac.compare_digest(entry_token, supplied_token):
+            return entry
+        if entry_hash and hmac.compare_digest(entry_hash, supplied_hash):
+            return entry
+    return None
+
+
+def _require_scope(token_entry: dict[str, Any], scope: str) -> None:
+    scopes = token_entry.get("scopes") or []
+    if scope not in scopes and "write" not in scopes and "admin" not in scopes:
+        raise PermissionError(f"Token missing required scope: {scope}")
+
+
+def _serialize_result(data: Any) -> dict[str, Any]:
+    structured = stringify_object_ids(data)
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(structured, ensure_ascii=False, default=str),
+            }
+        ],
+        "structuredContent": structured,
+    }
+
+
+def _list_demos(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    db = _mongo()
+    search = (arguments.get("search") or "").strip()
+    approved_only = bool(arguments.get("approved_only", False))
+    include_hidden = bool(arguments.get("include_hidden", False))
+    include_cancelled = bool(arguments.get("include_cancelled", False))
+    include_past = bool(arguments.get("include_past", True))
+    page = max(int(arguments.get("page", 1) or 1), 1)
+    per_page = min(max(int(arguments.get("per_page", 20) or 20), 1), 100)
+
+    clauses: list[dict[str, Any]] = [{"$or": [{"rejected": {"$exists": False}}, {"rejected": False}]}]
+    if approved_only:
+        clauses.append({"approved": True})
+    if not include_hidden:
+        clauses.append({"$or": [{"hide": {"$exists": False}}, {"hide": False}]})
+    if not include_cancelled:
+        clauses.append({"cancelled": {"$ne": True}})
+    if not include_past:
+        clauses.append({"$or": [{"in_past": {"$exists": False}}, {"in_past": False}]})
+    if search:
+        clauses.append(
+            {
+                "$or": [
+                    {"title": {"$regex": search, "$options": "i"}},
+                    {"city": {"$regex": search, "$options": "i"}},
+                    {"address": {"$regex": search, "$options": "i"}},
+                    {"description": {"$regex": search, "$options": "i"}},
+                ]
+            }
+        )
+    query = {"$and": clauses} if len(clauses) > 1 else clauses[0]
+
+    total = db.demonstrations.count_documents(query)
+    cursor = (
+        db.demonstrations.find(query)
+        .sort([("date", 1), ("_id", 1)])
+        .skip((page - 1) * per_page)
+        .limit(per_page)
+    )
+    items = [
+        {
+            "_id": doc["_id"],
+            "title": doc.get("title"),
+            "date": doc.get("date"),
+            "city": doc.get("city"),
+            "approved": doc.get("approved", False),
+            "hide": doc.get("hide", False),
+            "cancelled": doc.get("cancelled", False),
+            "running_number": doc.get("running_number"),
+            "slug": doc.get("slug"),
+        }
+        for doc in cursor
+    ]
+    return _serialize_result({"items": items, "total": total, "page": page, "per_page": per_page})
+
+
+def _get_demo(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    demo_id = arguments.get("demo_id")
+    if not demo_id:
+        raise ValueError("demo_id is required")
+    doc = _mongo().demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not doc:
+        raise LookupError("Demonstration not found")
+    return _serialize_result(doc)
+
+
+def _create_demo(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    required = ["title", "date", "start_time", "end_time", "city", "address"]
+    missing = [field for field in required if not arguments.get(field)]
+    if missing:
+        raise ValueError(f"Missing required fields: {', '.join(missing)}")
+
+    demo = Demonstration(
+        title=arguments["title"],
+        date=arguments["date"],
+        start_time=arguments["start_time"],
+        end_time=arguments["end_time"],
+        city=arguments["city"],
+        address=arguments["address"],
+        description=arguments.get("description"),
+        facebook=arguments.get("facebook"),
+        route=arguments.get("route"),
+        event_type=arguments.get("event_type") or arguments.get("type") or "other",
+        tags=_normalize_tags(arguments.get("tags")),
+        organizers=_normalize_organizers(arguments.get("organizers")),
+        approved=bool(arguments.get("approved", False)),
+        hide=bool(arguments.get("hide", False)),
+        created_datetime=datetime.utcnow(),
+        last_modified=datetime.utcnow(),
+    )
+    demo.save()
+    return _serialize_result({"created": True, "demo_id": demo._id, "slug": demo.slug})
+
+
+def _update_demo(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    demo_id = arguments.get("demo_id")
+    patch = arguments.get("patch") or {}
+    if not demo_id:
+        raise ValueError("demo_id is required")
+    if not isinstance(patch, dict) or not patch:
+        raise ValueError("patch must be a non-empty object")
+
+    db = _mongo()
+    doc = db.demonstrations.find_one({"_id": ObjectId(demo_id)})
+    if not doc:
+        raise LookupError("Demonstration not found")
+
+    demo = Demonstration.from_dict(doc)
+    allowed_fields = {
+        "title",
+        "date",
+        "start_time",
+        "end_time",
+        "city",
+        "address",
+        "description",
+        "facebook",
+        "route",
+        "tags",
+        "organizers",
+        "approved",
+        "hide",
+        "cancelled",
+        "event_type",
+    }
+    applied: dict[str, Any] = {}
+    for key, value in patch.items():
+        if key not in allowed_fields:
+            continue
+        if key == "tags":
+            value = _normalize_tags(value)
+        elif key == "organizers":
+            value = _normalize_organizers(value)
+        setattr(demo, key, value)
+        applied[key] = value
+
+    if not applied:
+        raise ValueError("No supported fields in patch")
+
+    demo.last_modified = datetime.utcnow()
+    demo.save()
+    return _serialize_result({"updated": True, "demo_id": demo._id, "applied": applied})
+
+
+def _list_organizations(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    db = _mongo()
+    search = (arguments.get("search") or "").strip()
+    page = max(int(arguments.get("page", 1) or 1), 1)
+    per_page = min(max(int(arguments.get("per_page", 20) or 20), 1), 100)
+    query: dict[str, Any] = {}
+    if search:
+        query = {
+            "$or": [
+                {"name": {"$regex": search, "$options": "i"}},
+                {"email": {"$regex": search, "$options": "i"}},
+            ]
+        }
+    total = db.organizations.count_documents(query)
+    cursor = (
+        db.organizations.find(query)
+        .sort("name", 1)
+        .skip((page - 1) * per_page)
+        .limit(per_page)
+    )
+    items = [
+        {
+            "_id": doc["_id"],
+            "name": doc.get("name"),
+            "email": doc.get("email"),
+            "website": doc.get("website"),
+            "verified": doc.get("verified", False),
+        }
+        for doc in cursor
+    ]
+    return _serialize_result({"items": items, "total": total, "page": page, "per_page": per_page})
+
+
+def _get_organization(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    org_id = arguments.get("organization_id")
+    if not org_id:
+        raise ValueError("organization_id is required")
+    doc = _mongo().organizations.find_one({"_id": ObjectId(org_id)})
+    if not doc:
+        raise LookupError("Organization not found")
+    return _serialize_result(doc)
+
+
+def _create_organization(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    required = ["name", "email", "description"]
+    missing = [field for field in required if not arguments.get(field)]
+    if missing:
+        raise ValueError(f"Missing required fields: {', '.join(missing)}")
+
+    organization = Organization(
+        name=arguments["name"],
+        description=arguments["description"],
+        email=arguments["email"],
+        website=arguments.get("website", ""),
+        logo=arguments.get("logo"),
+        social_media_links=arguments.get("social_media_links") or {},
+        verified=bool(arguments.get("verified", False)),
+        invitations=arguments.get("invitations") or [],
+    )
+    organization.save()
+    return _serialize_result({"created": True, "organization_id": organization._id})
+
+
+def _update_organization(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    org_id = arguments.get("organization_id")
+    patch = arguments.get("patch") or {}
+    if not org_id:
+        raise ValueError("organization_id is required")
+    if not isinstance(patch, dict) or not patch:
+        raise ValueError("patch must be a non-empty object")
+    allowed_fields = {
+        "name",
+        "description",
+        "email",
+        "website",
+        "logo",
+        "social_media_links",
+        "verified",
+        "fill_url",
+        "invitations",
+    }
+    update_payload = {key: value for key, value in patch.items() if key in allowed_fields}
+    if not update_payload:
+        raise ValueError("No supported fields in patch")
+
+    result = _mongo().organizations.update_one(
+        {"_id": ObjectId(org_id)},
+        {"$set": update_payload},
+    )
+    if result.matched_count == 0:
+        raise LookupError("Organization not found")
+    return _serialize_result({"updated": True, "organization_id": org_id, "applied": update_payload})
+
+
+def _list_cases(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    db = _mongo()
+    case_type = (arguments.get("case_type") or "").strip()
+    closed = arguments.get("closed")
+    page = max(int(arguments.get("page", 1) or 1), 1)
+    per_page = min(max(int(arguments.get("per_page", 20) or 20), 1), 100)
+    query: dict[str, Any] = {}
+    if case_type:
+        query["type"] = case_type
+    if closed is True:
+        query["meta.closed"] = True
+    elif closed is False:
+        query["$or"] = [{"meta.closed": {"$exists": False}}, {"meta.closed": False}]
+
+    total = db.cases.count_documents(query)
+    cursor = (
+        db.cases.find(query)
+        .sort([("created_at", -1), ("_id", -1)])
+        .skip((page - 1) * per_page)
+        .limit(per_page)
+    )
+    items = []
+    for doc in cursor:
+        items.append(
+            {
+                "_id": doc["_id"],
+                "running_num": doc.get("running_num"),
+                "type": doc.get("type"),
+                "demo_id": doc.get("demo_id"),
+                "organization_id": doc.get("organization_id"),
+                "closed": bool((doc.get("meta") or {}).get("closed")),
+                "updated_at": doc.get("updated_at"),
+            }
+        )
+    return _serialize_result({"items": items, "total": total, "page": page, "per_page": per_page})
+
+
+def _get_case(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "read")
+    case_id = arguments.get("case_id")
+    if not case_id:
+        raise ValueError("case_id is required")
+    doc = _mongo().cases.find_one({"_id": ObjectId(case_id)})
+    if not doc:
+        raise LookupError("Case not found")
+    return _serialize_result(doc)
+
+
+def _add_case_note(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    case_id = arguments.get("case_id")
+    note = (arguments.get("note") or "").strip()
+    actor = (arguments.get("actor") or token_entry.get("name") or "mcp").strip()
+    action_type = (arguments.get("action_type") or "internal_note").strip()
+    if not case_id or not note:
+        raise ValueError("case_id and note are required")
+    case = Case.get(case_id)
+    if not case:
+        raise LookupError("Case not found")
+    case.add_action(action_type=action_type, admin_user=actor, note=note)
+    return _serialize_result({"updated": True, "case_id": case_id, "action_type": action_type})
+
+
+def _close_case(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    case_id = arguments.get("case_id")
+    reason = (arguments.get("reason") or "Closed via MCP").strip()
+    actor = (arguments.get("actor") or token_entry.get("name") or "mcp").strip()
+    if not case_id:
+        raise ValueError("case_id is required")
+    db = _mongo()
+    doc = db.cases.find_one({"_id": ObjectId(case_id)})
+    if not doc:
+        raise LookupError("Case not found")
+    action_entry = {
+        "timestamp": datetime.utcnow(),
+        "admin": actor,
+        "action_type": "close_case",
+        "note": reason,
+    }
+    history_entry = {
+        "timestamp": datetime.utcnow(),
+        "action": "Case closed",
+        "user": actor,
+        "metadata": {"reason": reason, "source": "mcp"},
+    }
+    db.cases.update_one(
+        {"_id": ObjectId(case_id)},
+        {
+            "$set": {
+                "meta.closed": True,
+                "meta.closed_reason": reason,
+                "updated_at": datetime.utcnow(),
+            },
+            "$push": {"action_logs": action_entry, "case_history": history_entry},
+        },
+    )
+    return _serialize_result({"updated": True, "case_id": case_id, "closed": True})
+
+
+def _reopen_case(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict[str, Any]:
+    _require_scope(token_entry, "write")
+    case_id = arguments.get("case_id")
+    reason = (arguments.get("reason") or "Reopened via MCP").strip()
+    actor = (arguments.get("actor") or token_entry.get("name") or "mcp").strip()
+    if not case_id:
+        raise ValueError("case_id is required")
+    db = _mongo()
+    doc = db.cases.find_one({"_id": ObjectId(case_id)})
+    if not doc:
+        raise LookupError("Case not found")
+    action_entry = {
+        "timestamp": datetime.utcnow(),
+        "admin": actor,
+        "action_type": "reopen_case",
+        "note": reason,
+    }
+    history_entry = {
+        "timestamp": datetime.utcnow(),
+        "action": "Case reopened",
+        "user": actor,
+        "metadata": {"reason": reason, "source": "mcp"},
+    }
+    db.cases.update_one(
+        {"_id": ObjectId(case_id)},
+        {
+            "$set": {
+                "meta.closed": False,
+                "updated_at": datetime.utcnow(),
+            },
+            "$unset": {"meta.closed_reason": ""},
+            "$push": {"action_logs": action_entry, "case_history": history_entry},
+        },
+    )
+    return _serialize_result({"updated": True, "case_id": case_id, "closed": False})
+
+
+TOOLS: dict[str, dict[str, Any]] = {
+    "list_demos": {
+        "description": "List and search demonstrations from the admin dashboard dataset.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "search": {"type": "string"},
+                "approved_only": {"type": "boolean"},
+                "include_hidden": {"type": "boolean"},
+                "include_cancelled": {"type": "boolean"},
+                "include_past": {"type": "boolean"},
+                "page": {"type": "integer", "minimum": 1},
+                "per_page": {"type": "integer", "minimum": 1, "maximum": 100},
+            },
+        },
+        "handler": _list_demos,
+    },
+    "get_demo": {
+        "description": "Fetch a single demonstration by id.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["demo_id"],
+            "properties": {"demo_id": {"type": "string"}},
+        },
+        "handler": _get_demo,
+    },
+    "create_demo": {
+        "description": "Create a new demonstration.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["title", "date", "start_time", "end_time", "city", "address"],
+            "properties": {
+                "title": {"type": "string"},
+                "date": {"type": "string"},
+                "start_time": {"type": "string"},
+                "end_time": {"type": "string"},
+                "city": {"type": "string"},
+                "address": {"type": "string"},
+                "description": {"type": "string"},
+                "facebook": {"type": "string"},
+                "route": {},
+                "event_type": {"type": "string"},
+                "tags": {},
+                "organizers": {"type": "array"},
+                "approved": {"type": "boolean"},
+                "hide": {"type": "boolean"},
+            },
+        },
+        "handler": _create_demo,
+    },
+    "update_demo": {
+        "description": "Update a demonstration by applying a patch to supported admin fields.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["demo_id", "patch"],
+            "properties": {
+                "demo_id": {"type": "string"},
+                "patch": {"type": "object"},
+            },
+        },
+        "handler": _update_demo,
+    },
+    "list_organizations": {
+        "description": "List and search organizations.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "search": {"type": "string"},
+                "page": {"type": "integer", "minimum": 1},
+                "per_page": {"type": "integer", "minimum": 1, "maximum": 100},
+            },
+        },
+        "handler": _list_organizations,
+    },
+    "get_organization": {
+        "description": "Fetch a single organization by id.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["organization_id"],
+            "properties": {"organization_id": {"type": "string"}},
+        },
+        "handler": _get_organization,
+    },
+    "create_organization": {
+        "description": "Create a new organization.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["name", "email", "description"],
+            "properties": {
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+                "description": {"type": "string"},
+                "website": {"type": "string"},
+                "logo": {"type": "string"},
+                "social_media_links": {"type": "object"},
+                "verified": {"type": "boolean"},
+                "invitations": {"type": "array"},
+            },
+        },
+        "handler": _create_organization,
+    },
+    "update_organization": {
+        "description": "Update an organization with a supported field patch.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["organization_id", "patch"],
+            "properties": {
+                "organization_id": {"type": "string"},
+                "patch": {"type": "object"},
+            },
+        },
+        "handler": _update_organization,
+    },
+    "list_cases": {
+        "description": "List support/admin cases with basic filtering.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "case_type": {"type": "string"},
+                "closed": {"type": "boolean"},
+                "page": {"type": "integer", "minimum": 1},
+                "per_page": {"type": "integer", "minimum": 1, "maximum": 100},
+            },
+        },
+        "handler": _list_cases,
+    },
+    "get_case": {
+        "description": "Fetch a support/admin case by id.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["case_id"],
+            "properties": {"case_id": {"type": "string"}},
+        },
+        "handler": _get_case,
+    },
+    "add_case_note": {
+        "description": "Add an internal note/action log entry to a support case.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["case_id", "note"],
+            "properties": {
+                "case_id": {"type": "string"},
+                "note": {"type": "string"},
+                "action_type": {"type": "string"},
+                "actor": {"type": "string"},
+            },
+        },
+        "handler": _add_case_note,
+    },
+    "close_case": {
+        "description": "Close a support case and append audit/history entries.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["case_id"],
+            "properties": {
+                "case_id": {"type": "string"},
+                "reason": {"type": "string"},
+                "actor": {"type": "string"},
+            },
+        },
+        "handler": _close_case,
+    },
+    "reopen_case": {
+        "description": "Reopen a support case and append audit/history entries.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["case_id"],
+            "properties": {
+                "case_id": {"type": "string"},
+                "reason": {"type": "string"},
+                "actor": {"type": "string"},
+            },
+        },
+        "handler": _reopen_case,
+    },
+}
+
+
+@mcp_admin_bp.route("", methods=["POST"])
+def handle_admin_mcp():
+    request_json = request.get_json(silent=True) or {}
+    request_id = request_json.get("id")
+
+    token_entry = _authenticate()
+    if not token_entry:
+        return _jsonrpc_error(request_id, -32001, "Unauthorized MCP token", http_status=401)
+
+    method = request_json.get("method")
+    params = request_json.get("params") or {}
+
+    if method == "initialize":
+        return _jsonrpc_response(
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "mielenosoitukset-admin-mcp", "version": "0.1.0"},
+            },
+            request_id,
+        )
+
+    if method == "ping":
+        return _jsonrpc_response({}, request_id)
+
+    if method == "notifications/initialized":
+        return ("", 202)
+
+    if method == "tools/list":
+        return _jsonrpc_response(
+            {
+                "tools": [
+                    {
+                        "name": name,
+                        "description": tool["description"],
+                        "inputSchema": tool["inputSchema"],
+                    }
+                    for name, tool in TOOLS.items()
+                ]
+            },
+            request_id,
+        )
+
+    if method == "tools/call":
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+        tool = TOOLS.get(tool_name)
+        if not tool:
+            return _jsonrpc_error(request_id, -32602, f"Unknown tool: {tool_name}")
+        try:
+            return _jsonrpc_response(tool["handler"](arguments, token_entry), request_id)
+        except PermissionError as exc:
+            return _jsonrpc_error(request_id, -32003, str(exc), http_status=403)
+        except (ValueError, TypeError) as exc:
+            return _jsonrpc_error(request_id, -32602, str(exc))
+        except LookupError as exc:
+            return _jsonrpc_error(request_id, -32004, str(exc), http_status=404)
+        except Exception as exc:
+            return _jsonrpc_error(request_id, -32603, "Internal MCP tool error", data=str(exc), http_status=500)
+
+    return _jsonrpc_error(request_id, -32601, f"Method not found: {method}")

--- a/mielenosoitukset_fi/mcp_admin_bp.py
+++ b/mielenosoitukset_fi/mcp_admin_bp.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
-from datetime import datetime
+import secrets
+from datetime import datetime, timedelta
 from typing import Any
+from urllib.parse import urlencode
 
 from bson import ObjectId
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, redirect, render_template, request, url_for
+from flask_login import current_user
 import jwt
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
@@ -19,7 +23,7 @@ from mielenosoitukset_fi.utils.database import stringify_object_ids
 from mielenosoitukset_fi.utils.tokens import check_token
 
 
-mcp_admin_bp = Blueprint("admin_mcp", __name__, url_prefix="/api/admin/mcp")
+mcp_admin_bp = Blueprint("admin_mcp", __name__)
 
 
 def _mongo():
@@ -90,6 +94,258 @@ def _oauth_config() -> dict[str, Any]:
     return oauth if isinstance(oauth, dict) else {}
 
 
+def _oauth_enabled() -> bool:
+    if not _get_mcp_config().get("ENABLED", False):
+        return False
+    oauth = _oauth_config()
+    return oauth.get("ENABLED", True) is not False
+
+
+def _oauth_signing_secret() -> str:
+    oauth = _oauth_config()
+    return str(oauth.get("JWT_SHARED_SECRET") or current_app.config.get("SECRET_KEY") or "")
+
+
+def _oauth_audience() -> str:
+    oauth = _oauth_config()
+    return str(oauth.get("AUDIENCE") or _mcp_endpoint_url())
+
+
+def _oauth_required_scopes() -> list[str]:
+    oauth = _oauth_config()
+    required = oauth.get("REQUIRED_SCOPES")
+    if isinstance(required, list) and required:
+        return [str(scope) for scope in required if str(scope)]
+    return ["mcp.admin"]
+
+
+def _oauth_supported_scopes() -> list[str]:
+    oauth = _oauth_config()
+    configured = oauth.get("SUPPORTED_SCOPES")
+    if isinstance(configured, list) and configured:
+        return [str(scope) for scope in configured if str(scope)]
+    return ["mcp.admin", "read", "write", "admin"]
+
+
+def _oauth_default_scopes() -> list[str]:
+    oauth = _oauth_config()
+    configured = oauth.get("DEFAULT_SCOPES")
+    if isinstance(configured, list) and configured:
+        return [str(scope) for scope in configured if str(scope)]
+    default_scopes = _oauth_supported_scopes()
+    if "mcp.admin" not in default_scopes:
+        default_scopes.insert(0, "mcp.admin")
+    return default_scopes
+
+
+def _oauth_issuer() -> str:
+    oauth = _oauth_config()
+    return str(oauth.get("ISSUER") or request.url_root.rstrip("/"))
+
+
+def _mcp_endpoint_url() -> str:
+    return request.url_root.rstrip("/") + url_for("admin_mcp.handle_admin_mcp")
+
+
+def _oauth_authorization_endpoint_url() -> str:
+    return request.url_root.rstrip("/") + url_for("admin_mcp.oauth_authorize")
+
+
+def _oauth_token_endpoint_url() -> str:
+    return request.url_root.rstrip("/") + url_for("admin_mcp.oauth_token")
+
+
+def _oauth_registration_endpoint_url() -> str:
+    return request.url_root.rstrip("/") + url_for("admin_mcp.oauth_register")
+
+
+def _oauth_resource_metadata_url() -> str:
+    return request.url_root.rstrip("/") + url_for("admin_mcp.oauth_protected_resource_metadata")
+
+
+def _oauth_authorization_server_metadata() -> dict[str, Any]:
+    return {
+        "issuer": _oauth_issuer(),
+        "authorization_endpoint": _oauth_authorization_endpoint_url(),
+        "token_endpoint": _oauth_token_endpoint_url(),
+        "registration_endpoint": _oauth_registration_endpoint_url(),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "code_challenge_methods_supported": ["S256", "plain"],
+        "token_endpoint_auth_methods_supported": ["none", "client_secret_post", "client_secret_basic"],
+        "scopes_supported": _oauth_supported_scopes(),
+    }
+
+
+def _oauth_protected_resource_metadata_payload() -> dict[str, Any]:
+    return {
+        "resource": _mcp_endpoint_url(),
+        "authorization_servers": [_oauth_issuer()],
+        "scopes_supported": _oauth_supported_scopes(),
+        "bearer_methods_supported": ["header"],
+    }
+
+
+def _client_collection():
+    return _mongo().oauth_clients
+
+
+def _authorization_code_collection():
+    return _mongo().oauth_authorization_codes
+
+
+def _normalize_scope_list(raw_scope: str | None, *, default_to_all: bool = False) -> list[str]:
+    if raw_scope:
+        requested = [part for part in str(raw_scope).split() if part]
+    elif default_to_all:
+        requested = list(_oauth_default_scopes())
+    else:
+        requested = []
+
+    supported = _oauth_supported_scopes()
+    normalized: list[str] = []
+    for scope in requested:
+        if scope in supported and scope not in normalized:
+            normalized.append(scope)
+    return normalized
+
+
+def _serialize_scope_list(scopes: list[str]) -> str:
+    return " ".join(scope for scope in scopes if scope)
+
+
+def _code_challenge_s256(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _hash_client_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _is_mcp_admin_user(user: Any) -> bool:
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "global_admin", False):
+        return True
+    return getattr(user, "role", None) in {"god", "global_admin", "admin", "superuser"}
+
+
+def _lookup_client(client_id: str) -> dict[str, Any] | None:
+    if not client_id:
+        return None
+    return _client_collection().find_one({"client_id": client_id})
+
+
+def _register_client_document(payload: dict[str, Any]) -> dict[str, Any]:
+    redirect_uris = payload.get("redirect_uris") or []
+    if not isinstance(redirect_uris, list) or not redirect_uris:
+        raise ValueError("redirect_uris is required")
+
+    token_auth_method = str(payload.get("token_endpoint_auth_method") or "none")
+    if token_auth_method not in {"none", "client_secret_post", "client_secret_basic"}:
+        raise ValueError("Unsupported token_endpoint_auth_method")
+
+    client_id = f"mcp_{secrets.token_urlsafe(18)}"
+    client_secret = secrets.token_urlsafe(32) if token_auth_method != "none" else None
+    doc = {
+        "client_id": client_id,
+        "client_name": payload.get("client_name") or "ChatGPT MCP Client",
+        "redirect_uris": [str(uri) for uri in redirect_uris if str(uri)],
+        "grant_types": payload.get("grant_types") or ["authorization_code"],
+        "response_types": payload.get("response_types") or ["code"],
+        "scope": _serialize_scope_list(_normalize_scope_list(payload.get("scope"), default_to_all=True)),
+        "token_endpoint_auth_method": token_auth_method,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+    }
+    if client_secret:
+        doc["client_secret_hash"] = _hash_client_secret(client_secret)
+    _client_collection().insert_one(doc)
+    response_doc = {
+        "client_id": client_id,
+        "client_name": doc["client_name"],
+        "redirect_uris": doc["redirect_uris"],
+        "grant_types": doc["grant_types"],
+        "response_types": doc["response_types"],
+        "scope": doc["scope"],
+        "token_endpoint_auth_method": token_auth_method,
+        "client_id_issued_at": int(doc["created_at"].timestamp()),
+    }
+    if client_secret:
+        response_doc["client_secret"] = client_secret
+        response_doc["client_secret_expires_at"] = 0
+    return response_doc
+
+
+def _resolve_client_auth() -> tuple[dict[str, Any] | None, str | None, str | None]:
+    basic_auth = request.authorization
+    if basic_auth and basic_auth.username:
+        return _lookup_client(basic_auth.username), basic_auth.username, basic_auth.password
+
+    json_payload = request.get_json(silent=True) if request.is_json else {}
+    client_id = (request.form.get("client_id") or (json_payload or {}).get("client_id"))
+    client_secret = (request.form.get("client_secret") or (json_payload or {}).get("client_secret"))
+    if client_id:
+        return _lookup_client(client_id), client_id, client_secret
+    return None, None, None
+
+
+def _validate_client_auth(client: dict[str, Any] | None, client_id: str | None, client_secret: str | None) -> dict[str, Any]:
+    if not client or not client_id:
+        raise LookupError("Unknown OAuth client")
+
+    auth_method = client.get("token_endpoint_auth_method") or "none"
+    if auth_method == "none":
+        return client
+
+    expected_hash = client.get("client_secret_hash")
+    supplied_hash = _hash_client_secret(client_secret or "")
+    if not expected_hash or not hmac.compare_digest(expected_hash, supplied_hash):
+        raise PermissionError("Invalid OAuth client secret")
+    return client
+
+
+def _store_authorization_code(
+    *,
+    client_id: str,
+    user_id: Any,
+    redirect_uri: str,
+    scope: str,
+    code_challenge: str | None,
+    code_challenge_method: str | None,
+) -> str:
+    code = secrets.token_urlsafe(32)
+    _authorization_code_collection().insert_one(
+        {
+            "code": code,
+            "client_id": client_id,
+            "user_id": user_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method or "plain",
+            "created_at": datetime.utcnow(),
+            "expires_at": datetime.utcnow() + timedelta(minutes=10),
+            "used_at": None,
+        }
+    )
+    return code
+
+
+def _issue_oauth_access_token(*, client_id: str, user_id: Any, scope: str) -> str:
+    now = datetime.utcnow()
+    claims = {
+        "iss": _oauth_issuer(),
+        "sub": str(user_id),
+        "aud": _oauth_audience(),
+        "scope": scope,
+        "client_id": client_id,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(hours=1)).timestamp()),
+    }
+    return jwt.encode(claims, _oauth_signing_secret(), algorithm="HS256")
+
 def _scopes_from_claims(claims: dict[str, Any]) -> list[str]:
     scopes: list[str] = []
     scope_claim = claims.get("scope")
@@ -107,15 +363,15 @@ def _scopes_from_claims(claims: dict[str, Any]) -> list[str]:
 
 def _authenticate_oauth_bearer(supplied_token: str) -> dict[str, Any] | None:
     oauth = _oauth_config()
-    if not oauth.get("ENABLED", False):
+    if not _oauth_enabled():
         return None
 
     algorithms = oauth.get("JWT_ALGORITHMS") or ["HS256"]
     issuer = oauth.get("ISSUER")
-    audience = oauth.get("AUDIENCE")
-    shared_secret = oauth.get("JWT_SHARED_SECRET")
+    audience = oauth.get("AUDIENCE") or _oauth_audience()
+    shared_secret = _oauth_signing_secret()
     public_key = oauth.get("JWT_PUBLIC_KEY")
-    required_scopes = oauth.get("REQUIRED_SCOPES") or []
+    required_scopes = _oauth_required_scopes()
 
     verification_key = public_key or shared_secret
     if not verification_key:
@@ -183,6 +439,8 @@ def _authenticate() -> dict[str, Any] | None:
 
 def _require_scope(token_entry: dict[str, Any], scope: str) -> None:
     scopes = token_entry.get("scopes") or []
+    if "mcp.admin" in scopes:
+        return
     if scope == "read" and ("read" in scopes or "write" in scopes or "admin" in scopes):
         return
     if scope == "write" and ("write" in scopes or "admin" in scopes):
@@ -590,6 +848,29 @@ def _reopen_case(arguments: dict[str, Any], token_entry: dict[str, Any]) -> dict
     return _serialize_result({"updated": True, "case_id": case_id, "closed": False})
 
 
+def _oauth_error_redirect(redirect_uri: str, *, error: str, state: str | None = None, description: str | None = None):
+    params = {"error": error}
+    if state:
+        params["state"] = state
+    if description:
+        params["error_description"] = description
+    separator = "&" if "?" in redirect_uri else "?"
+    return redirect(f"{redirect_uri}{separator}{urlencode(params)}")
+
+
+def _oauth_json_error(error: str, description: str, status: int = 400):
+    return jsonify({"error": error, "error_description": description}), status
+
+
+def _unauthorized_mcp_response(request_id: Any):
+    response, status = _jsonrpc_error(request_id, -32001, "Unauthorized MCP token", http_status=401)
+    response.headers["WWW-Authenticate"] = (
+        f'Bearer realm="mielenosoitukset-admin-mcp", '
+        f'resource_metadata="{_oauth_resource_metadata_url()}"'
+    )
+    return response, status
+
+
 TOOLS: dict[str, dict[str, Any]] = {
     "list_demos": {
         "description": "List and search demonstrations from the admin dashboard dataset.",
@@ -768,14 +1049,199 @@ TOOLS: dict[str, dict[str, Any]] = {
 }
 
 
-@mcp_admin_bp.route("", methods=["POST"])
+@mcp_admin_bp.route("/.well-known/oauth-authorization-server", methods=["GET"])
+@mcp_admin_bp.route("/.well-known/oauth-authorization-server/api/admin/mcp", methods=["GET"])
+@mcp_admin_bp.route("/.well-known/openid-configuration", methods=["GET"])
+def oauth_authorization_server_metadata():
+    if not _oauth_enabled():
+        return jsonify({"error": "OAuth is disabled"}), 404
+    return jsonify(_oauth_authorization_server_metadata())
+
+
+@mcp_admin_bp.route("/.well-known/oauth-protected-resource/api/admin/mcp", methods=["GET"])
+def oauth_protected_resource_metadata():
+    if not _oauth_enabled():
+        return jsonify({"error": "OAuth is disabled"}), 404
+    return jsonify(_oauth_protected_resource_metadata_payload())
+
+
+@mcp_admin_bp.route("/api/admin/mcp/oauth/register", methods=["POST"])
+def oauth_register():
+    if not _oauth_enabled():
+        return jsonify({"error": "OAuth is disabled"}), 404
+    payload = request.get_json(silent=True) or {}
+    try:
+        client_doc = _register_client_document(payload)
+    except ValueError as exc:
+        return _oauth_json_error("invalid_client_metadata", str(exc), status=400)
+    return jsonify(client_doc), 201
+
+
+@mcp_admin_bp.route("/api/admin/mcp/oauth/authorize", methods=["GET", "POST"])
+def oauth_authorize():
+    if not _oauth_enabled():
+        return jsonify({"error": "OAuth is disabled"}), 404
+
+    if request.method == "GET":
+        if not getattr(current_user, "is_authenticated", False):
+            return redirect(url_for("users.auth.login", next=request.url))
+        if not _is_mcp_admin_user(current_user):
+            return "Admin MCP access requires an admin-capable account.", 403
+
+        client_id = (request.args.get("client_id") or "").strip()
+        redirect_uri = (request.args.get("redirect_uri") or "").strip()
+        response_type = (request.args.get("response_type") or "").strip()
+        state = (request.args.get("state") or "").strip()
+        scope = request.args.get("scope")
+        code_challenge = (request.args.get("code_challenge") or "").strip()
+        code_challenge_method = (request.args.get("code_challenge_method") or "plain").strip()
+
+        client = _lookup_client(client_id)
+        if not client:
+            return _oauth_json_error("invalid_client", "Unknown OAuth client", status=400)
+        if response_type != "code":
+            return _oauth_json_error("unsupported_response_type", "Only authorization code flow is supported", status=400)
+        if redirect_uri not in (client.get("redirect_uris") or []):
+            return _oauth_json_error("invalid_request", "redirect_uri is not registered for this client", status=400)
+        if code_challenge_method not in {"plain", "S256"}:
+            return _oauth_json_error("invalid_request", "Unsupported code_challenge_method", status=400)
+
+        requested_scopes = _normalize_scope_list(scope, default_to_all=True)
+        if not requested_scopes:
+            return _oauth_json_error("invalid_scope", "No supported scopes were requested", status=400)
+
+        return render_template(
+            "oauth/mcp_consent.html",
+            client=client,
+            client_name=client.get("client_name") or client_id,
+            redirect_uri=redirect_uri,
+            response_type=response_type,
+            state=state,
+            scope=_serialize_scope_list(requested_scopes),
+            scopes=requested_scopes,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+        )
+
+    if not getattr(current_user, "is_authenticated", False):
+        return redirect(url_for("users.auth.login", next=request.url))
+    if not _is_mcp_admin_user(current_user):
+        return "Admin MCP access requires an admin-capable account.", 403
+
+    client_id = (request.form.get("client_id") or "").strip()
+    redirect_uri = (request.form.get("redirect_uri") or "").strip()
+    state = (request.form.get("state") or "").strip()
+    scope = request.form.get("scope")
+    code_challenge = (request.form.get("code_challenge") or "").strip() or None
+    code_challenge_method = (request.form.get("code_challenge_method") or "plain").strip()
+    decision = (request.form.get("decision") or "deny").strip()
+
+    client = _lookup_client(client_id)
+    if not client or redirect_uri not in (client.get("redirect_uris") or []):
+        return _oauth_json_error("invalid_client", "Unknown OAuth client", status=400)
+    if decision != "approve":
+        return _oauth_error_redirect(
+            redirect_uri,
+            error="access_denied",
+            state=state or None,
+            description="The user denied the MCP authorization request.",
+        )
+
+    granted_scopes = _normalize_scope_list(scope, default_to_all=True)
+    if not granted_scopes:
+        return _oauth_error_redirect(
+            redirect_uri,
+            error="invalid_scope",
+            state=state or None,
+            description="No supported scopes were requested.",
+        )
+
+    code = _store_authorization_code(
+        client_id=client_id,
+        user_id=current_user._id,
+        redirect_uri=redirect_uri,
+        scope=_serialize_scope_list(granted_scopes),
+        code_challenge=code_challenge,
+        code_challenge_method=code_challenge_method,
+    )
+    params = {"code": code}
+    if state:
+        params["state"] = state
+    separator = "&" if "?" in redirect_uri else "?"
+    return redirect(f"{redirect_uri}{separator}{urlencode(params)}")
+
+
+@mcp_admin_bp.route("/api/admin/mcp/oauth/token", methods=["POST"])
+def oauth_token():
+    if not _oauth_enabled():
+        return jsonify({"error": "OAuth is disabled"}), 404
+
+    grant_type = (request.form.get("grant_type") or "").strip()
+    if grant_type != "authorization_code":
+        return _oauth_json_error("unsupported_grant_type", "Only authorization_code is supported", status=400)
+
+    client, client_id, client_secret = _resolve_client_auth()
+    try:
+        client = _validate_client_auth(client, client_id, client_secret)
+    except LookupError as exc:
+        return _oauth_json_error("invalid_client", str(exc), status=401)
+    except PermissionError as exc:
+        return _oauth_json_error("invalid_client", str(exc), status=401)
+
+    code_value = (request.form.get("code") or "").strip()
+    redirect_uri = (request.form.get("redirect_uri") or "").strip()
+    code_verifier = (request.form.get("code_verifier") or "").strip()
+    if not code_value or not redirect_uri:
+        return _oauth_json_error("invalid_request", "code and redirect_uri are required", status=400)
+
+    code_doc = _authorization_code_collection().find_one({"code": code_value})
+    if not code_doc:
+        return _oauth_json_error("invalid_grant", "Authorization code is invalid", status=400)
+    if code_doc.get("used_at") is not None:
+        return _oauth_json_error("invalid_grant", "Authorization code has already been used", status=400)
+    if code_doc.get("expires_at") and code_doc["expires_at"] < datetime.utcnow():
+        return _oauth_json_error("invalid_grant", "Authorization code has expired", status=400)
+    if code_doc.get("client_id") != client["client_id"]:
+        return _oauth_json_error("invalid_grant", "Authorization code was issued to another client", status=400)
+    if code_doc.get("redirect_uri") != redirect_uri:
+        return _oauth_json_error("invalid_grant", "redirect_uri does not match the original authorization request", status=400)
+
+    code_challenge = code_doc.get("code_challenge")
+    code_challenge_method = code_doc.get("code_challenge_method") or "plain"
+    if code_challenge:
+        if not code_verifier:
+            return _oauth_json_error("invalid_request", "code_verifier is required for this authorization code", status=400)
+        derived_challenge = _code_challenge_s256(code_verifier) if code_challenge_method == "S256" else code_verifier
+        if not hmac.compare_digest(code_challenge, derived_challenge):
+            return _oauth_json_error("invalid_grant", "code_verifier did not match the original code challenge", status=400)
+
+    _authorization_code_collection().update_one(
+        {"_id": code_doc["_id"]},
+        {"$set": {"used_at": datetime.utcnow()}},
+    )
+    access_token = _issue_oauth_access_token(
+        client_id=client["client_id"],
+        user_id=code_doc["user_id"],
+        scope=code_doc.get("scope") or _serialize_scope_list(_oauth_default_scopes()),
+    )
+    return jsonify(
+        {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": code_doc.get("scope") or _serialize_scope_list(_oauth_default_scopes()),
+        }
+    )
+
+
+@mcp_admin_bp.route("/api/admin/mcp", methods=["POST"])
 def handle_admin_mcp():
     request_json = request.get_json(silent=True) or {}
     request_id = request_json.get("id")
 
     token_entry = _authenticate()
     if not token_entry:
-        return _jsonrpc_error(request_id, -32001, "Unauthorized MCP token", http_status=401)
+        return _unauthorized_mcp_response(request_id)
 
     method = request_json.get("method")
     params = request_json.get("params") or {}

--- a/mielenosoitukset_fi/mcp_admin_bp.py
+++ b/mielenosoitukset_fi/mcp_admin_bp.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from bson import ObjectId
 from flask import Blueprint, current_app, jsonify, request
+import jwt
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
 from mielenosoitukset_fi.utils.classes.Case import Case
@@ -82,6 +83,61 @@ def _token_entries() -> list[dict[str, Any]]:
     return normalized
 
 
+def _oauth_config() -> dict[str, Any]:
+    oauth = _get_mcp_config().get("OAUTH") or {}
+    return oauth if isinstance(oauth, dict) else {}
+
+
+def _scopes_from_claims(claims: dict[str, Any]) -> list[str]:
+    scopes: list[str] = []
+    scope_claim = claims.get("scope")
+    if isinstance(scope_claim, str):
+        scopes.extend(part for part in scope_claim.split() if part)
+    scp_claim = claims.get("scp")
+    if isinstance(scp_claim, list):
+        scopes.extend(str(part) for part in scp_claim if str(part))
+    unique_scopes: list[str] = []
+    for scope in scopes:
+        if scope not in unique_scopes:
+            unique_scopes.append(scope)
+    return unique_scopes
+
+
+def _authenticate_oauth_bearer(supplied_token: str) -> dict[str, Any] | None:
+    oauth = _oauth_config()
+    if not oauth.get("ENABLED", False):
+        return None
+
+    algorithms = oauth.get("JWT_ALGORITHMS") or ["HS256"]
+    issuer = oauth.get("ISSUER")
+    audience = oauth.get("AUDIENCE")
+    shared_secret = oauth.get("JWT_SHARED_SECRET")
+    public_key = oauth.get("JWT_PUBLIC_KEY")
+    required_scopes = oauth.get("REQUIRED_SCOPES") or []
+
+    verification_key = public_key or shared_secret
+    if not verification_key:
+        return None
+
+    decode_kwargs: dict[str, Any] = {"algorithms": algorithms}
+    if audience:
+        decode_kwargs["audience"] = audience
+    if issuer:
+        decode_kwargs["issuer"] = issuer
+
+    claims = jwt.decode(supplied_token, verification_key, **decode_kwargs)
+    scopes = _scopes_from_claims(claims)
+    if required_scopes and not all(scope in scopes for scope in required_scopes):
+        raise PermissionError("OAuth token missing required MCP scopes")
+
+    return {
+        "name": claims.get("sub") or claims.get("client_id") or "oauth-token",
+        "scopes": scopes or ["read"],
+        "claims": claims,
+        "auth_type": "oauth_bearer",
+    }
+
+
 def _authenticate() -> dict[str, Any] | None:
     if not _get_mcp_config().get("ENABLED", False):
         return None
@@ -93,6 +149,13 @@ def _authenticate() -> dict[str, Any] | None:
     supplied_token = auth_header.split(" ", 1)[1].strip()
     if not supplied_token:
         return None
+
+    try:
+        oauth_entry = _authenticate_oauth_bearer(supplied_token)
+        if oauth_entry:
+            return oauth_entry
+    except jwt.PyJWTError:
+        pass
 
     supplied_hash = hashlib.sha256(supplied_token.encode("utf-8")).hexdigest()
     for entry in _token_entries():
@@ -107,7 +170,13 @@ def _authenticate() -> dict[str, Any] | None:
 
 def _require_scope(token_entry: dict[str, Any], scope: str) -> None:
     scopes = token_entry.get("scopes") or []
-    if scope not in scopes and "write" not in scopes and "admin" not in scopes:
+    if scope == "read" and ("read" in scopes or "write" in scopes or "admin" in scopes):
+        return
+    if scope == "write" and ("write" in scopes or "admin" in scopes):
+        return
+    if scope == "admin" and "admin" in scopes:
+        return
+    if scope not in scopes:
         raise PermissionError(f"Token missing required scope: {scope}")
 
 

--- a/mielenosoitukset_fi/mcp_admin_bp.py
+++ b/mielenosoitukset_fi/mcp_admin_bp.py
@@ -11,10 +11,12 @@ from flask import Blueprint, current_app, jsonify, request
 import jwt
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
+from mielenosoitukset_fi.api.exceptions import ApiException
 from mielenosoitukset_fi.utils.classes.Case import Case
 from mielenosoitukset_fi.utils.classes.Demonstration import Demonstration
 from mielenosoitukset_fi.utils.classes.Organization import Organization
 from mielenosoitukset_fi.utils.database import stringify_object_ids
+from mielenosoitukset_fi.utils.tokens import check_token
 
 
 mcp_admin_bp = Blueprint("admin_mcp", __name__, url_prefix="/api/admin/mcp")
@@ -149,6 +151,17 @@ def _authenticate() -> dict[str, Any] | None:
     supplied_token = auth_header.split(" ", 1)[1].strip()
     if not supplied_token:
         return None
+
+    try:
+        token_record = check_token(supplied_token)
+        return {
+            "name": str(token_record.get("user_id") or token_record.get("app_id") or "api-token"),
+            "scopes": token_record.get("scopes") or ["read"],
+            "token_record": token_record,
+            "auth_type": "api_token",
+        }
+    except ApiException:
+        pass
 
     try:
         oauth_entry = _authenticate_oauth_bearer(supplied_token)

--- a/mielenosoitukset_fi/templates/oauth/mcp_consent.html
+++ b/mielenosoitukset_fi/templates/oauth/mcp_consent.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MCP OAuth Consent</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f4f7fb;
+      color: #12213a;
+    }
+    .shell {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+    .card {
+      width: min(42rem, 100%);
+      background: #fff;
+      border-radius: 1.25rem;
+      box-shadow: 0 18px 48px rgba(18, 33, 58, 0.12);
+      padding: 2rem;
+    }
+    h1 {
+      margin: 0 0 0.75rem;
+      font-size: 1.8rem;
+    }
+    p {
+      line-height: 1.55;
+    }
+    .meta {
+      padding: 1rem;
+      background: #eef4ff;
+      border-radius: 1rem;
+      margin: 1.5rem 0;
+    }
+    .scopes {
+      margin: 1rem 0 1.5rem;
+      padding-left: 1.2rem;
+    }
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 0.85rem 1.25rem;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .approve {
+      background: #155ee9;
+      color: #fff;
+    }
+    .deny {
+      background: #eef2f7;
+      color: #12213a;
+    }
+    code {
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="card">
+      <h1>Salli MCP-yhteys?</h1>
+      <p>
+        <strong>{{ client_name }}</strong> pyytää pääsyä Mielenosoitukset.fi:n admin-MCP-työkaluihin.
+        Tämä antaa ChatGPT:lle mahdollisuuden lukea ja muokata admin-paneelin tietoja niillä scopeilla,
+        jotka hyväksyt alla.
+      </p>
+
+      <div class="meta">
+        <div><strong>Client ID:</strong> <code>{{ client.client_id }}</code></div>
+        <div><strong>Palautusosoite:</strong> <code>{{ redirect_uri }}</code></div>
+      </div>
+
+      <p>Hyväksyttävät scopet:</p>
+      <ul class="scopes">
+        {% for scope in scopes %}
+        <li><code>{{ scope }}</code></li>
+        {% endfor %}
+      </ul>
+
+      <form method="post">
+        <input type="hidden" name="client_id" value="{{ client.client_id }}">
+        <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+        <input type="hidden" name="response_type" value="{{ response_type }}">
+        <input type="hidden" name="state" value="{{ state }}">
+        <input type="hidden" name="scope" value="{{ scope }}">
+        <input type="hidden" name="code_challenge" value="{{ code_challenge }}">
+        <input type="hidden" name="code_challenge_method" value="{{ code_challenge_method }}">
+        <div class="actions">
+          <button class="approve" type="submit" name="decision" value="approve">Salli yhteys</button>
+          <button class="deny" type="submit" name="decision" value="deny">Peruuta</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/hash_admin_mcp_token.py
+++ b/scripts/hash_admin_mcp_token.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import getpass
+import hashlib
+
+
+def main() -> None:
+    token = getpass.getpass("Admin MCP token: ").strip()
+    if not token:
+        raise SystemExit("No token provided.")
+    print(hashlib.sha256(token.encode("utf-8")).hexdigest())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_admin_mcp.py
+++ b/tests/test_admin_mcp.py
@@ -1,4 +1,5 @@
 import hashlib
+import jwt
 
 from bson import ObjectId
 
@@ -29,6 +30,35 @@ def _mcp_client(app_factory, seeded_data):
     return client, token, seeded_data
 
 
+def _oauth_mcp_client(app_factory, seeded_data):
+    secret = "oauth-mcp-secret"
+    token = jwt.encode(
+        {
+            "sub": "pytest-oauth-client",
+            "iss": "https://auth.example.test",
+            "aud": "mielenosoitukset-admin-mcp",
+            "scope": "mcp.admin write read",
+        },
+        secret,
+        algorithm="HS256",
+    )
+    app = app_factory(
+        ADMIN_MCP={
+            "ENABLED": True,
+            "OAUTH": {
+                "ENABLED": True,
+                "ISSUER": "https://auth.example.test",
+                "AUDIENCE": "mielenosoitukset-admin-mcp",
+                "JWT_ALGORITHMS": ["HS256"],
+                "JWT_SHARED_SECRET": secret,
+                "REQUIRED_SCOPES": ["mcp.admin"],
+            },
+        }
+    )
+    client = app.test_client()
+    return client, token, seeded_data
+
+
 def test_admin_mcp_requires_bearer_token(app_factory, seeded_data):
     client, _, _ = _mcp_client(app_factory, seeded_data)
 
@@ -49,6 +79,16 @@ def test_admin_mcp_lists_tools(app_factory, seeded_data):
     tools = tools_response.get_json()["result"]["tools"]
     tool_names = {tool["name"] for tool in tools}
     assert {"list_demos", "update_demo", "list_cases", "update_organization"} <= tool_names
+
+
+def test_admin_mcp_accepts_oauth_bearer_tokens(app_factory, seeded_data):
+    client, token, _ = _oauth_mcp_client(app_factory, seeded_data)
+
+    response = client.post("/api/admin/mcp", json=_rpc("tools/list"), headers=_mcp_headers(token))
+
+    assert response.status_code == 200
+    tool_names = {tool["name"] for tool in response.get_json()["result"]["tools"]}
+    assert "list_demos" in tool_names
 
 
 def test_admin_mcp_can_search_demos(app_factory, seeded_data):

--- a/tests/test_admin_mcp.py
+++ b/tests/test_admin_mcp.py
@@ -1,0 +1,145 @@
+import hashlib
+
+from bson import ObjectId
+
+
+def _mcp_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _rpc(method: str, params=None, request_id=1):
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+
+
+def _mcp_client(app_factory, seeded_data):
+    token = "super-secret-mcp-token"
+    app = app_factory(
+        ADMIN_MCP={
+            "ENABLED": True,
+            "TOKENS": [
+                {
+                    "name": "pytest",
+                    "sha256": hashlib.sha256(token.encode("utf-8")).hexdigest(),
+                    "scopes": ["read", "write"],
+                }
+            ],
+        }
+    )
+    client = app.test_client()
+    return client, token, seeded_data
+
+
+def test_admin_mcp_requires_bearer_token(app_factory, seeded_data):
+    client, _, _ = _mcp_client(app_factory, seeded_data)
+
+    response = client.post("/api/admin/mcp", json=_rpc("initialize"))
+
+    assert response.status_code == 401
+    assert response.get_json()["error"]["message"] == "Unauthorized MCP token"
+
+
+def test_admin_mcp_lists_tools(app_factory, seeded_data):
+    client, token, _ = _mcp_client(app_factory, seeded_data)
+
+    init_response = client.post("/api/admin/mcp", json=_rpc("initialize"), headers=_mcp_headers(token))
+    assert init_response.status_code == 200
+    assert init_response.get_json()["result"]["serverInfo"]["name"] == "mielenosoitukset-admin-mcp"
+
+    tools_response = client.post("/api/admin/mcp", json=_rpc("tools/list"), headers=_mcp_headers(token))
+    tools = tools_response.get_json()["result"]["tools"]
+    tool_names = {tool["name"] for tool in tools}
+    assert {"list_demos", "update_demo", "list_cases", "update_organization"} <= tool_names
+
+
+def test_admin_mcp_can_search_demos(app_factory, seeded_data):
+    client, token, seeded = _mcp_client(app_factory, seeded_data)
+
+    response = client.post(
+        "/api/admin/mcp",
+        json=_rpc("tools/call", {"name": "list_demos", "arguments": {"search": "Climate March"}}),
+        headers=_mcp_headers(token),
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()["result"]["structuredContent"]
+    assert payload["items"]
+    assert any(item["_id"] == str(seeded["demo_id"]) for item in payload["items"])
+
+
+def test_admin_mcp_can_add_case_note(app_factory, seeded_data, db):
+    client, token, seeded = _mcp_client(app_factory, seeded_data)
+
+    response = client.post(
+        "/api/admin/mcp",
+        json=_rpc(
+            "tools/call",
+            {
+                "name": "add_case_note",
+                "arguments": {
+                    "case_id": str(seeded["case_id"]),
+                    "note": "Reviewed from MCP",
+                    "actor": "pytest-mcp",
+                },
+            },
+        ),
+        headers=_mcp_headers(token),
+    )
+
+    assert response.status_code == 200
+    case_doc = db.cases.find_one({"_id": seeded["case_id"]})
+    assert case_doc["action_logs"][-1]["note"] == "Reviewed from MCP"
+    assert case_doc["action_logs"][-1]["admin"] == "pytest-mcp"
+
+
+def test_admin_mcp_can_update_organization(app_factory, seeded_data, db):
+    client, token, seeded = _mcp_client(app_factory, seeded_data)
+
+    response = client.post(
+        "/api/admin/mcp",
+        json=_rpc(
+            "tools/call",
+            {
+                "name": "update_organization",
+                "arguments": {
+                    "organization_id": str(seeded["org_id"]),
+                    "patch": {"website": "https://example.test/mcp-updated"},
+                },
+            },
+        ),
+        headers=_mcp_headers(token),
+    )
+
+    assert response.status_code == 200
+    organization = db.organizations.find_one({"_id": seeded["org_id"]})
+    assert organization["website"] == "https://example.test/mcp-updated"
+
+
+def test_admin_mcp_can_create_demo(app_factory, seeded_data, db):
+    client, token, _ = _mcp_client(app_factory, seeded_data)
+
+    response = client.post(
+        "/api/admin/mcp",
+        json=_rpc(
+            "tools/call",
+            {
+                "name": "create_demo",
+                "arguments": {
+                    "title": "MCP Created Demo",
+                    "date": "2026-09-01",
+                    "start_time": "16:00",
+                    "end_time": "18:00",
+                    "city": "Helsinki",
+                    "address": "MCP Street 1",
+                    "description": "Created through MCP.",
+                    "tags": ["mcp", "admin"],
+                },
+            },
+        ),
+        headers=_mcp_headers(token),
+    )
+
+    assert response.status_code == 200
+    created_payload = response.get_json()["result"]["structuredContent"]
+    created_demo = db.demonstrations.find_one({"_id": ObjectId(created_payload["demo_id"])})
+    assert created_demo["title"] == "MCP Created Demo"
+    assert created_demo["city"] == "Helsinki"

--- a/tests/test_admin_mcp.py
+++ b/tests/test_admin_mcp.py
@@ -2,6 +2,7 @@ import hashlib
 import jwt
 
 from bson import ObjectId
+from mielenosoitukset_fi.utils.tokens import create_token
 
 
 def _mcp_headers(token: str) -> dict[str, str]:
@@ -89,6 +90,27 @@ def test_admin_mcp_accepts_oauth_bearer_tokens(app_factory, seeded_data):
     assert response.status_code == 200
     tool_names = {tool["name"] for tool in response.get_json()["result"]["tools"]}
     assert "list_demos" in tool_names
+
+
+def test_admin_mcp_accepts_existing_api_tokens(app_factory, seeded_data):
+    token, _ = create_token(
+        user_id=seeded_data["admin_id"],
+        token_type="short",
+        scopes=["read", "write", "admin"],
+        category="user",
+    )
+    app = app_factory(
+        ADMIN_MCP={
+            "ENABLED": True,
+        }
+    )
+    client = app.test_client()
+
+    response = client.post("/api/admin/mcp", json=_rpc("tools/list"), headers=_mcp_headers(token))
+
+    assert response.status_code == 200
+    tool_names = {tool["name"] for tool in response.get_json()["result"]["tools"]}
+    assert "list_cases" in tool_names
 
 
 def test_admin_mcp_can_search_demos(app_factory, seeded_data):

--- a/tests/test_admin_mcp.py
+++ b/tests/test_admin_mcp.py
@@ -1,4 +1,6 @@
 import hashlib
+import base64
+from urllib.parse import parse_qs, urlparse
 import jwt
 
 from bson import ObjectId
@@ -11,6 +13,11 @@ def _mcp_headers(token: str) -> dict[str, str]:
 
 def _rpc(method: str, params=None, request_id=1):
     return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+
+
+def _pkce_s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
 def _mcp_client(app_factory, seeded_data):
@@ -80,6 +87,110 @@ def test_admin_mcp_lists_tools(app_factory, seeded_data):
     tools = tools_response.get_json()["result"]["tools"]
     tool_names = {tool["name"] for tool in tools}
     assert {"list_demos", "update_demo", "list_cases", "update_organization"} <= tool_names
+
+
+def test_admin_mcp_oauth_metadata_advertises_registration_and_pkce(app_factory, seeded_data):
+    app = app_factory(ADMIN_MCP={"ENABLED": True})
+    client = app.test_client()
+
+    metadata_response = client.get("/.well-known/oauth-authorization-server")
+    resource_response = client.get("/.well-known/oauth-protected-resource/api/admin/mcp")
+
+    assert metadata_response.status_code == 200
+    metadata = metadata_response.get_json()
+    assert metadata["authorization_endpoint"].endswith("/api/admin/mcp/oauth/authorize")
+    assert metadata["token_endpoint"].endswith("/api/admin/mcp/oauth/token")
+    assert metadata["registration_endpoint"].endswith("/api/admin/mcp/oauth/register")
+    assert "S256" in metadata["code_challenge_methods_supported"]
+
+    assert resource_response.status_code == 200
+    resource_metadata = resource_response.get_json()
+    assert resource_metadata["resource"].endswith("/api/admin/mcp")
+    assert resource_metadata["authorization_servers"]
+
+
+def test_admin_mcp_dynamic_client_registration_and_oauth_code_flow(app_factory, seeded_data):
+    app = app_factory(ADMIN_MCP={"ENABLED": True})
+    client = app.test_client()
+
+    register_response = client.post(
+        "/api/admin/mcp/oauth/register",
+        json={
+            "client_name": "Pytest ChatGPT",
+            "redirect_uris": ["https://chatgpt.com/connector/oauth/test-callback"],
+            "token_endpoint_auth_method": "none",
+            "scope": "mcp.admin read write",
+        },
+    )
+    assert register_response.status_code == 201
+    registered = register_response.get_json()
+    client_id = registered["client_id"]
+    redirect_uri = registered["redirect_uris"][0]
+
+    with client.session_transaction() as session:
+        session["_user_id"] = str(seeded_data["admin_id"])
+        session["_fresh"] = True
+
+    code_verifier = "pytest-code-verifier-123456789"
+    auth_page = client.get(
+        "/api/admin/mcp/oauth/authorize",
+        query_string={
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "mcp.admin read write",
+            "state": "pytest-state",
+            "code_challenge": _pkce_s256(code_verifier),
+            "code_challenge_method": "S256",
+        },
+    )
+    assert auth_page.status_code == 200
+    assert "Salli MCP-yhteys?" in auth_page.get_data(as_text=True)
+    assert "Pytest ChatGPT" in auth_page.get_data(as_text=True)
+
+    approve_response = client.post(
+        "/api/admin/mcp/oauth/authorize",
+        data={
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "mcp.admin read write",
+            "state": "pytest-state",
+            "code_challenge": _pkce_s256(code_verifier),
+            "code_challenge_method": "S256",
+            "decision": "approve",
+        },
+        follow_redirects=False,
+    )
+    assert approve_response.status_code == 302
+    location = approve_response.headers["Location"]
+    redirect_parts = urlparse(location)
+    redirect_params = parse_qs(redirect_parts.query)
+    code = redirect_params["code"][0]
+    assert redirect_params["state"][0] == "pytest-state"
+
+    token_response = client.post(
+        "/api/admin/mcp/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    assert token_response.status_code == 200
+    token_payload = token_response.get_json()
+    assert token_payload["token_type"] == "Bearer"
+    assert "mcp.admin" in token_payload["scope"]
+
+    mcp_response = client.post(
+        "/api/admin/mcp",
+        json=_rpc("tools/list"),
+        headers=_mcp_headers(token_payload["access_token"]),
+    )
+    assert mcp_response.status_code == 200
+    tool_names = {tool["name"] for tool in mcp_response.get_json()["result"]["tools"]}
+    assert "list_demos" in tool_names
 
 
 def test_admin_mcp_accepts_oauth_bearer_tokens(app_factory, seeded_data):


### PR DESCRIPTION
## Summary
- add a new `/api/admin/mcp` JSON-RPC endpoint that exposes MCP-compatible admin tools for demonstrations, organizations, and support cases
- support both hashed static bearer tokens and OAuth-style JWT bearer tokens so the server can work with OpenAI-compatible remote MCP auth flows
- add setup documentation, a token-hashing helper script, and regression tests for the MCP endpoint

## Included tools
- `list_demos`
- `get_demo`
- `create_demo`
- `update_demo`
- `list_organizations`
- `get_organization`
- `create_organization`
- `update_organization`
- `list_cases`
- `get_case`
- `add_case_note`
- `close_case`
- `reopen_case`

## Notes
- This is the resource-server side of OAuth bearer-token validation. It does not yet implement a full authorization server, consent UI, or dynamic client registration flow by itself.
- The existing static token mode remains available as a bootstrap/fallback path.

## Testing
- `python -m py_compile config.py mielenosoitukset_fi/app.py mielenosoitukset_fi/mcp_admin_bp.py tests/test_admin_mcp.py scripts/hash_admin_mcp_token.py`
- `git diff --check`
- local runtime verification of live Mongo-backed MCP calls was blocked in this sandbox because direct Mongo access is denied here (`127.0.0.1:27017: [Errno 1] Operation not permitted`), so CI or a real app environment should be used for end-to-end validation
