### PR TITLE
[codex] Fix city-scoped admin review flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 * Added paikkakunta-scoped admin grants so national admins can assign users demonstration review permissions for one or more Finnish municipalities while keeping national/global admins above local reviewers.
 * Added an automatic MongoDB migration runner and registered the city-key backfill so future app starts apply safe, tracked data migrations without manual script execution.
+* Pinned the Docker Compose development LocalStack image to a community release so local S3 startup no longer depends on a floating image that may require a commercial auth token.
+* Docker Compose development now points the app at `config.compose.dev.yaml` through `CONFIG_YAML_PATH`, avoiding a nested bind mount that can prevent the backend container from starting on Docker Desktop.
 * Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - HOST=0.0.0.0
       - DEBUG=1
+      - CONFIG_YAML_PATH=/app/config.compose.dev.yaml
     depends_on:
       mongo:
         condition: service_healthy
@@ -31,7 +32,6 @@ services:
         condition: service_completed_successfully
     volumes:
       - .:/app
-      - ./config.compose.dev.yaml:/app/config.yaml
     restart: unless-stopped
 
   mongo:
@@ -63,7 +63,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack
+    image: localstack/localstack:3.8.1
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
@@ -77,7 +77,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   localstack-init:
-    image: localstack/localstack
+    image: localstack/localstack:3.8.1
     depends_on:
       localstack:
         condition: service_healthy

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -1492,6 +1492,13 @@ def demo_control():
                                         .skip(skip_count).limit(per_page)
         demos = _deduplicate_demos(list(demos_cursor))
 
+    if not current_user.global_admin:
+        demos = [
+            demo
+            for demo in demos
+            if _user_can_access_demo(demo.get("_id"), "LIST_DEMOS")
+        ]
+
     recommended_lookup = {
         doc.get("demo_id"): True for doc in mongo.recommended_demos.find({}, {"demo_id": 1})
     }

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -394,6 +394,11 @@ def save_user(user_id):
 
     user.save()
 
+    if _can_manage_scope_grants(current_user):
+        city_scope_keys = request.form.getlist("admin_scope_cities[]")
+        city_scope_permissions = request.form.getlist("admin_scope_permissions[city][]")
+        _sync_city_scope_grant(user._id, city_scope_keys, city_scope_permissions)
+
     # Build email summary
     permission_summary_html = "<p>Sinulla on seuraavat oikeudet:</p>"
 

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -2,7 +2,7 @@ from datetime import datetime, date, time
 import time as process_time
 from flask import Flask, redirect, request, session, g, url_for
 from flask_babel import Babel
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 from bson.objectid import ObjectId
 from mielenosoitukset_fi.background_jobs import JOB_DEFINITIONS, init_background_jobs
 
@@ -29,7 +29,7 @@ from mielenosoitukset_fi.notifications_bp import notif_bp
 
 import os
 
-from mielenosoitukset_fi.utils.wrappers import depracated_endpoint
+from mielenosoitukset_fi.utils.wrappers import depracated_endpoint, has_demo_permission
 
 from flask_caching import Cache  # Added for caching
 
@@ -325,6 +325,12 @@ def create_app(config_overrides=None) -> Flask:
                 }).sort("created_at", -1)
             )
             for demo in waiting_demos:
+                if not getattr(current_user, "global_admin", False) and not has_demo_permission(
+                    current_user,
+                    demo["_id"],
+                    "LIST_DEMOS",
+                ):
+                    continue
                 tasks.append({
                     "type": "demo",
                     "id": str(demo["_id"]),
@@ -341,6 +347,11 @@ def create_app(config_overrides=None) -> Flask:
         }).sort("created_at", -1)
             )
             for s in org_suggestions:
+                if not getattr(current_user, "global_admin", False) and not current_user.has_permission(
+                    "EDIT_ORGANIZATION",
+                    s["organization_id"],
+                ):
+                    continue
                 org = mongo.organizations.find_one({"_id": ObjectId(s["organization_id"])})
                 org_name = org["name"] if org else "Tuntematon organisaatio"
                 tasks.append({

--- a/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
+++ b/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
@@ -4,7 +4,7 @@ from mielenosoitukset_fi.utils.database import get_database_manager
 
 def migrate_city_keys(db=None):
     """Backfill normalized city keys for city-scoped admin permissions."""
-    db = db or get_database_manager()
+    db = db if db is not None else get_database_manager()
     results = {}
 
     for collection_name in ("demonstrations", "recu_demos"):

--- a/mielenosoitukset_fi/utils/wrappers.py
+++ b/mielenosoitukset_fi/utils/wrappers.py
@@ -175,7 +175,7 @@ def has_demo_permission(user, _id, permission_name):
         return False
 
     mongo = _get_mongo()
-    if not mongo:
+    if mongo is None:
         logger.error(
             "Demo permission denied: database unavailable for '%s'.", permission_name
         )


### PR DESCRIPTION
## What changed
- Saves city-scoped admin grants from the actual user save endpoint, so the edit form persists selected municipalities and permissions.
- Filters demo dashboard results and shared admin task widgets through scoped demo permissions to avoid leaking out-of-scope demonstrations.
- Fixes PyMongo database truthiness checks in the scoped permission path and migration runner.
- Fixes local Docker dev startup by pinning LocalStack and using `CONFIG_YAML_PATH` instead of a nested config bind mount.

## Why
City reviewers need to review only their assigned Finnish municipalities, while national/global admins keep broader access. Testing showed the UI displayed scoped controls but did not save grants, and the task widget could expose out-of-scope pending demos.

## Validation
- `docker compose -f compose.dev.yml up --build -d`
- `docker compose -f compose.dev.yml exec -T -e TEST_MONGO_URI=mongodb://mongo:27018 backend python -m pytest tests/test_wrappers.py tests/test_city_scoped_admin.py` -> 15 passed
- `git diff --check`
- Manual Flask-session checks: city reviewer can access Helsinki demo review/approve, gets 403 for Turku, and Turku is absent from dashboard/sidebar HTML.
- Verified automatic migration record `003_city_keys` in `schema_migrations`.


## Commit history note
The initial feature implementation is commit `435c334 feat: implement city-scoped admin permissions and migration for city keys`. It is already on `origin/main`, so GitHub does not show it as part of this PR diff. This PR currently contains the follow-up fix commit `5cb70dd fix city-scoped admin review flow` on top of that base.
