### PR TITLE
compose: more similar to compose.test.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Pride-kortit näyttävät oikein tyylitettyinä (tagit, ikonit, värit) lisäämällä puuttuvan `css/demo.css`-tyylin kampanjasivulle.
 * Pride-kartan merkinnät ja legendan värit vastaavat toisiaan (yhtenäinen violetin/rubiinin sävy) selkeyttääkseen mitä pisteet kuvaavat.
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
+* Docker Compose development now uses Mailpit for local SMTP testing and exposes Redis alongside the app dependencies, making the dev stack closer to the test stack.
 
 ### Fixed
 * Admin and suggestion route editors now allow the same street or route point to be added multiple times, so march routes can loop through a road more than once.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 Local development depends on following tools:
 - Caddy as reverse proxy and TLS certificate provider (using Caddy's local CA)
 - LocalStack to provide a local non-persistent AWS environment (just S3 for now)
-- reachfive/fake-smtp-server (might change) to provide a local SMTP server for testing email sending
+- Mailpit to provide a local SMTP server and web UI for testing email sending
 
 Configuration for backend is in `config.compose.dev.yaml` and mounted as volume mount to the backend container.
 
@@ -33,7 +33,7 @@ The following steps will set up the necessary environment for local development:
    or check https://caddyserver.com/docs/running#local-https-with-docker) and possibly your browser's trusted certificates as well.
 7. Open your browser to access the application
  - `https://miekkari.localhost:8443` goes landing page, do submit a demonstration
- - `http://localhost:1080/` to access the fake SMTP server interface, see email was sent to organizer and admin
+ - `http://localhost:8085/` to access Mailpit web UI to inspect emails sent to organizer and admin
  - `https://miekkari.localhost:8443/admin/demo/` to access the admin interface (TODO: create admin user)
 
 NOTE: most services expose default port, so if you have other services running on those ports, you might need to stop them or change the port mappings in `compose.dev.yml`.

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -61,6 +61,17 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "127.0.0.1:6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack
@@ -92,11 +103,19 @@ services:
       "
 
   mailserver:
-    image: reachfive/fake-smtp-server
+    container_name: mailpit
+    restart: unless-stopped
+    image: axllent/mailpit:v1.21.5
+    volumes:
+      - ./data:/data
     ports:
-      - "127.0.0.1:8025:1025"
-      - "127.0.0.1:1080:1080"
-
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:8085:8025"
+    environment:
+        MP_MAX_MESSAGES: 50
+        MP_DATABASE: /data/mailpit.db
+        MP_SMTP_AUTH_ACCEPT_ANY: 1
+        MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
 volumes:
   mongo_data:

--- a/config.compose.dev.example.yaml
+++ b/config.compose.dev.example.yaml
@@ -5,7 +5,7 @@ MONGO_DBNAME: "miekkari_db"  # Name of the MongoDB database
 MAIL:
   SERVER: "mailserver"  # SMTP server for sending emails
   PORT: 1025  # SMTP port, typically 587 for TLS
-  USE_TLS: true  # Enable TLS for secure email sending
+  USE_TLS: false  # Enable TLS for secure email sending
   USERNAME: "example@example.com"  # SMTP username
   PASSWORD: "example_password"  # SMTP password
   DEFAULT_SENDER: "example@example.com"  # Default sender email address


### PR DESCRIPTION
make use of same components as compose.test.yaml
if we want to add tests for email (e.g check mail server for received emails), those tests would be runnable also against compose.dev 