### PR TITLE
Fix settings changed email template lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ### Fixed
 * Admin and suggestion route editors now allow the same street or route point to be added multiple times, so march routes can loop through a road more than once.
+* User settings change notifications now have the missing `auth/settings_changed.html` email template, preventing settings updates from reporting a template lookup error.
 * New demonstration admin notification emails are now sent directly during the background notification job instead of being re-queued into a second email worker queue, so failed admin alert deliveries are surfaced as job errors instead of being silently marked complete.
 * PR preview workflow now posts an immediate spinning-up comment before building the preview, then edits the same comment into the final live URL once deploy completes.
 * PR preview workflow now stages the deploy script under the dedicated preview user's home directory instead of `/tmp`, avoiding permission failures on the server-side copy step.

--- a/mielenosoitukset_fi/templates/emails/auth/settings_changed.html
+++ b/mielenosoitukset_fi/templates/emails/auth/settings_changed.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Käyttäjäasetusten muutokset</title>
+    <style>
+        body {
+            background: #f4f4f4;
+            color: #333333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            width: 100%;
+            max-width: 600px;
+            padding: 20px;
+            background: #ffffff;
+            margin: 0 auto;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            text-align: center;
+            padding: 10px 0;
+            background: #0033A0;
+            color: #ffffff;
+            border-radius: 8px 8px 0 0;
+        }
+        .content {
+            margin: 20px;
+        }
+        .changes {
+            padding-left: 1.25rem;
+        }
+        .changes li {
+            margin-bottom: 0.75rem;
+        }
+        .value-label {
+            color: #666666;
+            font-size: 0.9em;
+        }
+        .footer {
+            margin-top: 20px;
+            text-align: center;
+            font-size: 0.9em;
+            color: #888888;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Käyttäjäasetuksia muutettiin</h1>
+        </div>
+        <div class="content">
+            <p>Hei {{ user_name }},</p>
+            <p>Tilisi käyttäjäasetuksia on päivitetty. Muutetut kentät:</p>
+            <ul class="changes">
+                {% for field, values in changed_fields.items() %}
+                <li>
+                    <strong>{{ field }}</strong><br>
+                    <span class="value-label">Vanha arvo:</span> {{ values.old if values.old is not none else "ei asetettu" }}<br>
+                    <span class="value-label">Uusi arvo:</span> {{ values.new if values.new is not none else "ei asetettu" }}
+                </li>
+                {% endfor %}
+            </ul>
+            <p>Jos et tehnyt tätä muutosta, ota välittömästi yhteyttä tukeemme.</p>
+            <p>Ystävällisin terveisin,<br>Tiimimme</p>
+        </div>
+        <div class="footer">
+            <p>Tämä on automaattinen viesti, älä vastaa tähän sähköpostiin.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,0 +1,21 @@
+from jinja2 import Environment, FileSystemLoader
+
+
+def test_settings_changed_email_template_renders():
+    env = Environment(loader=FileSystemLoader("mielenosoitukset_fi/templates/emails"))
+    template = env.get_template("auth/settings_changed.html")
+
+    rendered = template.render(
+        {
+            "user_name": "Test User",
+            "changed_fields": {
+                "city": {"old": "Helsinki", "new": "Kouvola"},
+                "language": {"old": None, "new": "fi"},
+            },
+        }
+    )
+
+    assert "Test User" in rendered
+    assert "city" in rendered
+    assert "Helsinki" in rendered
+    assert "Kouvola" in rendered


### PR DESCRIPTION
## Summary
- Add the missing `auth/settings_changed.html` email template used by user settings updates.
- Add a focused template render test so the lookup stays covered.
- Record the user-facing fix in `CHANGELOG.md`.

## Validation
- `python3 -m py_compile tests/test_email_templates.py`
- `python3 -m pytest tests/test_email_templates.py` could not run locally because `pytest` is not installed in this Python environment.