### PR TITLE
Fix PR 590 python-tests surface manifest

### DIFF
--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -1,28 +1,20 @@
 import copy
-import math
 import os
 import re
-import json
 import threading
 import time
 import uuid
 import hashlib
 import requests
-import xml.etree.ElementTree as ET
 from datetime import datetime, date, timedelta
-from flask_babel import _, refresh, format_date
+from flask_babel import _, format_date
 from flask import (
-    app,
-    g,
-    render_template,
     redirect,
     send_file,
     send_from_directory,
     url_for,
     request,
     abort,
-    Response,
-    get_flashed_messages,
     jsonify,
     session,
 )
@@ -36,19 +28,16 @@ from mielenosoitukset_fi.emailer.EmailSender import EmailSender
 from mielenosoitukset_fi.scripts.send_demo_reminders import generate_ical_event
 from mielenosoitukset_fi.utils.variables import CITY_LIST
 from mielenosoitukset_fi.utils.flashing import flash_message
-from mielenosoitukset_fi.utils.database import DEMO_FILTER, stringify_object_ids
+from mielenosoitukset_fi.utils.database import DEMO_FILTER
 from mielenosoitukset_fi.utils.analytics import log_demo_view
-from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required, depracated_endpoint
-from mielenosoitukset_fi.utils.screenshot import trigger_screenshot
+from mielenosoitukset_fi.utils.wrappers import permission_required, depracated_endpoint
 from mielenosoitukset_fi.utils.media_helpers import get_demo_cover_image
-from werkzeug.utils import secure_filename
 from mielenosoitukset_fi.a import generate_demo_sentence
 from pymongo.errors import DuplicateKeyError
 from pymongo import ASCENDING, DESCENDING
 from config import Config
 
 from mielenosoitukset_fi.utils.cache import (
-    cache,
     should_skip_cache,
     skip_cache_public_only,
 )

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -28,7 +28,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 from bson.objectid import ObjectId
-from mielenosoitukset_fi.utils.notifications import fetch_notifications
+from mielenosoitukset_fi.utils.notifications import fetch_notifications, serialize_notification
 from mielenosoitukset_fi.utils.s3 import upload_image_fileobj
 from mielenosoitukset_fi.utils.classes import Organizer, Demonstration, Organization, RecurringDemonstration
 from mielenosoitukset_fi.database_manager import DatabaseManager

--- a/tests/surface_manifest.json
+++ b/tests/surface_manifest.json
@@ -135,6 +135,13 @@
         "e2e-public"
       ]
     },
+    "mielenosoitukset_fi/mcp_admin_bp.py": {
+      "count": 10,
+      "sha256": "8f213902698ea302ccab346abe22fd0c49668d2baf571559a467d00a0c4af90a",
+      "coverage": [
+        "integration"
+      ]
+    },
     "mielenosoitukset_fi/notifications_bp.py": {
       "count": 3,
       "sha256": "1b4b57b231a01be68a23f14adb6f01592d0bd8ad21982ee29f506299107feca7",


### PR DESCRIPTION
Fixes the python-tests failure observed on #590 by adding the missing admin MCP blueprint entry to the route surface manifest.

Validation:
- `python3 -m unittest tests.test_surface_manifest -v` passes locally.

Note: #590's head branch is in the contributor fork `jpoikela/mielenosoitukset_fi`, where this app only has read access, so this branch carries the same PR changes plus the manifest correction in the base repository.