### PR TITLE
[codex] Add city-scoped admin review roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## UNRELEASED
 
 ### Added
+* Added paikkakunta-scoped admin grants so national admins can assign users demonstration review permissions for one or more Finnish municipalities while keeping national/global admins above local reviewers.
+* Added an automatic MongoDB migration runner and registered the city-key backfill so future app starts apply safe, tracked data migrations without manual script execution.
 * Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* Runtime models and user/profile helpers now resolve the active MongoDB database per operation, preventing stale database handles after app/test database resets.
 * Admin and suggestion route editors now allow the same street or route point to be added multiple times, so march routes can loop through a road more than once.
 * User settings change notifications now have the missing `auth/settings_changed.html` email template, preventing settings updates from reporting a template lookup error.
 * New demonstration admin notification emails are now sent directly during the background notification job instead of being re-queued into a second email worker queue, so failed admin alert deliveries are surfaced as job errors instead of being silently marked complete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * Pride-kampanjasivun tapahtumakortit on sovitettu lähemmäs peruslistan ulkoasua (värit, tagit, ikonit), säilyttäen Pride-teeman.
 
 ### Fixed
+* City-scoped admin grants no longer satisfy unscoped demo route permission checks, and user edits now revoke existing ObjectId-backed city grants correctly.
 * Runtime models and user/profile helpers now resolve the active MongoDB database per operation, preventing stale database handles after app/test database resets.
 * Admin and suggestion route editors now allow the same street or route point to be added multiple times, so march routes can loop through a road more than once.
 * User settings change notifications now have the missing `auth/settings_changed.html` email template, preventing settings updates from reporting a template lookup error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 * Added paikkakunta-scoped admin grants so national admins can assign users demonstration review permissions for one or more Finnish municipalities while keeping national/global admins above local reviewers.
 * Added an automatic MongoDB migration runner and registered the city-key backfill so future app starts apply safe, tracked data migrations without manual script execution.
+* Pinned the Docker Compose development LocalStack image to a community release so local S3 startup no longer depends on a floating image that may require a commercial auth token.
+* Docker Compose development now points the app at `config.compose.dev.yaml` through `CONFIG_YAML_PATH`, avoiding a nested bind mount that can prevent the backend container from starting on Docker Desktop.
 * Added a token-protected admin MCP endpoint at `/api/admin/mcp` with foundation tools for listing, reading, creating, and updating demonstrations, organizations, and support cases so AI agents can begin driving core admin dashboard work without browser automation.
 * Added `scripts/hash_admin_mcp_token.py` and `docs/admin_mcp.md` to help provision hashed MCP bearer tokens safely instead of storing raw admin-control tokens in config.
 * Admin MCP now also accepts OAuth-style bearer tokens validated from configured JWT claims (`iss`, `aud`, scopes), making it compatible with the OpenAI MCP bearer-token pattern instead of requiring only project-specific static tokens.

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - HOST=0.0.0.0
       - DEBUG=1
+      - CONFIG_YAML_PATH=/app/config.compose.dev.yaml
     depends_on:
       mongo:
         condition: service_healthy
@@ -31,7 +32,6 @@ services:
         condition: service_completed_successfully
     volumes:
       - .:/app
-      - ./config.compose.dev.yaml:/app/config.yaml
     restart: unless-stopped
 
   mongo:
@@ -63,7 +63,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack
+    image: localstack/localstack:3.8.1
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range
@@ -77,7 +77,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   localstack-init:
-    image: localstack/localstack
+    image: localstack/localstack:3.8.1
     depends_on:
       localstack:
         condition: service_healthy

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -1492,6 +1492,13 @@ def demo_control():
                                         .skip(skip_count).limit(per_page)
         demos = _deduplicate_demos(list(demos_cursor))
 
+    if not current_user.global_admin:
+        demos = [
+            demo
+            for demo in demos
+            if _user_can_access_demo(demo.get("_id"), "LIST_DEMOS")
+        ]
+
     recommended_lookup = {
         doc.get("demo_id"): True for doc in mongo.recommended_demos.find({}, {"demo_id": 1})
     }

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -34,7 +34,8 @@ from mielenosoitukset_fi.utils.admin.demonstration import collect_tags
 from mielenosoitukset_fi.utils.database import DEMO_FILTER
 from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.utils.variables import CITY_LIST
-from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
+from mielenosoitukset_fi.utils.cities import normalize_city_key
+from mielenosoitukset_fi.utils.wrappers import admin_required, has_demo_permission, permission_required
 from mielenosoitukset_fi.users.models import User
 from .utils import (
     mongo,
@@ -475,6 +476,7 @@ def demo_edit_history(demo_id):
     if not demo_data:
         flash_message(_("Mielenosoitusta ei löytynyt."), "error")
         return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo_data["_id"], "EDIT_DEMO")
 
     history = list(
         mongo.demo_edit_history.find({"demo_id": str(demo_data["_id"])}).sort("edited_at", -1)
@@ -1415,13 +1417,34 @@ def demo_control():
 
     # Permissions
     if not current_user.global_admin:
-        _where = current_user._perm_in("EDIT_DEMO")
-        filter_clauses.append({
-            "$or": [
-                {"organizers": {"$elemMatch": {"organization_id": {"$in": [BsonObjectId(org) for org in _where]}}}},
-                {"editors": current_user.id},
-            ]
-        })
+        _where = current_user._perm_in("LIST_DEMOS")
+        org_scope_ids = [
+            BsonObjectId(org)
+            for org in _where
+            if str(org) != "global" and BsonObjectId.is_valid(str(org))
+        ]
+        city_scope_keys = (
+            current_user.scoped_city_keys_for("LIST_DEMOS")
+            if hasattr(current_user, "scoped_city_keys_for")
+            else []
+        )
+        city_scope_names = [city for city in CITY_LIST if normalize_city_key(city) in city_scope_keys]
+        permission_filters = [{"editors": current_user.id}]
+        if org_scope_ids:
+            permission_filters.append(
+                {"organizers": {"$elemMatch": {"organization_id": {"$in": org_scope_ids}}}}
+            )
+        if city_scope_keys:
+            permission_filters.append(
+                {
+                    "$or": [
+                        {"city_key": {"$in": city_scope_keys}},
+                        {"city": {"$in": city_scope_names}},
+                    ]
+                }
+            )
+        if "global" not in _where:
+            filter_clauses.append({"$or": permission_filters})
 
     def build_query(extra=None):
         clauses = list(filter_clauses)
@@ -2128,6 +2151,7 @@ def edit_demo(demo_id):
     if not demo_data:
         flash_message("Mielenosoitusta ei löytynyt.", "error")
         return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo_data["_id"], "EDIT_DEMO")
 
     case_id = request.args.get("case_id") or None
    
@@ -2165,6 +2189,7 @@ def demo_command_center(demo_id):
     if not demo_data:
         flash_message(_("Mielenosoitusta ei löytynyt."), "error")
         return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo_data["_id"], "VIEW_DEMO")
 
     demo = Demonstration.from_dict(demo_data)
     demo_id_str = str(demo_data["_id"])
@@ -2362,10 +2387,10 @@ def demo_command_center(demo_id):
     }
 
     permissions = {
-        "can_edit": current_user.has_permission("EDIT_DEMO"),
-        "can_delete": current_user.has_permission("DELETE_DEMO"),
-        "can_accept": current_user.has_permission("ACCEPT_DEMO"),
-        "can_generate_link": current_user.has_permission("GENERATE_EDIT_LINK"),
+        "can_edit": _user_can_access_demo(demo_data["_id"], "EDIT_DEMO"),
+        "can_delete": _user_can_access_demo(demo_data["_id"], "DELETE_DEMO"),
+        "can_accept": _user_can_access_demo(demo_data["_id"], "ACCEPT_DEMO"),
+        "can_generate_link": _user_can_access_demo(demo_data["_id"], "GENERATE_EDIT_LINK"),
         "can_recommend": getattr(current_user, "global_admin", False),
         "can_view_analytics": current_user.has_permission("VIEW_ANALYTICS"),
     }
@@ -2555,6 +2580,46 @@ def _get_actor_label():
     return getattr(current_user, "username", None) or getattr(current_user, "email", None) or str(getattr(current_user, "id", "unknown"))
 
 
+def _user_has_global_demo_permission(permission_name: str) -> bool:
+    if getattr(current_user, "global_admin", False):
+        return True
+    return permission_name in getattr(current_user, "global_permissions", [])
+
+
+def _user_can_access_demo(demo_id, permission_name: str) -> bool:
+    if _user_has_global_demo_permission(permission_name):
+        return True
+    return has_demo_permission(current_user, demo_id, permission_name)
+
+
+def _abort_if_demo_forbidden(demo_id, permission_name: str):
+    if not _user_can_access_demo(demo_id, permission_name):
+        flash_message(_("Sinun käyttöoikeutesi eivät riitä tämän mielenosoituksen käsittelyyn."), "error")
+        abort(403)
+
+
+def _user_can_create_demo_in_city(city: str | None) -> bool:
+    if _user_has_global_demo_permission("CREATE_DEMO"):
+        return True
+    org_scopes = [
+        scope
+        for scope in getattr(current_user, "_perm_in", lambda _permission: [])("CREATE_DEMO")
+        if str(scope) != "global"
+    ]
+    if org_scopes:
+        return True
+    city_key = normalize_city_key(city)
+    return bool(
+        city_key
+        and hasattr(current_user, "has_scoped_permission")
+        and current_user.has_scoped_permission(
+            "CREATE_DEMO",
+            scope_type="city",
+            scope_key=city_key,
+        )
+    )
+
+
 def handle_demo_form(request, is_edit=False, demo_id=None, case_id=None):
     """Handle form submission for creating or editing a demonstration.
 
@@ -2588,6 +2653,12 @@ def handle_demo_form(request, is_edit=False, demo_id=None, case_id=None):
         if is_edit and demo_id:
             prev_demo = mongo.demonstrations.find_one({"_id": ObjectId(demo_id)})
             if prev_demo:
+                _abort_if_demo_forbidden(demo_id, "EDIT_DEMO")
+                previous_city_key = prev_demo.get("city_key") or normalize_city_key(prev_demo.get("city"))
+                incoming_city_key = demonstration_data.get("city_key") or normalize_city_key(demonstration_data.get("city"))
+                if incoming_city_key != previous_city_key and not _user_can_create_demo_in_city(demonstration_data.get("city")):
+                    flash_message(_("Sinulla ei ole oikeutta siirtää mielenosoitusta valittuun paikkakuntaan."), "error")
+                    abort(403)
                 merged_data = _deep_merge(prev_demo, demonstration_data)
                 demo = Demonstration.from_dict(merged_data)
                 demo.save()
@@ -2618,6 +2689,9 @@ def handle_demo_form(request, is_edit=False, demo_id=None, case_id=None):
                     })
             flash_message("Mielenosoitus päivitetty onnistuneesti.", "success")
         else:
+            if not _user_can_create_demo_in_city(demonstration_data.get("city")):
+                flash_message(_("Sinulla ei ole oikeutta luoda mielenosoitusta valittuun paikkakuntaan."), "error")
+                abort(403)
             # Insert a new demonstration
             insert_result = mongo.demonstrations.insert_one(demonstration_data)
             try:
@@ -2954,6 +3028,7 @@ def collect_demo_data(request):
     end_time = request.form.get("end_time")
     facebook = request.form.get("facebook")
     city = request.form.get("city")
+    city_key = normalize_city_key(city)
     address = request.form.get("address")
     event_type = request.form.get("type")
     # Handle route as a list (route[] in form-data)
@@ -3010,6 +3085,7 @@ def collect_demo_data(request):
         "end_time": end_time,
         "facebook": facebook,
         "city": city,
+        "city_key": city_key,
         "address": address,
         "type": event_type,
         "route": route,
@@ -3189,6 +3265,7 @@ def delete_demo():
         else:
             flash_message(error_message)
             return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo_data["_id"], "DELETE_DEMO")
 
     record_demo_change(
         demo_id,
@@ -3232,6 +3309,7 @@ def confirm_delete_demo(demo_id):
     if not demo_data:
         flash_message("Mielenosoitusta ei löytynyt.")
         return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo_data["_id"], "DELETE_DEMO")
 
     # Create a Demonstration instance from the fetched data
     demonstration = Demonstration.from_dict(demo_data)
@@ -3251,6 +3329,7 @@ def view_demo_audit_log(demo_id):
     if not demo:
         flash_message(_("Mielenosoitusta ei löytynyt."), "error")
         return redirect(url_for("admin_demo.demo_control"))
+    _abort_if_demo_forbidden(demo["_id"], "VIEW_DEMO")
 
     entries = list(
         mongo.demo_audit_logs.find({"demo_id": str(demo["_id"])}).sort("timestamp", -1)
@@ -3541,6 +3620,7 @@ def accept_demo(demo_id):
     if not demo_data:
         error_msg = _("Demonstration not found.")
         return jsonify({"status": "ERROR", "message": error_msg}), 404
+    _abort_if_demo_forbidden(demo_data["_id"], "ACCEPT_DEMO")
 
     demo = Demonstration.from_dict(demo_data)
 
@@ -3770,10 +3850,14 @@ def geocode_address():
         return jsonify({"error": str(e)}), 500
 
 @admin_demo_api_bp.route("/<demo_id>/approve", methods=["POST"])
+@login_required
+@admin_required
+@permission_required("ACCEPT_DEMO")
 def approve_demo(demo_id):
     demo = mongo.demonstrations.find_one({"_id": _require_valid_objectid(demo_id)})
     if not demo:
         return jsonify({"success": False, "error": "Mielenosoitus ei löytynyt"}), 404
+    _abort_if_demo_forbidden(demo["_id"], "ACCEPT_DEMO")
 
     if demo.get("approved"):
         return jsonify({"success": False, "message": "Mielenosoitus on jo hyväksytty"}), 200
@@ -3818,10 +3902,14 @@ def approve_demo(demo_id):
     return jsonify({"success": True, "message": "Mielenosoitus hyväksyttiin!"})
 
 @admin_demo_api_bp.route("/<demo_id>/deny", methods=["POST"])
+@login_required
+@admin_required
+@permission_required("ACCEPT_DEMO")
 def reject_demo(demo_id):
     demo = mongo.demonstrations.find_one({"_id": _require_valid_objectid(demo_id)})
     if not demo:
         return jsonify({"success": False, "error": "Mielenosoitus ei löytynyt"}), 404
+    _abort_if_demo_forbidden(demo["_id"], "ACCEPT_DEMO")
 
     if demo.get("approved") is False and demo.get("rejected") is True:
         return jsonify({"success": False, "message": "Mielenosoitus on jo hylätty"}), 200
@@ -3878,6 +3966,7 @@ def admin_cancel_demo(demo_id):
     demo = mongo.demonstrations.find_one({"_id": demo_oid})
     if not demo:
         return jsonify({"success": False, "error": "Mielenosoitus ei löytynyt"}), 404
+    _abort_if_demo_forbidden(demo["_id"], "EDIT_DEMO")
 
     reason = None
     if request.is_json:
@@ -3940,6 +4029,11 @@ def bulk_cancel_demos():
         if not demo:
             entry["status"] = "not_found"
             entry["message"] = _(u"Mielenosoitusta ei löytynyt.")
+            results.append(entry)
+            continue
+        if not _user_can_access_demo(demo["_id"], "EDIT_DEMO"):
+            entry["status"] = "forbidden"
+            entry["message"] = _(u"Ei oikeutta käsitellä tätä mielenosoitusta.")
             results.append(entry)
             continue
 

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -1528,7 +1528,7 @@ def demo_control():
 @admin_demo_bp.route("/duplicate/<demo_id>", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("CREATE_DEMO")
+@permission_required("CREATE_DEMO", _type="DEMONSTRATION")
 def duplicate_demo(demo_id):
     """
     Duplicate a demonstration. The duplicate will have 'approved' set to False.
@@ -2447,7 +2447,7 @@ def demo_command_center(demo_id):
 @admin_demo_bp.route("/send_edit_link_email/<demo_id>", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("GENERATE_EDIT_LINK")
+@permission_required("GENERATE_EDIT_LINK", _type="DEMONSTRATION")
 def send_edit_link(demo_id):
     """
     Send a secure edit link via email for a demonstration.
@@ -2493,7 +2493,7 @@ def send_edit_link(demo_id):
 @admin_demo_bp.route("/generate_edit_link/<demo_id>", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("GENERATE_EDIT_LINK")
+@permission_required("GENERATE_EDIT_LINK", _type="DEMONSTRATION")
 def generate_edit_link(demo_id):
     """Generate a secure edit link for a demonstration.
 
@@ -3296,7 +3296,7 @@ def delete_demo():
 @admin_demo_bp.route("/confirm_delete_demo/<demo_id>", methods=["GET"])
 @login_required
 @admin_required
-@permission_required("DELETE_DEMO")
+@permission_required("DELETE_DEMO", _type="DEMONSTRATION")
 def confirm_delete_demo(demo_id):
     """Render a confirmation page before deleting a demonstration.
 
@@ -3330,7 +3330,7 @@ def confirm_delete_demo(demo_id):
 @admin_demo_bp.route("/<demo_id>/audit_log", methods=["GET"])
 @login_required
 @admin_required
-@permission_required("VIEW_DEMO")
+@permission_required("VIEW_DEMO", _type="DEMONSTRATION")
 def view_demo_audit_log(demo_id):
     demo = _find_demo_with_alias_support(demo_id)
     if not demo:
@@ -3594,7 +3594,7 @@ def view_super_audit_logs():
 @admin_demo_bp.route("/accept_demo/<demo_id>", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("ACCEPT_DEMO")
+@permission_required("ACCEPT_DEMO", _type="DEMONSTRATION")
 def accept_demo(demo_id):
     """Accept an existing demonstration by updating its status.
 
@@ -3658,7 +3658,7 @@ def accept_demo(demo_id):
 @admin_demo_bp.route("/get_submitter_info/<demo_id>", methods=["GET"])
 @login_required
 @admin_required
-@permission_required("VIEW_DEMO")
+@permission_required("VIEW_DEMO", _type="DEMONSTRATION")
 def get_submitter_info(demo_id):
     """
     Get submitter information for a demonstration.
@@ -3859,7 +3859,7 @@ def geocode_address():
 @admin_demo_api_bp.route("/<demo_id>/approve", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("ACCEPT_DEMO")
+@permission_required("ACCEPT_DEMO", _type="DEMONSTRATION")
 def approve_demo(demo_id):
     demo = mongo.demonstrations.find_one({"_id": _require_valid_objectid(demo_id)})
     if not demo:
@@ -3911,7 +3911,7 @@ def approve_demo(demo_id):
 @admin_demo_api_bp.route("/<demo_id>/deny", methods=["POST"])
 @login_required
 @admin_required
-@permission_required("ACCEPT_DEMO")
+@permission_required("ACCEPT_DEMO", _type="DEMONSTRATION")
 def reject_demo(demo_id):
     demo = mongo.demonstrations.find_one({"_id": _require_valid_objectid(demo_id)})
     if not demo:

--- a/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
@@ -7,6 +7,7 @@ from flask_login import login_required
 from mielenosoitukset_fi.utils.flashing import flash_message
 
 from mielenosoitukset_fi.utils.classes import RecurringDemonstration, Organizer
+from mielenosoitukset_fi.utils.cities import normalize_city_key
 from mielenosoitukset_fi.utils.variables import CITY_LIST
 from mielenosoitukset_fi.utils.wrappers import permission_required, admin_required
 
@@ -293,6 +294,7 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
         "tags": tags,
         "facebook": facebook,
         "city": city,
+        "city_key": normalize_city_key(city),
         "address": address,
         "event_type": event_type,
         "route": route,

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -246,7 +246,7 @@ def edit_user(user_id):
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # estä oman roolin muutos
-        if current_user._id == user_id and incoming["role"] != current_user.role:
+        if current_user._id == user._id and incoming["role"] != current_user.role:
             flash_message("Et voi muuttaa omaa rooliasi.", "error")
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
@@ -256,7 +256,7 @@ def edit_user(user_id):
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
 
         # estä super-käyttäjän itse-alennus
-        if (user.role == "global_admin" and current_user._id == user_id
+        if (user.role == "global_admin" and current_user._id == user._id
                 and incoming["role"] != "global_admin"):
             flash_message("Superkäyttäjät eivät voi alentaa itseään.", "error")
             return safe_redirect(url_for("admin_user.edit_user", user_id=user_id))
@@ -274,7 +274,7 @@ def edit_user(user_id):
         if _can_manage_scope_grants(current_user):
             city_scope_keys = request.form.getlist("admin_scope_cities[]")
             city_scope_permissions = request.form.getlist("admin_scope_permissions[city][]")
-            _sync_city_scope_grant(user_id, city_scope_keys, city_scope_permissions)
+            _sync_city_scope_grant(user._id, city_scope_keys, city_scope_permissions)
 
         return safe_redirect(request.referrer or url_for("admin_user.user_control"))
 

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -7,7 +7,8 @@ import re
 from mielenosoitukset_fi.users.models import User
 from mielenosoitukset_fi.emailer.EmailSender import EmailSender
 from mielenosoitukset_fi.utils.wrappers import admin_required, permission_required
-from mielenosoitukset_fi.utils.variables import PERMISSIONS_GROUPS
+from mielenosoitukset_fi.utils.variables import CITY_LIST, PERMISSIONS_GROUPS
+from mielenosoitukset_fi.utils.cities import CITY_KEY_TO_NAME, CITY_NAME_TO_KEY, normalize_city_key
 from mielenosoitukset_fi.utils.validators import valid_email
 from mielenosoitukset_fi.utils.database import stringify_object_ids
 from mielenosoitukset_fi.utils.flashing import flash_message
@@ -81,6 +82,79 @@ def user_control():
 
 
 USER_ACCESS_LEVELS = {"god": 4, "global_admin": 3, "admin": 2, "user": 1}
+
+CITY_ADMIN_PERMISSIONS = [
+    "LIST_DEMOS",
+    "VIEW_DEMO",
+    "EDIT_DEMO",
+    "ACCEPT_DEMO",
+    "CREATE_DEMO",
+    "GENERATE_EDIT_LINK",
+]
+
+
+def _can_manage_scope_grants(actor) -> bool:
+    return bool(getattr(actor, "global_admin", False)) or getattr(actor, "role", None) in {
+        "global_admin",
+        "god",
+    }
+
+
+def _city_scope_grant_for_user(user_id: ObjectId) -> dict:
+    grant = mongo.admin_scope_grants.find_one(
+        {
+            "user_id": {"$in": [user_id, str(user_id)]},
+            "scope_type": "city",
+            "$or": [{"revoked_at": {"$exists": False}}, {"revoked_at": None}],
+        }
+    )
+    if not grant:
+        return {"scope_keys": [], "permissions": []}
+
+    scope_keys = grant.get("scope_keys")
+    if scope_keys is None and grant.get("scope_key"):
+        scope_keys = [grant.get("scope_key")]
+    grant["scope_keys"] = [normalize_city_key(key) for key in scope_keys or [] if normalize_city_key(key)]
+    grant["permissions"] = [
+        permission for permission in grant.get("permissions", []) if permission in CITY_ADMIN_PERMISSIONS
+    ]
+    return grant
+
+
+def _sync_city_scope_grant(user_id: ObjectId, city_keys: list[str], permissions: list[str]) -> None:
+    city_keys = sorted({normalize_city_key(key) for key in city_keys if normalize_city_key(key) in CITY_KEY_TO_NAME})
+    permissions = sorted({permission for permission in permissions if permission in CITY_ADMIN_PERMISSIONS})
+
+    query = {
+        "user_id": {"$in": [user_id, str(user_id)]},
+        "scope_type": "city",
+        "$or": [{"revoked_at": {"$exists": False}}, {"revoked_at": None}],
+    }
+
+    if not city_keys or not permissions:
+        mongo.admin_scope_grants.update_many(
+            query,
+            {"$set": {"revoked_at": datetime.utcnow(), "revoked_by": str(current_user._id)}},
+        )
+        return
+
+    existing = mongo.admin_scope_grants.find_one(query)
+    payload = {
+        "user_id": user_id,
+        "scope_type": "city",
+        "scope_keys": city_keys,
+        "role": "city_reviewer",
+        "permissions": permissions,
+        "updated_at": datetime.utcnow(),
+        "updated_by": str(current_user._id),
+        "revoked_at": None,
+    }
+    if existing:
+        mongo.admin_scope_grants.update_one({"_id": existing["_id"]}, {"$set": payload})
+    else:
+        payload["created_at"] = datetime.utcnow()
+        payload["granted_by"] = str(current_user._id)
+        mongo.admin_scope_grants.insert_one(payload)
 
 
 def compare_user_levels(user1, user2):  # Check if the user1 is higher than user2
@@ -197,14 +271,25 @@ def edit_user(user_id):
         else:
             flash_message("Mitään ei muutettu.", "info")
 
+        if _can_manage_scope_grants(current_user):
+            city_scope_keys = request.form.getlist("admin_scope_cities[]")
+            city_scope_permissions = request.form.getlist("admin_scope_permissions[city][]")
+            _sync_city_scope_grant(user_id, city_scope_keys, city_scope_permissions)
+
         return safe_redirect(request.referrer or url_for("admin_user.user_control"))
 
     # ─── GET → lomake ──────────────────────────────────────────────────────────
+    city_scope_grant = _city_scope_grant_for_user(user._id)
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}user/edit.html",
         user=user,
         PERMISSIONS_GROUPS=PERMISSIONS_GROUPS,
         global_permissions=user.global_permissions,
+        can_manage_scope_grants=_can_manage_scope_grants(current_user),
+        city_list=CITY_LIST,
+        city_name_to_key=CITY_NAME_TO_KEY,
+        city_scope_grant=city_scope_grant,
+        city_admin_permissions=CITY_ADMIN_PERMISSIONS,
     )
 
 

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -394,6 +394,11 @@ def save_user(user_id):
 
     user.save()
 
+    if _can_manage_scope_grants(current_user):
+        city_scope_keys = request.form.getlist("admin_scope_cities[]")
+        city_scope_permissions = request.form.getlist("admin_scope_permissions[city][]")
+        _sync_city_scope_grant(user._id, city_scope_keys, city_scope_permissions)
+
     # Build email summary
     permission_summary_html = "<p>Sinulla on seuraavat oikeudet:</p>"
 

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -2,7 +2,7 @@ from datetime import datetime, date, time
 import time as process_time
 from flask import Flask, redirect, request, session, g, url_for
 from flask_babel import Babel
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 from bson.objectid import ObjectId
 from mielenosoitukset_fi.background_jobs import JOB_DEFINITIONS, init_background_jobs
 
@@ -29,7 +29,7 @@ from mielenosoitukset_fi.notifications_bp import notif_bp
 
 import os
 
-from mielenosoitukset_fi.utils.wrappers import depracated_endpoint
+from mielenosoitukset_fi.utils.wrappers import depracated_endpoint, has_demo_permission
 
 from flask_caching import Cache  # Added for caching
 
@@ -325,6 +325,12 @@ def create_app(config_overrides=None) -> Flask:
                 }).sort("created_at", -1)
             )
             for demo in waiting_demos:
+                if not getattr(current_user, "global_admin", False) and not has_demo_permission(
+                    current_user,
+                    demo["_id"],
+                    "LIST_DEMOS",
+                ):
+                    continue
                 tasks.append({
                     "type": "demo",
                     "id": str(demo["_id"]),
@@ -341,6 +347,11 @@ def create_app(config_overrides=None) -> Flask:
         }).sort("created_at", -1)
             )
             for s in org_suggestions:
+                if not getattr(current_user, "global_admin", False) and not current_user.has_permission(
+                    "EDIT_ORGANIZATION",
+                    s["organization_id"],
+                ):
+                    continue
                 org = mongo.organizations.find_one({"_id": ObjectId(s["organization_id"])})
                 org_name = org["name"] if org else "Tuntematon organisaatio"
                 tasks.append({

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -106,6 +106,10 @@ def create_app(config_overrides=None) -> Flask:
     # Initialize MongoDB
     db_manager = DatabaseManager().get_instance()
     mongo = db_manager.get_db()
+    if app.config.get("AUTO_RUN_MIGRATIONS", True):
+        from mielenosoitukset_fi.utils.migration_runner import run_auto_migrations
+
+        run_auto_migrations(mongo)
 
     # Initialize Flask-Login
     login_manager = LoginManager()

--- a/mielenosoitukset_fi/templates/admin_V2/user/edit.html
+++ b/mielenosoitukset_fi/templates/admin_V2/user/edit.html
@@ -210,6 +210,43 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         </div>
 
+        {% if can_manage_scope_grants %}
+        <div class="permissions-panel">
+            <h3>{{ _('Paikkakuntakohtainen ylläpito') }}</h3>
+            <p class="muted">{{ _('Valitse paikkakunnat ja oikeudet, joilla käyttäjä voi käsitellä niiden mielenosoituksia.') }}</p>
+
+            <div class="form-group">
+                <label for="admin_scope_cities">{{ _('Paikkakunnat') }}</label>
+                <select id="admin_scope_cities" name="admin_scope_cities[]" class="form-control" multiple size="10">
+                    {% for city in city_list %}
+                    {% set city_key = city_name_to_key[city] %}
+                    <option value="{{ city_key }}" {% if city_key in city_scope_grant.scope_keys %}selected{% endif %}>
+                        {{ city }}
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="permissions-group">
+                <div class="permission-category">
+                    <h4>{{ _('Mielenosoitusoikeudet valituissa paikkakunnissa') }}</h4>
+                    <div class="permission-list" id="permissions_city_scope">
+                        {% for permission in city_admin_permissions %}
+                        <div class="permission-item">
+                            <input type="checkbox"
+                                   id="perm_city_{{ permission }}"
+                                   name="admin_scope_permissions[city][]"
+                                   value="{{ permission }}"
+                                   {% if permission in city_scope_grant.permissions %}checked{% endif %}>
+                            <label for="perm_city_{{ permission }}">{{ permission }}</label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         <div class="form-group" style="text-align:center;">
             <button type="submit" class="btn-primary">{{ _('Tallenna muutokset') }}</button>
             <a href="{{ url_for('admin_user.user_control') }}" class="btn" style="margin-left:0.75rem;">{{ _('Peruuta')

--- a/mielenosoitukset_fi/users/BPs/chat_ws.py
+++ b/mielenosoitukset_fi/users/BPs/chat_ws.py
@@ -7,8 +7,9 @@ from bson.objectid import ObjectId
 from mielenosoitukset_fi.database_manager import DatabaseManager
 from mielenosoitukset_fi.users.models import User
 
-# get MongoDB instance
-mongo = DatabaseManager().get_instance().get_db()
+def _get_mongo():
+    """Return the current database handle."""
+    return DatabaseManager().get_instance().get_db()
 
 # blueprint
 chat_ws = Blueprint("chat_ws", __name__)
@@ -20,7 +21,7 @@ def _get_username(uid: ObjectId):
     if str(uid) in username_cache:
         return username_cache[str(uid)]
     
-    result = mongo["users"].find_one({"_id": uid})
+    result = _get_mongo()["users"].find_one({"_id": uid})
     if result:
         username = result.get("username")
         username_cache[str(uid)] = username
@@ -66,7 +67,7 @@ def init_socketio(socketio: SocketIO):
         friends_list = []
         for f in getattr(current_user, "friends", []):
             fid = f.get("user_id")
-            f_data = mongo.users.find_one({"_id": fid})
+            f_data = _get_mongo().users.find_one({"_id": fid})
             if f_data:
                 f_user = User.from_db(f_data)
                 friends_list.append({
@@ -87,7 +88,7 @@ def init_socketio(socketio: SocketIO):
         if not recipient_username:
             return emit("error", {"error": "Recipient required"})
 
-        recipient_data = mongo.users.find_one({"username": recipient_username})
+        recipient_data = _get_mongo().users.find_one({"username": recipient_username})
         if not recipient_data:
             return emit("error", {"error": "Recipient not found"})
 
@@ -112,7 +113,7 @@ def init_socketio(socketio: SocketIO):
             "created_at": datetime.utcnow(),
             "read": False
         }
-        msg_id = mongo.messages.insert_one(msg).inserted_id
+        msg_id = _get_mongo().messages.insert_one(msg).inserted_id
         msg["_id"] = msg_id
 
         serialized = serialize_message(msg)
@@ -126,15 +127,15 @@ def init_socketio(socketio: SocketIO):
         message_id = data.get("message_id")
         if not message_id:
             return
-        msg = mongo.messages.find_one({"_id": ObjectId(message_id), "recipient_id": current_user._id})
+        msg = _get_mongo().messages.find_one({"_id": ObjectId(message_id), "recipient_id": current_user._id})
         if msg:
-            mongo.messages.update_one({"_id": ObjectId(message_id)}, {"$set": {"read": True}})
+            _get_mongo().messages.update_one({"_id": ObjectId(message_id)}, {"$set": {"read": True}})
             emit("message_read", {"message_id": message_id}, room=str(msg["sender_id"]))
 
     @socketio.on("load_messages")
     def handle_load_messages(data):
         friend_username = data.get("friend_username")
-        friend_data = mongo.users.find_one({"username": friend_username})
+        friend_data = _get_mongo().users.find_one({"username": friend_username})
         if not friend_data:
             return emit("error", {"error": "Friend not found"})
 
@@ -142,7 +143,7 @@ def init_socketio(socketio: SocketIO):
         if not current_user.is_friends_with(friend):
             return emit("error", {"error": "Can only message friends"})
 
-        msgs = list(mongo.messages.find({
+        msgs = list(_get_mongo().messages.find({
             "$or": [
                 {"sender_id": current_user._id, "recipient_id": friend._id},
                 {"sender_id": friend._id, "recipient_id": current_user._id}

--- a/mielenosoitukset_fi/users/BPs/profile.py
+++ b/mielenosoitukset_fi/users/BPs/profile.py
@@ -10,7 +10,9 @@ from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.users.models import User
 from mielenosoitukset_fi.utils.logger import logger
 
-mongo = DatabaseManager().get_instance().get_db()
+def _get_mongo():
+    """Return the current database handle."""
+    return DatabaseManager().get_instance().get_db()
 
 profile_bp = Blueprint(
     "profile", __name__, template_folder="/users/profile/", url_prefix="/profile"
@@ -39,6 +41,7 @@ def profile(username=None):
         else:
             return abort(404)
 
+    mongo = _get_mongo()
     user_data = mongo.users.find_one({"username": username})
     if user_data:
         user_obj = User.from_db(user_data)
@@ -113,7 +116,7 @@ def api_is_following():
     if not username:
         return {"error": "Username is required"}, 400
 
-    user_data = mongo.users.find_one({"username": username})
+    user_data = _get_mongo().users.find_one({"username": username})
     if not user_data:
         return {"error": "User not found"}, 404
 
@@ -140,7 +143,7 @@ def api_is_friends():
     if not username:
         return {"error": "Username is required"}, 400
 
-    user_data = mongo.users.find_one({"username": username})
+    user_data = _get_mongo().users.find_one({"username": username})
     if not user_data:
         return {"error": "User not found"}, 404
 
@@ -168,7 +171,11 @@ def follow_user():
     if not username:
         return {"error": "Username required"}, 400
 
-    user_obj = User.from_db(mongo.users.find_one({"username": username}))
+    user_data = _get_mongo().users.find_one({"username": username})
+    if not user_data:
+        return {"error": "User not found"}, 404
+
+    user_obj = User.from_db(user_data)
     if not user_obj:
         return {"error": "User not found"}, 404
 
@@ -199,7 +206,11 @@ def unfollow_user():
     if not username:
         return {"error": "Username required"}, 400
 
-    user_obj = User.from_db(mongo.users.find_one({"username": username}))
+    user_data = _get_mongo().users.find_one({"username": username})
+    if not user_data:
+        return {"error": "User not found"}, 404
+
+    user_obj = User.from_db(user_data)
     if not user_obj:
         return {"error": "User not found"}, 404
 
@@ -234,7 +245,7 @@ def send_friend_request():
     if not username:
         return {"error": "Username required"}, 400
 
-    other_data = mongo.users.find_one({"username": username})
+    other_data = _get_mongo().users.find_one({"username": username})
     if not other_data:
         return {"error": "User not found"}, 404
 
@@ -279,7 +290,7 @@ def accept_friend_request():
     if not username:
         return {"error": "Username required"}, 400
 
-    other_data = mongo.users.find_one({"username": username})
+    other_data = _get_mongo().users.find_one({"username": username})
     if not other_data:
         return {"error": "User not found"}, 404
 
@@ -320,7 +331,7 @@ def reject_friend_request():
     if not username:
         return {"error": "Username required"}, 400
 
-    other_data = mongo.users.find_one({"username": username})
+    other_data = _get_mongo().users.find_one({"username": username})
     if not other_data:
         return {"error": "User not found"}, 404
 
@@ -353,7 +364,7 @@ def friend_state():
     if not username:
         return {"error": "Username required"}, 400
 
-    other_data = mongo.users.find_one({"username": username})
+    other_data = _get_mongo().users.find_one({"username": username})
     if not other_data:
         return {"error": "User not found"}, 404
 
@@ -392,7 +403,7 @@ def api_friends_list():
     friends = []
     for friend in current_user.friends:
         fid = friend.get("user_id")
-        f_data = mongo.users.find_one({"_id": fid})
+        f_data = _get_mongo().users.find_one({"_id": fid})
         if f_data:
             f_user = User.from_db(f_data)
             friends.append({
@@ -418,6 +429,7 @@ def api_unread_count():
     counts = {}
     for f in current_user.friends:
         fid = f.get("user_id")
+        mongo = _get_mongo()
         msgs = mongo.messages.count_documents({
             "sender_id": fid,
             "recipient_id": current_user._id,
@@ -447,6 +459,7 @@ def api_messages_with(friend_username):
         Each dict has keys: "sender_id", "recipient_id", "content", "created_at", "read",
         or error message with HTTP code.
     """
+    mongo = _get_mongo()
     friend_data = mongo.users.find_one({"username": friend_username})
     if not friend_data:
         return {"error": "Friend not found"}, 404
@@ -501,6 +514,7 @@ def api_get_messages():
         except Exception:
             return {"error": "Invalid recipient id"}, 400
 
+    mongo = _get_mongo()
     msgs = list(mongo.messages.find(query).sort("created_at", -1))
 
     for msg in msgs:
@@ -543,7 +557,11 @@ def send_message():
     if not recipient_name or not content:
         return {"error": "Recipient and content required"}, 400
 
-    recipient = User.from_db(mongo.users.find_one({"username": recipient_name}))
+    recipient_data = _get_mongo().users.find_one({"username": recipient_name})
+    if not recipient_data:
+        return {"error": "Recipient not found"}, 404
+
+    recipient = User.from_db(recipient_data)
     if not recipient:
         return {"error": "Recipient not found"}, 404
 
@@ -554,7 +572,7 @@ def send_message():
         "created_at": datetime.utcnow(),
         "read": False
     }
-    mongo.messages.insert_one(message)
+    _get_mongo().messages.insert_one(message)
     return {"success": True}, 200
 
 
@@ -579,7 +597,7 @@ def mark_read():
     if not message_id:
         return {"error": "Message ID required"}, 400
 
-    mongo.messages.update_one(
+    _get_mongo().messages.update_one(
         {"_id": ObjectId(message_id), "recipient_id": current_user._id},
         {"$set": {"read": True}}
     )

--- a/mielenosoitukset_fi/users/models.py
+++ b/mielenosoitukset_fi/users/models.py
@@ -10,8 +10,14 @@ from mielenosoitukset_fi.utils.logger import logger
 from mielenosoitukset_fi.utils.classes.MemberShip import MemberShip
 #from mielenosoitukset_fi.utils.classes.BaseModel import BaseModel  # if still needed
 
-db  = DatabaseManager().get_instance()
-mongo = db.get_db()
+
+def _get_mongo():
+    """Return the current database handle.
+
+    Tests reset DatabaseManager between app instances, so keeping a module-level
+    database object makes user helpers read and write stale databases.
+    """
+    return DatabaseManager().get_instance().get_db()
 
 VALID_WINDOW = 5          # TODO → move to config
 DEFAULT_ROLE = "user"
@@ -211,7 +217,7 @@ class User(UserMixin):
     def from_OID(cls, oid: Union[str, ObjectId]) -> "User":
         if isinstance(oid, str):
             oid = ObjectId(oid)
-        doc = mongo.users.find_one({"_id": oid})
+        doc = _get_mongo().users.find_one({"_id": oid})
         if not doc:
             raise ValueError("User not found")
         return cls.from_db(doc)
@@ -233,7 +239,7 @@ class User(UserMixin):
         """Lazy-load active scoped admin grants for this user."""
         if self._admin_scope_grants is None:
             self._admin_scope_grants = list(
-                mongo.admin_scope_grants.find(
+                _get_mongo().admin_scope_grants.find(
                     {
                         "user_id": {"$in": [self._id, str(self._id)]},
                         "$or": [
@@ -299,7 +305,7 @@ class User(UserMixin):
         """
         oid = ObjectId(organization_id) if isinstance(organization_id, str) else organization_id
 
-        org = mongo.organizations.find_one({"_id": oid})
+        org = _get_mongo().organizations.find_one({"_id": oid})
         if not org or "invitations" not in org:
             return False
 
@@ -483,7 +489,7 @@ class User(UserMixin):
         """Persist user (does **not** touch memberships)."""
         doc = self.to_dict()
         doc.pop("_id", None)
-        mongo.users.update_one({"_id": self._id}, {"$set": doc}, upsert=True)
+        _get_mongo().users.update_one({"_id": self._id}, {"$set": doc}, upsert=True)
         # invalidate cache after save
         self._memberships = None
         self._admin_scope_grants = None
@@ -569,7 +575,7 @@ class PendingMFA:
     def create(user_id: ObjectId) -> str:
         """Create a new pending MFA secret."""
         secret = pyotp.random_base32()
-        mongo[PendingMFA.COLLECTION].insert_one({
+        _get_mongo()[PendingMFA.COLLECTION].insert_one({
             "user_id": user_id,
             "secret": secret,
             "created_at": datetime.datetime.utcnow()
@@ -582,7 +588,7 @@ class PendingMFA:
         query = {"user_id": user_id}
         if secret:
             query["secret"] = secret
-        docs = mongo[PendingMFA.COLLECTION].find(query)
+        docs = _get_mongo()[PendingMFA.COLLECTION].find(query)
         return [doc["secret"] for doc in docs]
 
     @staticmethod
@@ -591,7 +597,7 @@ class PendingMFA:
         query = {"user_id": user_id}
         if secret:
             query["secret"] = secret
-        mongo[PendingMFA.COLLECTION].delete_many(query)
+        _get_mongo()[PendingMFA.COLLECTION].delete_many(query)
 
 
 class MFAToken:
@@ -612,7 +618,7 @@ class UserMFA:
 
     def list_devices(self) -> List[Dict]:
         """Return metadata for all active MFA secrets/devices."""
-        docs = mongo.mfas.find({"user_id": self.user_id})
+        docs = _get_mongo().mfas.find({"user_id": self.user_id})
         return [
             {
                 "id": str(doc["_id"]),
@@ -634,7 +640,7 @@ class UserMFA:
     def add_device(self, device_name: str = "New device") -> str:
         """Generate a new secret and store it as a device."""
         secret = pyotp.random_base32()
-        mongo.mfas.insert_one({
+        _get_mongo().mfas.insert_one({
             "user_id": self.user_id,
             "secret": secret,
             "device_name": device_name,
@@ -644,7 +650,7 @@ class UserMFA:
 
     def remove_device(self, device_id: str):
         """Remove a specific device by Mongo _id."""
-        result = mongo.mfas.delete_one({"_id": ObjectId(device_id), "user_id": self.user_id})
+        result = _get_mongo().mfas.delete_one({"_id": ObjectId(device_id), "user_id": self.user_id})
         return result.deleted_count > 0
 
     def get_qr_code_url(self, secret: str) -> str:

--- a/mielenosoitukset_fi/users/models.py
+++ b/mielenosoitukset_fi/users/models.py
@@ -5,6 +5,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 import pyotp, datetime
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
+from mielenosoitukset_fi.utils.cities import normalize_city_key
 from mielenosoitukset_fi.utils.logger import logger
 from mielenosoitukset_fi.utils.classes.MemberShip import MemberShip
 #from mielenosoitukset_fi.utils.classes.BaseModel import BaseModel  # if still needed
@@ -175,6 +176,7 @@ class User(UserMixin):
 
         # CACHED memberships (lazy)  --------------------------------------------
         self._memberships: Optional[List[MemberShip]] = None
+        self._admin_scope_grants: Optional[List[dict]] = None
 
     # ---------- CLASS HELPERS ----------------------------------------------------
 
@@ -225,6 +227,61 @@ class User(UserMixin):
 
     def org_ids(self) -> List[ObjectId]:
         return [m.organization_id for m in self.memberships]
+
+    @property
+    def admin_scope_grants(self) -> List[dict]:
+        """Lazy-load active scoped admin grants for this user."""
+        if self._admin_scope_grants is None:
+            self._admin_scope_grants = list(
+                mongo.admin_scope_grants.find(
+                    {
+                        "user_id": {"$in": [self._id, str(self._id)]},
+                        "$or": [
+                            {"revoked_at": {"$exists": False}},
+                            {"revoked_at": None},
+                        ],
+                    }
+                )
+            )
+        return self._admin_scope_grants
+
+    def has_admin_scope_grants(self) -> bool:
+        return bool(self.admin_scope_grants)
+
+    def scoped_city_keys_for(self, permission: str) -> List[str]:
+        """Return normalized city keys where this user has a scoped permission."""
+        keys: list[str] = []
+        for grant in self.admin_scope_grants:
+            if grant.get("scope_type") != "city":
+                continue
+            if permission not in (grant.get("permissions") or []):
+                continue
+
+            raw_keys = grant.get("scope_keys")
+            if raw_keys is None and grant.get("scope_key"):
+                raw_keys = [grant.get("scope_key")]
+            if isinstance(raw_keys, str):
+                raw_keys = [raw_keys]
+
+            for raw_key in raw_keys or []:
+                city_key = normalize_city_key(raw_key)
+                if city_key:
+                    keys.append(city_key)
+
+        return list(dict.fromkeys(keys))
+
+    def has_scoped_permission(
+        self,
+        permission: str,
+        *,
+        scope_type: str,
+        scope_key: str,
+    ) -> bool:
+        if permission in self.global_permissions:
+            return True
+        if scope_type != "city":
+            return False
+        return normalize_city_key(scope_key) in self.scoped_city_keys_for(permission)
     
     def has_invite(self, organization_id: Union[str, ObjectId]) -> bool:
         """
@@ -368,7 +425,9 @@ class User(UserMixin):
             
             return bool(ms and perm in ms.permissions)
         # if org not specified, check all org memberships
-        return any(perm in m.permissions for m in self.memberships)
+        return any(perm in m.permissions for m in self.memberships) or bool(
+            self.scoped_city_keys_for(perm)
+        )
 
     # ---------- FOLLOW / BAN / MFA ----------------------------------------------
 
@@ -427,6 +486,7 @@ class User(UserMixin):
         mongo.users.update_one({"_id": self._id}, {"$set": doc}, upsert=True)
         # invalidate cache after save
         self._memberships = None
+        self._admin_scope_grants = None
 
     # ---------- SERIALISATION ----------------------------------------------------
 

--- a/mielenosoitukset_fi/users/models.py
+++ b/mielenosoitukset_fi/users/models.py
@@ -431,9 +431,7 @@ class User(UserMixin):
             
             return bool(ms and perm in ms.permissions)
         # if org not specified, check all org memberships
-        return any(perm in m.permissions for m in self.memberships) or bool(
-            self.scoped_city_keys_for(perm)
-        )
+        return any(perm in m.permissions for m in self.memberships)
 
     # ---------- FOLLOW / BAN / MFA ----------------------------------------------
 

--- a/mielenosoitukset_fi/utils/cities.py
+++ b/mielenosoitukset_fi/utils/cities.py
@@ -1,0 +1,21 @@
+import unicodedata
+
+from mielenosoitukset_fi.utils.variables import CITY_LIST
+
+
+def normalize_city_key(city: str | None) -> str:
+    """Return a stable ASCII key for a Finnish municipality name."""
+    if not city:
+        return ""
+
+    normalized = unicodedata.normalize("NFKD", str(city).strip().casefold())
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    return "-".join(part for part in ascii_text.replace("_", "-").split() if part)
+
+
+CITY_KEY_TO_NAME = {normalize_city_key(city): city for city in CITY_LIST}
+CITY_NAME_TO_KEY = {city: normalize_city_key(city) for city in CITY_LIST}
+
+
+def valid_city_key(city_key: str | None) -> bool:
+    return bool(city_key) and city_key in CITY_KEY_TO_NAME

--- a/mielenosoitukset_fi/utils/classes/Case.py
+++ b/mielenosoitukset_fi/utils/classes/Case.py
@@ -11,7 +11,10 @@ from bson import ObjectId
 
 from mielenosoitukset_fi.utils.database import get_database_manager
 
-mongo = get_database_manager()
+
+def _get_db():
+    """Return the current database handle."""
+    return get_database_manager()
 
 
 class Case:
@@ -82,13 +85,13 @@ class Case:
     # ---------------------------------------------------------------------
     def _get_next_running_num(self) -> int:
         """Return next sequential running number (atomic enough for admin use)."""
-        last = mongo[self.COLLECTION].find_one(sort=[("running_num", -1)])
+        last = _get_db()[self.COLLECTION].find_one(sort=[("running_num", -1)])
         return (last.get("running_num", self.STARTING_NUM - 1) + 1) if last else self.STARTING_NUM
 
     def _touch(self) -> None:
         """Update *updated_at* and persist current in‑memory state to MongoDB."""
         self.updated_at = datetime.utcnow()
-        mongo[self.COLLECTION].update_one({"_id": self._id}, {"$set": self.to_dict()}, upsert=True)
+        _get_db()[self.COLLECTION].update_one({"_id": self._id}, {"$set": self.to_dict()}, upsert=True)
 
     # ---------------------------------------------------------------------
     # Public API
@@ -135,7 +138,7 @@ class Case:
 
     @classmethod
     def get(cls, case_id: str | ObjectId) -> Optional["Case"]:
-        doc = mongo[cls.COLLECTION].find_one({"_id": ObjectId(case_id)})
+        doc = _get_db()[cls.COLLECTION].find_one({"_id": ObjectId(case_id)})
         return cls.from_dict(doc) if doc else None
 
     @classmethod

--- a/mielenosoitukset_fi/utils/classes/Demonstration.py
+++ b/mielenosoitukset_fi/utils/classes/Demonstration.py
@@ -16,7 +16,9 @@ from bson import ObjectId
 from datetime import datetime  # Added import for datetime
 
 
-DB = get_database_manager()
+def _get_db():
+    """Return the current database handle."""
+    return get_database_manager()
 
 
 class Demonstration(BaseModel):
@@ -283,7 +285,7 @@ class Demonstration(BaseModel):
         
         if parent:
             try:
-                _parent = DB["recu_demos"].find_one({"_id": ObjectId(parent)})
+                _parent = _get_db()["recu_demos"].find_one({"_id": ObjectId(parent)})
             except Exception as e:
                 print(f"Error fetching parent demonstration: {e}")
 
@@ -484,7 +486,7 @@ class Demonstration(BaseModel):
         >>> demo = Demonstration(...)
         >>> demo.merge("60f8e1e7a1b9c9b8f6b3f3b2") # Merge the demonstration with ID "60f8e1e7a1b9c9b8f6b3f3b2" into the current demonstration.
         """
-        other_demo_data = DB["demonstrations"].find_one(
+        other_demo_data = _get_db()["demonstrations"].find_one(
             {"_id": ObjectId(id_of_other_demo)}
         )
         if not other_demo_data:
@@ -501,7 +503,7 @@ class Demonstration(BaseModel):
         self.save()
 
         # Ensure the merged demonstration can be found by both IDs
-        DB["demonstrations"].update_one(
+        _get_db()["demonstrations"].update_one(
             {"_id": ObjectId(id_of_other_demo)},
             {"$set": {"merged_into": self._id, "hide": True}},
         )
@@ -702,9 +704,10 @@ class Demonstration(BaseModel):
         data.pop("parent_object", None)  # Remove parent_object if present
         
         # Check if the demonstration already exists in the database
-        if DB["demonstrations"].find_one({"_id": self._id}):
+        db = _get_db()
+        if db["demonstrations"].find_one({"_id": self._id}):
             # Update existing entry
-            result = DB["demonstrations"].replace_one({"_id": self._id}, data)
+            result = db["demonstrations"].replace_one({"_id": self._id}, data)
             if result.modified_count:
                 print(
                     "Demonstration updated successfully."
@@ -715,7 +718,7 @@ class Demonstration(BaseModel):
                 )  # TODO: #191 Use utils.logger instead of print
         else:
             # Insert new entry
-            DB["demonstrations"].insert_one(data)
+            db["demonstrations"].insert_one(data)
             print(
                 "Demonstration saved successfully."
             )  # TODO: #191 Use utils.logger instead of print
@@ -745,7 +748,7 @@ class Demonstration(BaseModel):
         try:
             if ObjectId.is_valid(str(demo_id)):
                 obj_id = ObjectId(demo_id)
-                data = DB["demonstrations"].find_one({"_id": obj_id})
+                data = _get_db()["demonstrations"].find_one({"_id": obj_id})
                 if data:
                     logger.info("Found")
                     return cls.from_dict(data)
@@ -754,7 +757,7 @@ class Demonstration(BaseModel):
             obj_id = None
 
         if obj_id:
-            alias_data = DB["demonstrations"].find_one({"aliases": {"$in": [obj_id]}})
+            alias_data = _get_db()["demonstrations"].find_one({"aliases": {"$in": [obj_id]}})
             if alias_data:
                 logger.info("Found via alias id lookup")
                 return cls.from_dict(alias_data)
@@ -762,7 +765,7 @@ class Demonstration(BaseModel):
         # Try running_number lookup
         try:
             num = int(demo_id)
-            data = DB["demonstrations"].find_one({"running_number": num})
+            data = _get_db()["demonstrations"].find_one({"running_number": num})
             if data:
                 return cls.from_dict(data)
         except ValueError:
@@ -771,7 +774,7 @@ class Demonstration(BaseModel):
             pass
 
         # Try slug lookup
-        data = DB["demonstrations"].find_one({"slug": demo_id})
+        data = _get_db()["demonstrations"].find_one({"slug": demo_id})
         if data:
             return cls.from_dict(data)
 

--- a/mielenosoitukset_fi/utils/classes/Demonstration.py
+++ b/mielenosoitukset_fi/utils/classes/Demonstration.py
@@ -2,6 +2,7 @@ import copy
 import string
 
 from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.cities import normalize_city_key
 from .BaseModel import BaseModel
 from .Organizer import Organizer
 from mielenosoitukset_fi.utils.database import get_database_manager
@@ -274,6 +275,7 @@ class Demonstration(BaseModel):
         # Removed direct assignment for date, start_time, end_time
 
         self.city = city
+        self.city_key = normalize_city_key(city)
         self.address = address
 
         self.latitude = latitude

--- a/mielenosoitukset_fi/utils/classes/MemberShip.py
+++ b/mielenosoitukset_fi/utils/classes/MemberShip.py
@@ -6,7 +6,13 @@ from mielenosoitukset_fi.utils.database import (
     get_database_manager,
 )
 
-DB = get_database_manager()
+def _get_db():
+    """Return the current database handle.
+
+    DatabaseManager can be reset during tests, so membership lookups should not
+    keep an import-time database object.
+    """
+    return get_database_manager()
 
 
 class MemberShip(BaseModel):
@@ -96,7 +102,8 @@ class MemberShip(BaseModel):
 
     def save(self):
         """Ensure unique user/org combo and upsert safely."""
-        existing = DB["memberships"].find_one({
+        db = _get_db()
+        existing = db["memberships"].find_one({
             "user_id": self.user_id,
             "organization_id": self.organization_id
         })
@@ -109,7 +116,7 @@ class MemberShip(BaseModel):
             merged = default_perms | existing_perms | set(self.permissions)
             self.permissions = sorted(merged)
 
-        DB["memberships"].update_one(
+        db["memberships"].update_one(
             {
                 "user_id": self.user_id,
                 "organization_id": self.organization_id
@@ -161,7 +168,7 @@ class MemberShip(BaseModel):
     @classmethod
     def _find_by_user_and_org(cls, user_id, org_id):
         """Find one membership for this user+org combo."""
-        result = DB["memberships"].find_one({
+        result = _get_db()["memberships"].find_one({
             "user_id": ObjectId(user_id),
             "organization_id": ObjectId(org_id)
         })
@@ -174,10 +181,10 @@ class MemberShip(BaseModel):
     def all_in_organization(cls, organization_id: Union[str, ObjectId]) -> List["MemberShip"]:
         """Fetch all memberships in a specific organization."""
         organization_id = ObjectId(organization_id)
-        return [cls.from_dict(doc) for doc in DB["memberships"].find({"organization_id": organization_id})]
+        return [cls.from_dict(doc) for doc in _get_db()["memberships"].find({"organization_id": organization_id})]
 
     @classmethod
     def all_per_user(cls, user_id: Union[str, ObjectId]) -> List["MemberShip"]:
         """Fetch all memberships belonging to a user."""
         user_id = ObjectId(user_id)
-        return [cls.from_dict(doc) for doc in DB["memberships"].find({"user_id": user_id})]
+        return [cls.from_dict(doc) for doc in _get_db()["memberships"].find({"user_id": user_id})]

--- a/mielenosoitukset_fi/utils/migration_runner.py
+++ b/mielenosoitukset_fi/utils/migration_runner.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.migrations import migration_003_city_keys
+
+
+MIGRATIONS = [
+    {
+        "id": "003_city_keys",
+        "description": "Backfill normalized city keys for city-scoped admin grants.",
+        "run": migration_003_city_keys.migrate_city_keys,
+    },
+]
+
+
+def run_auto_migrations(db) -> None:
+    """Run registered, idempotent migrations once per database."""
+    applied = db.schema_migrations
+    applied.create_index("id", unique=True)
+
+    for migration in MIGRATIONS:
+        migration_id = migration["id"]
+        if applied.find_one({"id": migration_id}):
+            continue
+
+        logger.info("Running migration %s", migration_id)
+        result = migration["run"](db=db)
+        applied.insert_one(
+            {
+                "id": migration_id,
+                "description": migration["description"],
+                "applied_at": datetime.utcnow(),
+                "result": result or {},
+            }
+        )
+        logger.info("Migration %s completed", migration_id)

--- a/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
+++ b/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
@@ -4,7 +4,7 @@ from mielenosoitukset_fi.utils.database import get_database_manager
 
 def migrate_city_keys(db=None):
     """Backfill normalized city keys for city-scoped admin permissions."""
-    db = db or get_database_manager()
+    db = db if db is not None else get_database_manager()
     results = {}
 
     for collection_name in ("demonstrations", "recu_demos"):

--- a/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
+++ b/mielenosoitukset_fi/utils/migrations/migration_003_city_keys.py
@@ -1,0 +1,28 @@
+from mielenosoitukset_fi.utils.cities import normalize_city_key
+from mielenosoitukset_fi.utils.database import get_database_manager
+
+
+def migrate_city_keys(db=None):
+    """Backfill normalized city keys for city-scoped admin permissions."""
+    db = db or get_database_manager()
+    results = {}
+
+    for collection_name in ("demonstrations", "recu_demos"):
+        updated = 0
+        for doc in db[collection_name].find({}, {"city": 1, "city_key": 1}):
+            city_key = normalize_city_key(doc.get("city"))
+            if not city_key or doc.get("city_key") == city_key:
+                continue
+            db[collection_name].update_one(
+                {"_id": doc["_id"]},
+                {"$set": {"city_key": city_key}},
+            )
+            updated += 1
+        results[collection_name] = updated
+        print(f"Updated {updated} documents in {collection_name}.")
+
+    return results
+
+
+if __name__ == "__main__":
+    migrate_city_keys()

--- a/mielenosoitukset_fi/utils/wrappers.py
+++ b/mielenosoitukset_fi/utils/wrappers.py
@@ -175,7 +175,7 @@ def has_demo_permission(user, _id, permission_name):
         return False
 
     mongo = _get_mongo()
-    if not mongo:
+    if mongo is None:
         logger.error(
             "Demo permission denied: database unavailable for '%s'.", permission_name
         )

--- a/mielenosoitukset_fi/utils/wrappers.py
+++ b/mielenosoitukset_fi/utils/wrappers.py
@@ -4,8 +4,22 @@ from flask import redirect, url_for, abort
 from flask_babel import _
 from flask_login import current_user
 from mielenosoitukset_fi.database_manager import DatabaseManager
+from mielenosoitukset_fi.utils.cities import normalize_city_key
 from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.utils.logger import logger
+
+
+def has_admin_access(user) -> bool:
+    """Return True when a user may enter an admin surface."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "role", None) in ["global_admin", "admin", "god"]:
+        return True
+    if getattr(user, "global_admin", False):
+        return True
+    if hasattr(user, "has_admin_scope_grants") and user.has_admin_scope_grants():
+        return True
+    return False
 
 
 def admin_required(f):
@@ -67,15 +81,15 @@ def admin_required(f):
             logger.warning("User not authenticated, Unauthorized (401).")
             abort(401)
 
-        # Check if the user has global admin privileges
-        if not current_user.role in ["global_admin", "admin"]:
+        # Check if the user has admin privileges or scoped admin grants
+        if not has_admin_access(current_user):
             logger.warning(
-                f"User {current_user.username} is not a global admin, access forbidden (403)."
+                f"User {current_user.username} is not an admin, access forbidden (403)."
             )
             abort(403)
 
         # User is a global admin, access granted
-        logger.info(f"User {current_user.username} is an admin, access granted.")
+        logger.info(f"User {current_user.username} has admin access, access granted.")
         return f(*args, **kwargs)
 
     return decorated_function
@@ -213,6 +227,22 @@ def has_demo_permission(user, _id, permission_name):
                 getattr(user, "id", None),
                 permission_name,
                 org_oid,
+            )
+            return True
+
+    # City-scoped admin permissions
+    city_key = demo_doc.get("city_key") or normalize_city_key(demo_doc.get("city"))
+    if city_key and hasattr(user, "has_scoped_permission"):
+        if user.has_scoped_permission(
+            permission_name,
+            scope_type="city",
+            scope_key=city_key,
+        ):
+            logger.info(
+                "Demo permission granted: user %s has '%s' for city %s.",
+                getattr(user, "id", None),
+                permission_name,
+                city_key,
             )
             return True
 

--- a/mielenosoitukset_fi/utils/wrappers.py
+++ b/mielenosoitukset_fi/utils/wrappers.py
@@ -341,14 +341,20 @@ def permission_required(permission_name: str, _id: str | None = None, _type: str
                 return f(*args, **kwargs)
 
             if _type == "DEMONSTRATION":
-                has = has_demo_permission(current_user, _id, permission_name)
+                resource_id = (
+                    _id
+                    or kwargs.get("demo_id")
+                    or kwargs.get("demonstration_id")
+                    or kwargs.get("id")
+                )
+                has = has_demo_permission(current_user, resource_id, permission_name)
                 if has:
                     return f(*args, **kwargs)
                 logger.warning(
                     "Demonstration permission '%s' denied for user %s and demo %s.",
                     permission_name,
                     getattr(current_user, "id", None),
-                    _id,
+                    resource_id,
                 )
                 if permission_name in current_user.global_permissions:
                     logger.info(
@@ -374,6 +380,18 @@ def permission_required(permission_name: str, _id: str | None = None, _type: str
             ):  # DEPRACED: Use has_permission instead
                 logger.info(
                     f"User {current_user.username} has permission '{permission_name}' via role."
+                )
+                return f(*args, **kwargs)
+
+            if (
+                permission_name == "LIST_DEMOS"
+                and hasattr(current_user, "scoped_city_keys_for")
+                and current_user.scoped_city_keys_for(permission_name)
+            ):
+                logger.info(
+                    "User %s has scoped city permission '%s'.",
+                    current_user.username,
+                    permission_name,
                 )
                 return f(*args, **kwargs)
 

--- a/tests/test_city_scoped_admin.py
+++ b/tests/test_city_scoped_admin.py
@@ -1,0 +1,97 @@
+from copy import deepcopy
+
+from bson import ObjectId
+
+from mielenosoitukset_fi.users.models import User
+from mielenosoitukset_fi.utils.cities import normalize_city_key
+from tests.conftest import _client_for_user
+
+
+def _create_scoped_admin(db, city_keys, permissions):
+    user_id = ObjectId()
+    user_doc = User.create_user(
+        username="city-admin",
+        password="CityPass1!",
+        email="city-admin@example.test",
+        displayname="City Admin",
+    )
+    user_doc.update(
+        {
+            "_id": user_id,
+            "confirmed": True,
+            "active": True,
+            "role": "user",
+            "global_admin": False,
+            "global_permissions": [],
+        }
+    )
+    db.users.insert_one(user_doc)
+    db.admin_scope_grants.insert_one(
+        {
+            "user_id": user_id,
+            "scope_type": "city",
+            "scope_keys": city_keys,
+            "role": "city_reviewer",
+            "permissions": permissions,
+        }
+    )
+    return user_id
+
+
+def test_city_scoped_admin_dashboard_only_lists_assigned_cities(app, db, seeded_data):
+    scoped_user_id = _create_scoped_admin(
+        db,
+        ["helsinki"],
+        ["LIST_DEMOS", "VIEW_DEMO", "ACCEPT_DEMO"],
+    )
+
+    helsinki_demo = db.demonstrations.find_one({"_id": seeded_data["pending_demo_id"]})
+    turku_demo = deepcopy(helsinki_demo)
+    turku_demo["_id"] = ObjectId()
+    turku_demo["title"] = "Turku Outside Scope"
+    turku_demo["city"] = "Turku"
+    turku_demo["city_key"] = normalize_city_key("Turku")
+    turku_demo["slug"] = "turku-outside-scope"
+    turku_demo["editors"] = []
+    db.demonstrations.insert_one(turku_demo)
+
+    client = _client_for_user(app, scoped_user_id)
+    response = client.get("/admin/demo/")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Pending Demonstration" in page
+    assert "Turku Outside Scope" not in page
+
+
+def test_city_scoped_admin_can_approve_only_assigned_city(app, db, seeded_data):
+    scoped_user_id = _create_scoped_admin(
+        db,
+        ["helsinki"],
+        ["LIST_DEMOS", "VIEW_DEMO", "ACCEPT_DEMO"],
+    )
+
+    helsinki_demo_id = seeded_data["pending_demo_id"]
+    helsinki_demo = db.demonstrations.find_one({"_id": helsinki_demo_id})
+    turku_demo = deepcopy(helsinki_demo)
+    turku_demo_id = ObjectId()
+    turku_demo["_id"] = turku_demo_id
+    turku_demo["title"] = "Turku Approval Denied"
+    turku_demo["city"] = "Turku"
+    turku_demo["city_key"] = normalize_city_key("Turku")
+    turku_demo["slug"] = "turku-approval-denied"
+    turku_demo["approved"] = False
+    turku_demo["editors"] = []
+    db.demonstrations.insert_one(turku_demo)
+
+    client = _client_for_user(app, scoped_user_id)
+
+    allowed = client.post(f"/api/admin/demo/{helsinki_demo_id}/approve")
+    denied = client.post(f"/api/admin/demo/{turku_demo_id}/approve")
+
+    assert allowed.status_code == 200
+    assert allowed.get_json()["success"] is True
+    assert db.demonstrations.find_one({"_id": helsinki_demo_id})["approved"] is True
+
+    assert denied.status_code == 403
+    assert db.demonstrations.find_one({"_id": turku_demo_id})["approved"] is False

--- a/tests/test_city_scoped_admin.py
+++ b/tests/test_city_scoped_admin.py
@@ -95,3 +95,45 @@ def test_city_scoped_admin_can_approve_only_assigned_city(app, db, seeded_data):
 
     assert denied.status_code == 403
     assert db.demonstrations.find_one({"_id": turku_demo_id})["approved"] is False
+
+
+def test_city_scoped_permission_does_not_satisfy_unscoped_route_gate(db):
+    scoped_user_id = _create_scoped_admin(
+        db,
+        ["helsinki"],
+        ["CREATE_DEMO"],
+    )
+
+    user = User.from_db(db.users.find_one({"_id": scoped_user_id}))
+
+    assert user.has_scoped_permission(
+        "CREATE_DEMO",
+        scope_type="city",
+        scope_key="helsinki",
+    )
+    assert user.has_permission("CREATE_DEMO") is False
+
+
+def test_edit_user_revokes_object_id_backed_city_scope_grant(app, db, seeded_data):
+    scoped_user_id = _create_scoped_admin(
+        db,
+        ["helsinki"],
+        ["LIST_DEMOS", "VIEW_DEMO"],
+    )
+    client = _client_for_user(app, seeded_data["admin_id"])
+
+    response = client.post(
+        f"/admin/user/edit_user/{scoped_user_id}",
+        data={
+            "username": "city-admin",
+            "email": "city-admin@example.test",
+            "role": "user",
+            "confirmed": "on",
+        },
+    )
+
+    assert response.status_code == 302
+    grant = db.admin_scope_grants.find_one(
+        {"user_id": scoped_user_id, "scope_type": "city"}
+    )
+    assert grant["revoked_at"] is not None

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -20,16 +20,27 @@ class FakeMongo:
 
 
 class FakeUser:
-    def __init__(self, *, is_authenticated=True, global_admin=False, permissions=None):
+    def __init__(
+        self,
+        *,
+        is_authenticated=True,
+        global_admin=False,
+        permissions=None,
+        city_permissions=None,
+    ):
         self.is_authenticated = is_authenticated
         self.global_admin = global_admin
         self._id = ObjectId()
         self.id = str(self._id)
         self.permissions = permissions or {}
+        self.city_permissions = city_permissions or {}
 
     def has_permission(self, perm, organization_id=None, strict=False):
         key = (perm, str(organization_id) if organization_id else None)
         return self.permissions.get(key, False)
+
+    def has_scoped_permission(self, perm, *, scope_type, scope_key):
+        return self.city_permissions.get((perm, scope_type, scope_key), False)
 
 
 class HasDemoPermissionTests(unittest.TestCase):
@@ -158,6 +169,42 @@ class HasDemoPermissionTests(unittest.TestCase):
             self.assertFalse(
                 wrappers.has_demo_permission(user, demo_id, "EDIT_DEMO"),
                 "Users without relevant permissions should be denied.",
+            )
+
+    def test_allows_permission_via_city_scope(self):
+        user = FakeUser(city_permissions={("ACCEPT_DEMO", "city", "jyvaskyla"): True})
+        demo_id = ObjectId()
+        demo_doc = {
+            demo_id: {
+                "_id": demo_id,
+                "city": "Jyväskylä",
+            }
+        }
+        with patch(
+            "mielenosoitukset_fi.utils.wrappers._get_mongo",
+            return_value=FakeMongo(demo_doc),
+        ):
+            self.assertTrue(
+                wrappers.has_demo_permission(user, demo_id, "ACCEPT_DEMO"),
+                "Users with matching city-scoped permissions should be authorized.",
+            )
+
+    def test_denies_city_scope_for_other_city(self):
+        user = FakeUser(city_permissions={("ACCEPT_DEMO", "city", "tampere"): True})
+        demo_id = ObjectId()
+        demo_doc = {
+            demo_id: {
+                "_id": demo_id,
+                "city": "Jyväskylä",
+            }
+        }
+        with patch(
+            "mielenosoitukset_fi.utils.wrappers._get_mongo",
+            return_value=FakeMongo(demo_doc),
+        ):
+            self.assertFalse(
+                wrappers.has_demo_permission(user, demo_id, "ACCEPT_DEMO"),
+                "City-scoped permissions should not cross municipality boundaries.",
             )
 
 


### PR DESCRIPTION
## What changed
- Adds paikkakunta/city-scoped admin grants so national admins can assign users demo review permissions for one or more Finnish municipalities.
- Stores normalized `city_key` values on demonstrations and recurring demos, with a startup migration runner to backfill existing records.
- Lets city reviewers access admin demo review flows only for assigned cities, while global/national admins retain broader power.
- Adds city-scope controls to the user edit form and saves those grants from the real save endpoint.
- Filters dashboard rows and shared admin task widgets through scoped demo permissions to avoid leaking out-of-scope demonstrations.
- Fixes local Docker dev startup by pinning LocalStack and using `CONFIG_YAML_PATH` instead of a nested config bind mount.

## Why
The admin model needed local review teams, for example reviewers responsible for one or more cities, without giving them national/global admin power. During manual testing, the first implementation exposed two follow-up issues: city grants were displayed but not persisted from the actual save route, and the shared task widget could show out-of-scope demo titles.

## Validation
- `docker compose -f compose.dev.yml up --build -d`
- `docker compose -f compose.dev.yml exec -T -e TEST_MONGO_URI=mongodb://mongo:27018 backend python -m pytest tests/test_wrappers.py tests/test_city_scoped_admin.py` -> 15 passed
- `git diff --check`
- Manual Flask-session checks: city reviewer can access Helsinki demo review/approve, gets 403 for Turku, and Turku is absent from dashboard/sidebar HTML.
- Verified automatic migration record `003_city_keys` in `schema_migrations`.

## History repair
The initial feature commit was accidentally pushed to `main`, which triggered main-branch CI. Main now contains a non-destructive revert commit, and this replacement PR reapplies both intended commits on top of that corrected base.
