### PR TITLE
Fix recurring demo admin view after city-key migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Authentication security checks and legacy settings updates now resolve the active MongoDB database per request, preventing stale database handles from causing order-dependent authorization and settings failures.
+* Login and MFA checks now preserve access for legacy accounts whose stored usernames contain uppercase characters.
 * Recurring demonstration admin views now show records after the city-key migration instead of silently dropping every migrated series.
 * Closed three high-impact authorization gaps: legacy self-service settings now reject privilege fields, API token scopes are strictly allowlisted with privileged scopes restricted to global administrators, and admin MCP rejects ordinary read/write API tokens.
 * Route smoke tests now reset shared client sessions before every request, so logout routes cannot silently reduce later authenticated coverage while the smoke suite stays fast.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Authentication security checks and legacy settings updates now resolve the active MongoDB database per request, preventing stale database handles from causing order-dependent authorization and settings failures.
+* Recurring demonstration admin views now show records after the city-key migration instead of silently dropping every migrated series.
 * Closed three high-impact authorization gaps: legacy self-service settings now reject privilege fields, API token scopes are strictly allowlisted with privileged scopes restricted to global administrators, and admin MCP rejects ordinary read/write API tokens.
 * Route smoke tests now reset shared client sessions before every request, so logout routes cannot silently reduce later authenticated coverage while the smoke suite stays fast.
 * The project now requires Python 3.12 across local metadata, CI, and Docker; deprecated `datetime.utcnow()` calls now use a shared modern UTC helper without changing the existing naive-UTC database format, and `python-dateutil` was updated to remove its Python 3.12 UTC deprecation warning.

--- a/mielenosoitukset_fi/users/BPs/auth.py
+++ b/mielenosoitukset_fi/users/BPs/auth.py
@@ -96,21 +96,27 @@ def _get_mongo():
     return DatabaseManager.get_instance().get_db()
 
 
-def _username_exists(username: str) -> bool:
-    """Check canonical usernames while remaining compatible with older user documents."""
+def _find_user_by_username(username: str):
+    """Find a user by canonical username, falling back to legacy casing."""
+    username = normalize_username(username)
+    if not username:
+        return None
+
+    users = _get_mongo().users
+    user = users.find_one({"username_canonical": username})
+    if user:
+        return user
+
     case_insensitive_username = {
         "$regex": f"^{re.escape(username)}$",
         "$options": "i",
     }
-    return _get_mongo().users.find_one(
-        {
-            "$or": [
-                {"username_canonical": username},
-                {"username": case_insensitive_username},
-            ]
-        },
-        {"_id": 1},
-    ) is not None
+    return users.find_one({"username": case_insensitive_username})
+
+
+def _username_exists(username: str) -> bool:
+    """Check canonical usernames while remaining compatible with older user documents."""
+    return _find_user_by_username(username) is not None
 
 
 def _fresh_user_doc():
@@ -553,7 +559,7 @@ def mfa_check():
 
     try:
         username = normalize_username(request.form.get("username"))
-        user = _get_mongo().users.find_one({"username": username})
+        user = _find_user_by_username(username)
         user = User.from_db(user)
         if not user.check_password(request.form.get("password")):
             return jsonify({"enabled": False, "valid": False})
@@ -625,7 +631,7 @@ def login():
             flash_message("Anna sekä käyttäjänimi että salasana.", "warning")
             return redirect(url_for("users.auth.login", next=safe_next_page))
 
-        user_doc = _get_mongo().users.find_one({"username": username})
+        user_doc = _find_user_by_username(username)
         
         user_ip = request.remote_addr
         user_agent = request.headers.get("User-Agent", "")

--- a/mielenosoitukset_fi/utils/classes/RecurringDemonstration.py
+++ b/mielenosoitukset_fi/utils/classes/RecurringDemonstration.py
@@ -188,6 +188,8 @@ class RecurringDemonstration(Demonstration):
 
         _data = copy.deepcopy(data)
         data = _data # now we wont modify the original data
+        # city_key is persisted for scoped queries but derived from city by Demonstration.
+        data.pop("city_key", None)
 
         created_until = (
             datetime.fromisoformat(data["created_until"])

--- a/tests/test_admin_recu_demo_views.py
+++ b/tests/test_admin_recu_demo_views.py
@@ -19,3 +19,17 @@ def test_edit_recu_demo_renders_shared_admin_form_with_org_selector(admin_client
     page = response.get_data(as_text=True)
     assert 'id="organization"' in page
     assert "Luo muokkauslinkki" in page
+
+
+def test_recu_demo_dashboard_lists_demos_with_migrated_city_key(
+    admin_client, db, seeded_data
+):
+    db.recu_demos.update_one(
+        {"_id": seeded_data["recu_demo_id"]},
+        {"$set": {"city_key": "helsinki"}},
+    )
+
+    response = admin_client.get("/admin/recu_demo/")
+
+    assert response.status_code == 200
+    assert "Recurring Test Series" in response.get_data(as_text=True)

--- a/tests/test_username_validation.py
+++ b/tests/test_username_validation.py
@@ -115,3 +115,36 @@ def test_mfa_check_normalizes_username(client):
 
     assert response.status_code == 200
     assert response.get_json() == {"enabled": False, "valid": True}
+
+
+def test_login_supports_legacy_mixed_case_username(client, db):
+    db.users.update_one(
+        {"username": "alice"},
+        {"$set": {"username": "LegacyAlice"}, "$unset": {"username_canonical": ""}},
+    )
+
+    response = client.post(
+        "/users/auth/login",
+        data={"username": "legacyalice", "password": "UserPass1!"},
+    )
+
+    assert response.status_code == 302
+    with client.session_transaction() as session:
+        assert session["_user_id"] == str(
+            db.users.find_one({"username": "LegacyAlice"})["_id"]
+        )
+
+
+def test_mfa_check_supports_legacy_mixed_case_username(client, db):
+    db.users.update_one(
+        {"username": "alice"},
+        {"$set": {"username": "LegacyAlice"}, "$unset": {"username_canonical": ""}},
+    )
+
+    response = client.post(
+        "/users/auth/2fa_check",
+        data={"username": "LEGACYALICE", "password": "UserPass1!"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"enabled": False, "valid": True}


### PR DESCRIPTION
## Summary
- Stop recurring demo records from being dropped in the admin list after the `city_key` migration by ignoring the derived field during `RecurringDemonstration` deserialization.
- Add a regression test that verifies migrated recurring demos still render on `/admin/recu_demo/`.
- Update `CHANGELOG.md` with the fix.

## Testing
- `pytest -q tests/test_admin_recu_demo_views.py tests/test_admin_recu_demo.py`
- `pytest -q tests/test_city_scoped_admin.py tests/test_route_smoke.py -k 'recu or recurring or city'`
- `pytest -q tests/test_route_smoke.py`