### PR TITLE
Fix user deletion personal-data cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Admin user deletion now requires top-level approval in addition to delete permission, shows an impact warning before confirmation, removes directly associated personal-data records while keeping submitted public demonstrations for separate review, and lets users request account deletion from their own settings page with a destructive-action warning and explicit confirmation phrase.
 * Admin and suggestion route editors now allow the same street or route point to be added multiple times, so march routes can loop through a road more than once.
 * New demonstration admin notification emails are now sent directly during the background notification job instead of being re-queued into a second email worker queue, so failed admin alert deliveries are surfaced as job errors instead of being silently marked complete.
 * PR preview workflow now posts an immediate spinning-up comment before building the preview, then edits the same comment into the final live URL once deploy completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Pride-kortit näyttävät oikein tyylitettyinä (tagit, ikonit, värit) lisäämällä puuttuvan `css/demo.css`-tyylin kampanjasivulle.
 * Pride-kartan merkinnät ja legendan värit vastaavat toisiaan (yhtenäinen violetin/rubiinin sävy) selkeyttääkseen mitä pisteet kuvaavat.
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
+* README now links directly to the project's DeepWiki documentation badge, and the backlog notes that the user settings page needs a broader UX cleanup.
 
 ### Fixed
 * Admin user deletion now requires top-level approval in addition to delete permission, shows an impact warning before confirmation, removes directly associated personal-data records while keeping submitted public demonstrations for separate review, and lets users request account deletion from their own settings page with a destructive-action warning and explicit confirmation phrase.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mielenosoitukset.fi
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/botsarefuture/mielenosoitukset_fi)
+
 Mielenosoitukset.fi is an open-source platform for discovering and submitting demonstrations in Finland. Users can browse upcoming events, submit new demonstrations, and administrators can manage and approve submissions. The project is actively maintained and welcomes new contributors — see the Contributing section below for how to help.
 
 > ⚠️ **Documentation notice**

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@
 
 - [ ] Dashboard
 - [ ] Form
+- [ ] Rework the user settings page layout and visual hierarchy; the current page is hard to scan and looks unfinished.
 
 
 ## Logical stuff

--- a/docs/admin_users.md
+++ b/docs/admin_users.md
@@ -13,6 +13,11 @@ Key changes
   - View the user's edit history
   - Delete the user (if you have the permission)
 - Delete confirmation uses a shared `deleteModal.js` behavior with fast-delete (hold Shift to delete instantly).
+- User deletion is a top-level destructive action: the actor must have both `DELETE_USER` and top-level approval (`global_admin`/`god`).
+- Deleting a user removes direct personal-data links, including submitter and support records, but does not automatically delete demonstrations they submitted through the public submission flow.
+- Submitted demonstrations are shown in the delete impact estimate for separate support/admin review if event removal is also needed.
+- The delete confirmation modal fetches and displays an impact estimate before the final confirmation, including how many submitted demonstrations need separate review and how many directly related records will be removed.
+- Users can request account deletion from their own settings page. The request is stored in `account_deletion_requests` and emailed to `tuki@mielenosoitukset.fi`; support/admins still perform the approved deletion.
 - The edit page contains improved help text, clearer confirmed checkbox, and Cancel button.
 
 Keyboard and shortcuts
@@ -25,4 +30,5 @@ Developer notes
 - The user list template is `templates/admin_V2/user/list.html`.
 - The edit page is `templates/admin_V2/user/edit.html`.
 - Deletion uses the shared `static/js/deleteModal.js` which expects the confirm button to have id `confirmDelete` and sets `data-type` to `user`.
-
+- User deletion cleanup is implemented in `admin/admin_user_bp.py` via `_delete_user_personal_data`; keep that helper in sync with any new collection that stores user personal data.
+- User deletion clearance is enforced server-side in `admin/admin_user_bp.py`; do not rely on template-only hiding for this action.

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -385,6 +385,245 @@ def is_valid_email(email):
     return "@" in email and "." in email.split("@")[-1]
 
 
+def _has_user_deletion_clearance(user):
+    """Require top-level approval for destructive user erasure."""
+    return bool(getattr(user, "global_admin", False)) or getattr(user, "role", None) in {
+        "global_admin",
+        "god",
+    }
+
+
+def _user_deletion_clearance_error():
+    return "Käyttäjän poisto on erittäin vaativa toimenpide ja vaatii ylimmän hyväksynnän."
+
+
+def _build_user_erasure_plan(user_id, user_data):
+    """Build the collection queries used for user erasure."""
+    user_object_id = ObjectId(user_id)
+    user_id_str = str(user_object_id)
+    username = user_data.get("username")
+    email = user_data.get("email")
+
+    email_queries = []
+    if email:
+        email_queries = [
+            {"email": email},
+            {"username": email},
+            {"user_email": email},
+            {"reporter_email": email},
+            {"submitter.email": email},
+            {"submitter_email": email},
+            {"suggested_by.email": email},
+            {"form_snapshot.email": email},
+            {"form_snapshot.user_email": email},
+            {"form_snapshot.reporter_email": email},
+            {"form_snapshot.submitter_email": email},
+            {"query_args.email": email},
+            {"query_args.user_email": email},
+        ]
+
+    username_queries = []
+    if username:
+        username_queries = [
+            {"username": username},
+            {"user.username": username},
+            {"form_snapshot.username": username},
+        ]
+
+    submitter_lookup = {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}, *email_queries]}
+    submitted_demo_ids = set()
+    for submitter in mongo.submitters.find(submitter_lookup, {"demonstration_id": 1}):
+        demo_id = submitter.get("demonstration_id")
+        if demo_id:
+            submitted_demo_ids.add(demo_id)
+            submitted_demo_ids.add(str(demo_id))
+
+    case_lookup = {"$or": [{"submitter_id": user_object_id}, {"submitter_id": user_id_str}, *email_queries]}
+    for case in mongo.cases.find(case_lookup, {"demo_id": 1}):
+        demo_id = case.get("demo_id")
+        if demo_id:
+            submitted_demo_ids.add(demo_id)
+            submitted_demo_ids.add(str(demo_id))
+
+    submitted_demo_object_ids = [
+        demo_id for demo_id in submitted_demo_ids if isinstance(demo_id, ObjectId)
+    ]
+    for demo_id in list(submitted_demo_ids):
+        if isinstance(demo_id, str):
+            try:
+                submitted_demo_object_ids.append(ObjectId(demo_id))
+            except Exception:
+                pass
+    submitted_demo_object_ids = list({demo_id for demo_id in submitted_demo_object_ids})
+    submitted_demo_strings = [str(demo_id) for demo_id in submitted_demo_object_ids]
+
+    cleanup_plan = [
+        ("user_settings", {"user_id": user_object_id}),
+        ("login_logs", {"$or": [{"user_id": user_object_id}, *username_queries, *email_queries]}),
+        (
+            "password_changes",
+            {
+                "$or": [
+                    {"user_id": user_object_id},
+                    {"user_id": user_id_str},
+                    *email_queries,
+                ]
+            },
+        ),
+        (
+            "demo_reminders",
+            {
+                "$or": [
+                    {"user_id": user_object_id},
+                    {"user_id": user_id_str},
+                    *email_queries,
+                ]
+            },
+        ),
+        (
+            "reports",
+            {
+                "$or": [
+                    {"user": user_object_id},
+                    {"user": user_id_str},
+                    *email_queries,
+                ]
+            },
+        ),
+        ("malicious_reports", {"$or": email_queries or [{"_id": None}]}),
+        ("demo_submission_errors", {"$or": [{"user.id": user_id_str}, *username_queries, *email_queries]}),
+        ("notifications", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}]}),
+        ("messages", {"$or": [{"sender_id": user_object_id}, {"recipient_id": user_object_id}]}),
+        ("memberships", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}]}),
+        ("api_tokens", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}]}),
+        ("api_token_requests", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}, *username_queries]}),
+        ("developer_apps", {"$or": [{"owner_id": user_object_id}, {"owner_id": user_id_str}]}),
+        ("developer_scope_requests", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}]}),
+        ("account_deletion_requests", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}, *email_queries]}),
+        ("submitters", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}, *email_queries]}),
+        ("demo_suggestions", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}, *email_queries]}),
+        ("cases", {"$or": [{"submitter_id": user_object_id}, {"submitter_id": user_id_str}, *email_queries]}),
+        ("board_audit_logs", {"$or": [{"user_id": user_object_id}, {"user_id": user_id_str}]}),
+    ]
+
+    return {
+        "cleanup_plan": cleanup_plan,
+        "submitted_demo_object_ids": submitted_demo_object_ids,
+        "submitted_demo_strings": submitted_demo_strings,
+        "user_object_id": user_object_id,
+        "user_id_str": user_id_str,
+    }
+
+
+def _calculate_user_erasure_impact(user_id, user_data):
+    """Count records that would be removed with the user."""
+    plan = _build_user_erasure_plan(user_id, user_data)
+    collection_counts = {}
+    for collection_name, query in plan["cleanup_plan"]:
+        if query.get("$or") == []:
+            continue
+        count = mongo[collection_name].count_documents(query)
+        if count:
+            collection_counts[collection_name] = count
+
+    user_object_id = plan["user_object_id"]
+    user_id_str = plan["user_id_str"]
+    relationship_query = {
+        "$or": [
+            {"friends.user_id": {"$in": [user_object_id, user_id_str]}},
+            {"friend_requests.user_id": {"$in": [user_object_id, user_id_str]}},
+            {"friend_requests.sent_by": {"$in": [user_object_id, user_id_str]}},
+            {"followers": {"$in": [user_object_id, user_id_str]}},
+            {"following": {"$in": [user_object_id, user_id_str]}},
+        ]
+    }
+
+    return {
+        "collections": collection_counts,
+        "submitted_demonstrations": len(plan["submitted_demo_object_ids"]),
+        "submitted_demonstration_ids": plan["submitted_demo_strings"],
+        "submitted_demonstrations_deleted": 0,
+        "relationship_documents": mongo.users.count_documents(relationship_query),
+        "demonstration_editor_links": mongo.demonstrations.count_documents(
+            {"editors": {"$in": [user_object_id, user_id_str]}}
+        ),
+        "total_collection_records": sum(collection_counts.values()),
+    }
+
+
+def _delete_user_personal_data(user_id, user_data):
+    """Delete records that directly identify the removed user."""
+    plan = _build_user_erasure_plan(user_id, user_data)
+    user_object_id = plan["user_object_id"]
+    user_id_str = plan["user_id_str"]
+
+    deleted_counts = {}
+    for collection_name, query in plan["cleanup_plan"]:
+        if query.get("$or") == []:
+            continue
+        result = mongo[collection_name].delete_many(query)
+        if result.deleted_count:
+            deleted_counts[collection_name] = result.deleted_count
+
+    mongo.users.update_many(
+        {},
+        {
+            "$pull": {
+                "friends": {"user_id": {"$in": [user_object_id, user_id_str]}},
+                "friend_requests": {"user_id": {"$in": [user_object_id, user_id_str]}},
+                "followers": {"$in": [user_object_id, user_id_str]},
+                "following": {"$in": [user_object_id, user_id_str]},
+            }
+        },
+    )
+    mongo.users.update_many(
+        {},
+        {"$pull": {"friend_requests": {"sent_by": {"$in": [user_object_id, user_id_str]}}}},
+    )
+
+    mongo.demonstrations.update_many(
+        {"editors": {"$in": [user_object_id, user_id_str]}},
+        {"$pull": {"editors": {"$in": [user_object_id, user_id_str]}}},
+    )
+
+    return deleted_counts
+
+
+@admin_user_bp.route("/delete_user/impact/<user_id>", methods=["GET"])
+@login_required
+@admin_required
+@permission_required("DELETE_USER")
+def delete_user_impact(user_id):
+    """Return the records affected by deleting a user."""
+    if not _has_user_deletion_clearance(current_user):
+        return jsonify({"status": "ERROR", "message": _user_deletion_clearance_error()}), 403
+
+    try:
+        user_object_id = ObjectId(user_id)
+    except Exception:
+        return jsonify({"status": "ERROR", "message": "Virheellinen käyttäjän tunniste."}), 400
+
+    user_data = mongo.users.find_one({"_id": user_object_id})
+    if not user_data:
+        return jsonify({"status": "ERROR", "message": "Käyttäjää ei löydy."}), 404
+
+    target_user = User.from_db(user_data)
+    if compare_user_levels(current_user, target_user) is False:
+        return jsonify(
+            {
+                "status": "ERROR",
+                "message": "Et voi poistaa käyttäjää, jolla on korkeampi käyttöoikeustaso kuin sinulla.",
+            }
+        ), 403
+
+    return jsonify(
+        {
+            "status": "OK",
+            "impact": _calculate_user_erasure_impact(user_id, user_data),
+        }
+    )
+
+
 # Delete user
 @admin_user_bp.route("/delete_user", methods=["POST"])
 @login_required
@@ -413,8 +652,26 @@ def delete_user():
             else redirect(request.referrer or url_for("admin_user.user_control"))
         )
 
+    if not _has_user_deletion_clearance(current_user):
+        error_message = _user_deletion_clearance_error()
+        if json_mode:
+            return jsonify({"status": "ERROR", "message": error_message}), 403
+        else:
+            flash_message(error_message, "error")
+            return redirect(request.referrer or url_for("admin_user.user_control"))
+
+    try:
+        user_object_id = ObjectId(user_id)
+    except Exception:
+        error_message = "Virheellinen käyttäjän tunniste."
+        if json_mode:
+            return jsonify({"status": "ERROR", "message": error_message})
+        else:
+            flash_message(error_message, "error")
+            return redirect(request.referrer or url_for("admin_user.user_control"))
+
     # Fetch the user from the database
-    user_data = mongo.users.find_one({"_id": ObjectId(user_id)})
+    user_data = mongo.users.find_one({"_id": user_object_id})
 
     if not user_data:
         error_message = "Käyttäjää ei löydy."
@@ -435,7 +692,8 @@ def delete_user():
             return redirect(request.referrer or url_for("admin_user.user_control"))
 
     # Perform deletion
-    mongo.users.delete_one({"_id": ObjectId(user_id)})
+    _delete_user_personal_data(user_id, user_data)
+    mongo.users.delete_one({"_id": user_object_id})
 
     success_message = "Käyttäjä poistettu onnistuneesti."
     if json_mode:

--- a/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
@@ -31,6 +31,13 @@
       </div>
       <div class="modal-body">
         <p>{{ _('Haluatko poistaa käyttäjän:') }} <strong id="userTitle"></strong>?</p>
+        <div id="deleteImpactBox" class="alert alert-warning" role="alert">
+          <div class="d-flex align-items-center gap-2">
+            <span class="spinner-border spinner-border-sm" id="deleteImpactSpinner" aria-hidden="true"></span>
+            <strong>{{ _('Lasketaan poiston vaikutuksia...') }}</strong>
+          </div>
+          <div id="deleteImpactContent" class="mt-2"></div>
+        </div>
         <div id="vahvistaContainer" style="margin-top:15px;">
           <label for="confirmInput">{{ _('Kirjoita VAHVISTA vahvistaaksesi poiston') }}</label>
           <input type="text" id="confirmInput" class="form-control">
@@ -58,6 +65,10 @@
     const finalDeleteBtn = document.getElementById('finalDeleteBtn');
     const countdownText = document.getElementById('countdownText');
     const cancelBtn = document.getElementById('cancelDeleteBtn');
+    const impactBox = document.getElementById('deleteImpactBox');
+    const impactSpinner = document.getElementById('deleteImpactSpinner');
+    const impactContent = document.getElementById('deleteImpactContent');
+    let impactLoaded = false;
 
     // Reset modal
     userTitle.textContent = username;
@@ -65,8 +76,51 @@
     finalDeleteBtn.disabled = true;
     countdownText.style.display = "none";
     countdownText.textContent = "";
+    impactBox.className = "alert alert-warning";
+    impactSpinner.style.display = "inline-block";
+    impactContent.innerHTML = "";
     clearInterval(countdown3Sec);
     clearInterval(countdownInterval);
+
+    fetch(`{{ url_for('admin_user.delete_user_impact', user_id='__USER_ID__') }}`.replace('__USER_ID__', encodeURIComponent(userId)))
+      .then(res => res.json())
+      .then(data => {
+        impactSpinner.style.display = "none";
+        if (data.status !== "OK") {
+          impactBox.className = "alert alert-danger";
+          impactContent.textContent = data.message || "Poiston vaikutuksia ei voitu laskea.";
+          return;
+        }
+
+        const impact = data.impact || {};
+        const collections = impact.collections || {};
+        const collectionRows = Object.entries(collections)
+          .filter(([, count]) => count > 0)
+          .map(([name, count]) => `<li><strong>${name}</strong>: ${count}</li>`)
+          .join("");
+        const submittedCount = impact.submitted_demonstrations || 0;
+        const totalRecords = impact.total_collection_records || 0;
+        const relationshipDocs = impact.relationship_documents || 0;
+        const editorLinks = impact.demonstration_editor_links || 0;
+
+        impactContent.innerHTML = `
+          <p class="mb-2"><strong>Tämä poisto vaikuttaa seuraaviin tietoihin:</strong></p>
+          <ul class="mb-2">
+            <li>Käyttäjätili poistetaan.</li>
+            <li>${submittedCount} käyttäjän ilmoittamaa mielenosoitusta jää erillisen tukiarvion piiriin eikä poistu automaattisesti.</li>
+            <li>${totalRecords} suoraan liittyvää tietoriviä poistetaan eri kokoelmista.</li>
+            <li>${relationshipDocs} muun käyttäjän ystävä-/seuraussuhderiviä siivotaan.</li>
+            <li>${editorLinks} mielenosoituksen editoriviittausta siivotaan.</li>
+          </ul>
+          ${collectionRows ? `<details><summary>Näytä poistettavat kokoelmat</summary><ul class="mb-0 mt-2">${collectionRows}</ul></details>` : ""}
+        `;
+        impactLoaded = true;
+      })
+      .catch(() => {
+        impactSpinner.style.display = "none";
+        impactBox.className = "alert alert-danger";
+        impactContent.textContent = "Poiston vaikutuksia ei voitu laskea yhteysvirheen vuoksi.";
+      });
 
     // Cancel button stops everything
     const stopAll = () => {
@@ -84,6 +138,12 @@
       clearInterval(countdown3Sec);
       finalDeleteBtn.disabled = true;
       countdownText.style.display = "none";
+
+      if (!impactLoaded) {
+        countdownText.style.display = "block";
+        countdownText.textContent = "Odota, että poiston vaikutusarvio latautuu.";
+        return;
+      }
 
       if (confirmInput.value.toUpperCase() === "VAHVISTA") {
         let countdown = 3;

--- a/mielenosoitukset_fi/templates/admin_V2/_users_table.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_users_table.html
@@ -77,13 +77,20 @@
             </li>
             {% endif %}
 
-            {% if current_user.has_permission("DELETE_USER") %}
+            {% if current_user.has_permission("DELETE_USER") and (current_user.global_admin or current_user.role in ["global_admin", "god"]) %}
             <li>
               <button class="dropdown-item text-danger" type="button"
                       onclick="openDeleteModal(event, '{{ user.displayname or user.username }}', '{{ user._id }}', 'user')"
                       data-bs-toggle="tooltip" title="{{ _('Poista käyttäjä') }}">
                 <i class="fas fa-trash-alt me-2"></i>{{ _('Poista') }}
               </button>
+            </li>
+            {% elif current_user.has_permission("DELETE_USER") %}
+            <li>
+              <span class="dropdown-item disabled text-muted"
+                    data-bs-toggle="tooltip" title="{{ _('Käyttäjän poisto vaatii ylimmän hyväksynnän') }}">
+                <i class="fas fa-lock me-2"></i>{{ _('Poisto vaatii ylimmän hyväksynnän') }}
+              </span>
             </li>
             {% endif %}
 

--- a/mielenosoitukset_fi/templates/emails/account_deletion_request.html
+++ b/mielenosoitukset_fi/templates/emails/account_deletion_request.html
@@ -1,0 +1,54 @@
+{% extends "admin_email_base.html" %}
+{% set eyebrow = "Tietosuojapyyntö" %}
+{% set heading = "Käyttäjä pyytää tilinsä poistamista" %}
+
+{% block subject %}Käyttäjä pyytää tilin poistoa{% endblock %}
+
+{% block body %}
+<p>
+    Käyttäjä on lähettänyt pyynnön tilinsä poistamisesta omalta asetussivultaan.
+    Tarkista pyyntö, arvioi vaikutukset admin-paneelissa ja käsittele tilin poisto ylimmän hyväksynnän prosessin mukaisesti.
+    Jos käyttäjän ilmoittamia julkisia mielenosoituksia pitää poistaa tai muuttaa, tee se erillisenä päätöksenä vaikutusarvion jälkeen.
+</p>
+
+<ul class="data-list">
+    <li>
+        <strong>Käyttäjä-ID</strong>
+        {{ request_doc.user_id }}
+    </li>
+    <li>
+        <strong>Käyttäjänimi</strong>
+        {{ request_doc.username }}
+    </li>
+    <li>
+        <strong>Näyttönimi</strong>
+        {{ request_doc.displayname or "ei asetettu" }}
+    </li>
+    <li>
+        <strong>Sähköposti</strong>
+        {{ request_doc.email or "ei asetettu" }}
+    </li>
+    {% if request_doc.reason %}
+    <li>
+        <strong>Käyttäjän lisätiedot</strong>
+        {{ request_doc.reason }}
+    </li>
+    {% endif %}
+    <li>
+        <strong>IP-osoite</strong>
+        {{ request_doc.ip or "ei saatavilla" }}
+    </li>
+    <li>
+        <strong>User-Agent</strong>
+        {{ request_doc.user_agent or "ei saatavilla" }}
+    </li>
+    <li>
+        <strong>Vastaanotettu</strong>
+        {{ request_doc.created_at.strftime('%d.%m.%Y %H:%M UTC') if request_doc.created_at else "ei saatavilla" }}
+    </li>
+</ul>
+
+<div class="btn-group">
+    <a class="btn btn-danger" href="{{ admin_user_url }}">Avaa käyttäjä adminissa</a>
+</div>
+{% endblock %}

--- a/mielenosoitukset_fi/templates/privacy.html
+++ b/mielenosoitukset_fi/templates/privacy.html
@@ -61,6 +61,8 @@
       <li><strong>{{ _('Oikeus rajoittaa käsittelyä') }}</strong>: {{ _('voit pyytää tietojesi käsittelyn rajoittamista tietyissä tilanteissa.') }}</li>
       <li><strong>{{ _('Oikeus vastustaa') }}</strong>: {{ _('sinulla on oikeus vastustaa tietojesi käsittelyä tietyissä tilanteissa.') }}</li>
     </ul>
+    <p>{{ _('Voit pyytää käyttäjätilisi poistamista omalta asetussivultasi. Poistopyyntö lähetetään asiakastukeen käsiteltäväksi, koska tilin poistaminen voi vaikuttaa myös julkisesti ilmoitettuihin mielenosoituksiin.') }}</p>
+    <p>{{ _('Jos käyttäjätilisi poistetaan, poistamme sinuun liittyvät henkilötiedot ja ilmoittajatiedot. Tililläsi ilmoitettuja julkisia mielenosoituksia ei poisteta automaattisesti pelkän tilin poiston vuoksi, mutta tuki arvioi erikseen, pitääkö myös tapahtumatietoja poistaa tai muuttaa.') }}</p>
   </section>
   <section class="section-card">
     <h2>{{ _('Evästeiden käyttö') }}</h2>

--- a/mielenosoitukset_fi/templates/users/auth/settings.html
+++ b/mielenosoitukset_fi/templates/users/auth/settings.html
@@ -600,6 +600,48 @@
           </table>
         </div>
       </div>
+
+      <div class="settings-section border border-danger">
+        <h5 class="text-danger"><i class="fas fa-user-slash"></i> {{ _('Tilin poisto') }}</h5>
+        <p class="text-muted">
+          {{ _('Voit pyytää käyttäjätilisi poistamista. Pyyntö lähetetään asiakastukeen, koska tilin poistaminen poistaa henkilötietojasi ja voi vaatia myös ilmoittamiesi mielenosoitusten erillistä arviointia.') }}
+        </p>
+        <div class="alert alert-danger">
+          <i class="fa-solid fa-triangle-exclamation me-2"></i>
+          <strong>{{ _('Tämä on tuhoisa ja vaikeasti peruttava toimenpide.') }}</strong>
+          <ul class="mb-0 mt-2">
+            <li>{{ _('Tilisi ja siihen liittyvät henkilötiedot voidaan poistaa pysyvästi.') }}</li>
+            <li>{{ _('Ilmoittajatietosi ja tukipyyntöihin liittyvät henkilötietosi poistetaan tai käsitellään tietosuojaprosessin mukaisesti.') }}</li>
+            <li>{{ _('Tililläsi ilmoittamiasi julkisia mielenosoituksia ei poisteta automaattisesti, mutta tuki arvioi erikseen, pitääkö tapahtumatietoja poistaa tai muuttaa.') }}</li>
+            <li>{{ _('Pyyntö voi vaikuttaa myös muihin käyttäjiin, järjestäjiin ja sivustolla julkaistuihin tapahtumatietoihin.') }}</li>
+          </ul>
+        </div>
+        <div class="alert alert-warning">
+          <i class="fa-solid fa-circle-info me-2"></i>
+          {{ _('Tämä nappi ei poista tiliä heti. Se lähettää tukipyynnön, jonka ylläpito käsittelee vaikutusarvion ja ylimmän hyväksynnän kautta.') }}
+        </div>
+        <form id="account-deletion-form">
+          <div class="mb-3">
+            <label class="form-label" for="account-deletion-reason">{{ _('Lisätiedot tuelle') }}</label>
+            <textarea class="form-control" id="account-deletion-reason" rows="3"
+                      placeholder="{{ _('Voit kertoa esimerkiksi, haluatko samalla poistaa ilmoittamasi mielenosoitukset.') }}"></textarea>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="account-deletion-confirmation">
+              {{ _('Vahvista pyyntö kirjoittamalla täsmälleen:') }}
+            </label>
+            <code class="d-block mb-2">YMMÄRRÄN ETTÄ TILIN POISTO ON PYSYVÄ JA VOI VAIKUTTAA ILMOITTAMIINI MIELENOSOITUKSIIN</code>
+            <input class="form-control" id="account-deletion-confirmation" type="text" autocomplete="off"
+                   aria-describedby="account-deletion-confirmation-help">
+            <div class="form-text" id="account-deletion-confirmation-help">
+              {{ _('Vahvistuslause vaaditaan, jotta on selvää että ymmärrät pyynnön mahdolliset seuraukset.') }}
+            </div>
+          </div>
+          <button class="btn btn-danger" id="account-deletion-submit" type="submit">
+            <i class="fa-solid fa-paper-plane me-1"></i> {{ _('Lähetä poistopyyntö asiakastukeen') }}
+          </button>
+        </form>
+      </div>
     </div>
 
     <!-- Profiili Tab -->
@@ -734,6 +776,46 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", () => {
+    const accountDeletionForm = document.getElementById("account-deletion-form");
+    const accountDeletionReason = document.getElementById("account-deletion-reason");
+    const accountDeletionConfirmation = document.getElementById("account-deletion-confirmation");
+    const accountDeletionSubmit = document.getElementById("account-deletion-submit");
+    const accountDeletionRequiredConfirmation = "YMMÄRRÄN ETTÄ TILIN POISTO ON PYSYVÄ JA VOI VAIKUTTAA ILMOITTAMIINI MIELENOSOITUKSIIN";
+
+    accountDeletionForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      hideSettingsMessage();
+
+      if (accountDeletionConfirmation.value.trim().toUpperCase() !== accountDeletionRequiredConfirmation) {
+        showSettingsMessage("{{ _('Kirjoita koko vahvistuslause lähettääksesi poistopyynnön.') }}");
+        return;
+      }
+
+      accountDeletionSubmit.disabled = true;
+      try {
+        const response = await fetch("/users/auth/api/v2/account_deletion_request", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            confirmation: accountDeletionConfirmation.value,
+            reason: accountDeletionReason.value
+          })
+        });
+        const result = await response.json();
+        if (result.status === "success") {
+          showSettingsMessage(result.message, "success");
+          accountDeletionForm.reset();
+        } else {
+          showSettingsMessage(result.message || "{{ _('Poistopyynnön lähettäminen epäonnistui.') }}");
+        }
+      } catch (error) {
+        console.error(error);
+        showSettingsMessage("{{ _('Poistopyynnön lähettäminen epäonnistui yhteysvirheen vuoksi.') }}");
+      } finally {
+        accountDeletionSubmit.disabled = false;
+      }
+    });
+
     const profileForm = document.getElementById("profile-form");
     const bioInput = document.getElementById("bio");
     const fileInput = document.getElementById("profile-pic");

--- a/mielenosoitukset_fi/users/BPs/auth.py
+++ b/mielenosoitukset_fi/users/BPs/auth.py
@@ -877,7 +877,7 @@ def account_deletion_request():
         "email": user.email,
         "reason": reason,
         "status": "pending",
-        "created_at": datetime.datetime.utcnow(),
+        "created_at": datetime.utcnow(),
         "ip": request.remote_addr,
         "user_agent": request.headers.get("User-Agent", ""),
     }
@@ -1058,7 +1058,7 @@ def mfa_setup_api():
                 "user_id": user._id,
                 "secret": secret,
                 "device_name": device_name,
-                "created_at": datetime.datetime.utcnow()
+                "created_at": datetime.utcnow()
             })
             PendingMFA.delete(user._id, secret)
             user.mfa_enabled = True

--- a/mielenosoitukset_fi/users/BPs/auth.py
+++ b/mielenosoitukset_fi/users/BPs/auth.py
@@ -843,6 +843,78 @@ def process_settings_change(user, changed_fields):
         print("Updated display name to the user object too")
         user.save()
 
+
+@auth_bp.route("/api/v2/account_deletion_request", methods=["POST"])
+@login_required
+def account_deletion_request():
+    """Let the current user request account deletion from support."""
+    user = current_user
+    payload = request.get_json(silent=True) or {}
+    confirmation = (payload.get("confirmation") or "").strip().upper()
+    reason = (payload.get("reason") or "").strip()
+    required_confirmation = "YMMÄRRÄN ETTÄ TILIN POISTO ON PYSYVÄ JA VOI VAIKUTTAA ILMOITTAMIINI MIELENOSOITUKSIIN"
+
+    if confirmation != required_confirmation:
+        return jsonify({
+            "status": "error",
+            "message": "Kirjoita koko vahvistuslause lähettääksesi poistopyynnön.",
+        }), 400
+
+    existing = mongo.account_deletion_requests.find_one({
+        "user_id": ObjectId(user._id),
+        "status": {"$in": ["pending", "open"]},
+    })
+    if existing:
+        return jsonify({
+            "status": "success",
+            "message": "Poistopyyntösi on jo vastaanotettu. Tuki käsittelee sen mahdollisimman pian.",
+        })
+
+    request_doc = {
+        "user_id": ObjectId(user._id),
+        "username": user.username,
+        "displayname": getattr(user, "displayname", None),
+        "email": user.email,
+        "reason": reason,
+        "status": "pending",
+        "created_at": datetime.datetime.utcnow(),
+        "ip": request.remote_addr,
+        "user_agent": request.headers.get("User-Agent", ""),
+    }
+    result = mongo.account_deletion_requests.insert_one(request_doc)
+    request_doc["_id"] = result.inserted_id
+
+    try:
+        email_sender.queue_email(
+            template_name="account_deletion_request.html",
+            subject="Käyttäjä pyytää tilin poistoa",
+            recipients=["tuki@mielenosoitukset.fi"],
+            context={
+                "request_doc": request_doc,
+                "admin_user_url": url_for(
+                    "admin_user.edit_user",
+                    user_id=str(user._id),
+                    _external=True,
+                ),
+            },
+        )
+    except Exception as exc:
+        current_app.logger.exception("Failed to send account deletion request email")
+        mongo.account_deletion_requests.update_one(
+            {"_id": result.inserted_id},
+            {"$set": {"email_error": str(exc)}},
+        )
+        return jsonify({
+            "status": "error",
+            "message": "Poistopyyntö tallennettiin, mutta tukiviestin lähetys epäonnistui. Ota yhteyttä tukeen.",
+        }), 500
+
+    return jsonify({
+        "status": "success",
+        "message": "Poistopyyntö on lähetetty asiakastukeen. Saat vahvistuksen, kun tuki käsittelee pyynnön.",
+    })
+
+
 @auth_bp.route("/api/v2/settings", methods=["GET", "POST"])
 @login_required
 def settings_api_v2():

--- a/tests/surface_manifest.json
+++ b/tests/surface_manifest.json
@@ -65,8 +65,8 @@
       ]
     },
     "mielenosoitukset_fi/admin/admin_user_bp.py": {
-      "count": 8,
-      "sha256": "df393544e63f55eebd24b19860edc017182a07831612299decd842d54b59954e",
+      "count": 9,
+      "sha256": "ad077cf655dd3a5933e75567b21719d70fe14401a06cf97eb587f896c17c65a9",
       "coverage": [
         "integration",
         "e2e-admin"
@@ -150,8 +150,8 @@
       ]
     },
     "mielenosoitukset_fi/users/BPs/auth.py": {
-      "count": 29,
-      "sha256": "bd8f1297aa0d8d5129ec0a3bba7249024c63f534c5369c51cad91128a008e2d1",
+      "count": 30,
+      "sha256": "70f3a7c19cd270193339c6857889e81cb1ec053c89b176aa5e9467b4a7b3424e",
       "coverage": [
         "integration",
         "e2e-auth"

--- a/tests/test_account_deletion_request.py
+++ b/tests/test_account_deletion_request.py
@@ -1,0 +1,75 @@
+import importlib
+
+
+DESTRUCTIVE_CONFIRMATION = "YMMÄRRÄN ETTÄ TILIN POISTO ON PYSYVÄ JA VOI VAIKUTTAA ILMOITTAMIINI MIELENOSOITUKSIIN"
+
+
+class CapturingEmailSender:
+    def __init__(self):
+        self.messages = []
+
+    def queue_email(self, **kwargs):
+        self.messages.append(kwargs)
+
+
+def test_account_deletion_request_requires_confirmation(user_client, db, seeded_data):
+    response = user_client.post(
+        "/users/auth/api/v2/account_deletion_request",
+        json={"confirmation": "POISTA", "reason": "Haluan poistaa tilini."},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["status"] == "error"
+    assert db.account_deletion_requests.count_documents({"user_id": seeded_data["user_id"]}) == 0
+
+
+def test_account_deletion_request_records_request_and_emails_support(
+    user_client,
+    db,
+    seeded_data,
+    monkeypatch,
+):
+    auth_module = importlib.import_module("mielenosoitukset_fi.users.BPs.auth")
+    sender = CapturingEmailSender()
+    monkeypatch.setattr(auth_module, "email_sender", sender, raising=True)
+
+    response = user_client.post(
+        "/users/auth/api/v2/account_deletion_request",
+        json={"confirmation": DESTRUCTIVE_CONFIRMATION, "reason": "Haluan poistaa tilini."},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "success"
+
+    request_doc = db.account_deletion_requests.find_one({"user_id": seeded_data["user_id"]})
+    assert request_doc is not None
+    assert request_doc["email"] == "alice@example.test"
+    assert request_doc["status"] == "pending"
+    assert request_doc["reason"] == "Haluan poistaa tilini."
+
+    assert len(sender.messages) == 1
+    message = sender.messages[0]
+    assert message["template_name"] == "account_deletion_request.html"
+    assert message["recipients"] == ["tuki@mielenosoitukset.fi"]
+    assert str(seeded_data["user_id"]) in message["context"]["admin_user_url"]
+
+
+def test_account_deletion_request_does_not_duplicate_open_requests(
+    user_client,
+    db,
+    seeded_data,
+    monkeypatch,
+):
+    auth_module = importlib.import_module("mielenosoitukset_fi.users.BPs.auth")
+    sender = CapturingEmailSender()
+    monkeypatch.setattr(auth_module, "email_sender", sender, raising=True)
+
+    for _ in range(2):
+        response = user_client.post(
+            "/users/auth/api/v2/account_deletion_request",
+            json={"confirmation": DESTRUCTIVE_CONFIRMATION, "reason": "Tuplapyyntö."},
+        )
+        assert response.status_code == 200
+
+    assert db.account_deletion_requests.count_documents({"user_id": seeded_data["user_id"]}) == 1
+    assert len(sender.messages) == 1

--- a/tests/test_admin_user_bp.py
+++ b/tests/test_admin_user_bp.py
@@ -143,7 +143,7 @@ def test_delete_user_removes_direct_personal_data(admin_client, db, seeded_data)
     assert db.demo_submission_tokens.count_documents({"demo_id": pending_demo_id}) == 1
     assert db.demo_cancellation_tokens.count_documents({"demo_id": pending_demo_id}) == 1
     assert db.demo_audit_logs.count_documents({"demo_id": str(pending_demo_id)}) == 1
-    assert db.magic_links.count_documents({"demo_id": str(pending_demo_id)}) == 1
+    assert db.magic_links.find_one({"demo_id": str(pending_demo_id), "action": "preview"}) is not None
     assert db.users.count_documents({"friends.user_id": user_id}) == 0
     assert db.users.count_documents({"friend_requests.sent_by": user_id}) == 0
     assert db.demonstrations.count_documents({"editors": user_id}) == 0

--- a/tests/test_admin_user_bp.py
+++ b/tests/test_admin_user_bp.py
@@ -79,3 +79,136 @@ def test_user_control_searches_display_names(admin_client, db, seeded_data):
     body = response.get_data(as_text=True)
     assert "Friendly Admin" in body
     assert "displayname-search-user" in body
+
+
+def test_delete_user_removes_direct_personal_data(admin_client, db, seeded_data):
+    user_id = seeded_data["user_id"]
+    user_id_str = str(user_id)
+    pending_demo_id = seeded_data["pending_demo_id"]
+
+    db.user_settings.insert_one({"user_id": user_id, "language": "fi"})
+    db.password_changes.insert_one({"email": "alice@example.test", "token": "raw-reset-token"})
+    db.password_changes.insert_one({"user_id": user_id, "method": "settings_page", "ip": "127.0.0.1"})
+    db.demo_reminders.insert_one({"demonstration_id": pending_demo_id, "user_email": "alice@example.test", "user_ip": "127.0.0.1"})
+    db.reports.insert_one({"demo_id": pending_demo_id, "user": user_id, "reporter_email": "alice@example.test"})
+    db.malicious_reports.insert_one({"user_email": "alice@example.test", "ip": "127.0.0.1"})
+    db.demo_submission_errors.insert_one(
+        {
+            "user": {"id": user_id_str, "username": "alice"},
+            "form_snapshot": {"submitter_email": "alice@example.test"},
+        }
+    )
+    db.api_token_requests.insert_one({"user_id": user_id, "username": "alice"})
+    db.developer_apps.insert_one({"owner_id": user_id, "name": "Alice app"})
+    db.developer_scope_requests.insert_one({"user_id": user_id, "scopes": ["write"]})
+    db.account_deletion_requests.insert_one({"user_id": user_id, "email": "alice@example.test", "status": "pending"})
+    db.demo_submission_tokens.insert_one({"token": "alice-submission", "demo_id": pending_demo_id})
+    db.demo_cancellation_tokens.insert_one({"token_hash": "alice-cancel", "demo_id": pending_demo_id})
+    db.demo_audit_logs.insert_one({"demo_id": str(pending_demo_id), "action": "created"})
+    db.magic_links.insert_one({"demo_id": str(pending_demo_id), "action": "preview"})
+    db.users.update_one(
+        {"_id": seeded_data["friend_id"]},
+        {"$push": {"friend_requests": {"sent_by": user_id, "sent_ip": "127.0.0.1"}}},
+    )
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$addToSet": {"editors": user_id_str}},
+    )
+
+    response = admin_client.post("/admin/user/delete_user", data={"user_id": user_id_str})
+
+    assert response.status_code == 302
+    assert db.users.find_one({"_id": user_id}) is None
+    assert db.demonstrations.find_one({"_id": pending_demo_id}) is not None
+    assert db.user_settings.count_documents({"user_id": user_id}) == 0
+    assert db.login_logs.count_documents({"user_id": user_id}) == 0
+    assert db.password_changes.count_documents({"email": "alice@example.test"}) == 0
+    assert db.password_changes.count_documents({"user_id": user_id}) == 0
+    assert db.demo_reminders.count_documents({"demonstration_id": pending_demo_id}) == 0
+    assert db.reports.count_documents({"$or": [{"user": user_id}, {"reporter_email": "alice@example.test"}]}) == 0
+    assert db.malicious_reports.count_documents({"user_email": "alice@example.test"}) == 0
+    assert db.demo_submission_errors.count_documents({"user.id": user_id_str}) == 0
+    assert db.notifications.count_documents({"user_id": user_id}) == 0
+    assert db.messages.count_documents({"recipient_id": user_id}) == 0
+    assert db.memberships.count_documents({"user_id": user_id}) == 0
+    assert db.api_tokens.count_documents({"user_id": user_id}) == 0
+    assert db.api_token_requests.count_documents({"user_id": user_id}) == 0
+    assert db.developer_apps.count_documents({"owner_id": user_id}) == 0
+    assert db.developer_scope_requests.count_documents({"user_id": user_id}) == 0
+    assert db.account_deletion_requests.count_documents({"user_id": user_id}) == 0
+    assert db.submitters.count_documents({"submitter_email": "alice@example.test"}) == 0
+    assert db.demo_suggestions.count_documents({"suggested_by.email": "alice@example.test"}) == 0
+    assert db.cases.count_documents({"submitter_id": user_id}) == 0
+    assert db.board_audit_logs.count_documents({"user_id": user_id_str}) == 0
+    assert db.demo_submission_tokens.count_documents({"demo_id": pending_demo_id}) == 1
+    assert db.demo_cancellation_tokens.count_documents({"demo_id": pending_demo_id}) == 1
+    assert db.demo_audit_logs.count_documents({"demo_id": str(pending_demo_id)}) == 1
+    assert db.magic_links.count_documents({"demo_id": str(pending_demo_id)}) == 1
+    assert db.users.count_documents({"friends.user_id": user_id}) == 0
+    assert db.users.count_documents({"friend_requests.sent_by": user_id}) == 0
+    assert db.demonstrations.count_documents({"editors": user_id}) == 0
+    assert db.demonstrations.count_documents({"editors": user_id_str}) == 0
+
+
+def test_delete_user_impact_reports_submitted_demo_cleanup(admin_client, db, seeded_data):
+    user_id = seeded_data["user_id"]
+    user_id_str = str(user_id)
+    pending_demo_id = seeded_data["pending_demo_id"]
+
+    db.demo_submission_tokens.insert_one({"token": "alice-impact-submission", "demo_id": pending_demo_id})
+    db.demo_audit_logs.insert_one({"demo_id": str(pending_demo_id), "action": "created"})
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$addToSet": {"editors": user_id_str}},
+    )
+
+    response = admin_client.get(f"/admin/user/delete_user/impact/{user_id}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "OK"
+    impact = payload["impact"]
+    assert impact["submitted_demonstrations"] == 1
+    assert str(pending_demo_id) in impact["submitted_demonstration_ids"]
+    assert impact["collections"]["submitters"] == 1
+    assert impact["submitted_demonstrations_deleted"] == 0
+    assert "demonstrations" not in impact["collections"]
+    assert "demo_submission_tokens" not in impact["collections"]
+    assert "demo_audit_logs" not in impact["collections"]
+    assert impact["demonstration_editor_links"] >= 1
+
+
+def test_delete_user_requires_top_level_clearance(app, db, seeded_data):
+    lower_admin_id = ObjectId()
+    db.users.insert_one(
+        {
+            "_id": lower_admin_id,
+            "username": "lower-admin",
+            "displayname": "Lower Admin",
+            "email": "lower-admin@example.test",
+            "password_hash": "unused",
+            "role": "admin",
+            "global_admin": False,
+            "confirmed": True,
+            "active": True,
+            "global_permissions": ["DELETE_USER"],
+        }
+    )
+
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["_user_id"] = str(lower_admin_id)
+        session["_fresh"] = True
+
+    target_user_id = seeded_data["user_id"]
+    impact_response = client.get(f"/admin/user/delete_user/impact/{target_user_id}")
+    delete_response = client.post(
+        "/admin/user/delete_user",
+        json={"user_id": str(target_user_id)},
+    )
+
+    assert impact_response.status_code == 403
+    assert impact_response.get_json()["status"] == "ERROR"
+    assert delete_response.status_code == 403
+    assert delete_response.get_json()["status"] == "ERROR"
+    assert db.users.find_one({"_id": target_user_id}) is not None


### PR DESCRIPTION
## Summary
- Closes part of #596 by extending admin user deletion to remove directly associated personal-data records from settings, login/reset logs, reminders, reports, submission errors, notifications, messages, memberships, support records, account deletion requests, and API/developer token collections.
- Makes user deletion a top-level destructive action: the actor must have `DELETE_USER` and top-level approval (`global_admin`/`god`) to see the impact estimate or execute deletion.
- Adds a GDPR account-deletion request action to the user's own settings page. The request is stored in `account_deletion_requests` and emailed to `tuki@mielenosoitukset.fi` for support/admin processing.
- Keeps public demonstrations submitted by the removed user by default, while showing them in the impact estimate for separate support/admin review if event removal or edits are also needed.
- Adds a deletion impact estimate endpoint and warning in the user delete modal showing how many submitted demonstrations require separate review and how many direct personal-data records will be removed before final confirmation.
- Handles the reviewed cleanup edge cases for `password_changes.user_id`, pending `friend_requests.sent_by`, and string-valued `demonstrations.editors` entries.
- Documents that account deletion can be requested from settings, that approved account deletion removes direct personal-data links, and that submitted public demonstrations are not automatically deleted.
- Adds regression coverage for the admin delete flow, impact endpoint, top-level-clearance requirement, support deletion request flow, and reviewed cleanup edge cases, and records the change in `CHANGELOG.md`.

## Notes
This PR addresses the right-to-erasure cleanup gap from #596. The broader cookie consent, audit-log redaction, retention/TTL, and privacy-policy disclosure items remain for follow-up work.

## Validation
- `python3 -m py_compile mielenosoitukset_fi/users/BPs/auth.py mielenosoitukset_fi/admin/admin_user_bp.py tests/test_account_deletion_request.py tests/test_admin_user_bp.py`
- `git diff --check`
- `python3 -m pytest tests/test_account_deletion_request.py tests/test_admin_user_bp.py -q` could not run locally because `pytest` is not installed in this Python environment.
- Template render/import checks are limited locally because `jinja2`/`pytz` are not installed in this Python environment.