### PR TITLE
Expand privacy notice disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Streamlined `_path_value` logic in test route smoke tests and enhanced payload generation for better test coverage and maintainability.
 
 ### Added
+* Expanded the public privacy notice to disclose the service's actual personal-data categories, processing purposes and legal bases, cookies and analytics, recipients, current retention limitations, and data-subject rights.
 * Added shared detailed and boolean username validators, canonical username storage for new accounts, and normalized availability, login, and MFA checks for consistent, safer account handling.
 * Added paikkakunta-scoped admin grants so national admins can assign users demonstration review permissions for one or more Finnish municipalities while keeping national/global admins above local reviewers.
 * Added an automatic MongoDB migration runner and registered the city-key backfill so future app starts apply safe, tracked data migrations without manual script execution.

--- a/mielenosoitukset_fi/templates/privacy.html
+++ b/mielenosoitukset_fi/templates/privacy.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _('Yksityisyydensuoja ja GDPR') }}{% endblock %}
+{% block title %}{{ _('Tietosuojaseloste') }}{% endblock %}
 
 {% block styles %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/toolbox.css') }}" />
@@ -15,60 +15,98 @@
 <div class="container-main-content">
   <section class="hero-section">
     <div class="hero-content">
-      <h1>{{ _('Yksityisyydensuoja ja GDPR') }}</h1>
+      <h1>{{ _('Tietosuojaseloste') }}</h1>
       <p class="lead">
-{{ _('Mielenosoitukset.fi sitoutuu suojelemaan käyttäjiensä yksityisyyttä ja noudattamaan EU:n yleistä tietosuoja-asetusta (GDPR). Tämä osio kertoo, kuinka keräämme, käytämme ja suojelemme henkilötietojasi.') }}
+        {{ _('Tässä selosteessa kerromme, mitä henkilötietoja Mielenosoitukset.fi-palvelu käsittelee, miksi tietoja käsitellään ja miten voit käyttää oikeuksiasi.') }}
       </p>
+      <p><strong>{{ _('Päivitetty: 9.6.2026') }}</strong></p>
     </div>
   </section>
 
   <section class="section-card">
-    <h2>{{ _('Mitä tietoja keräämme?') }}</h2>
+    <h2>{{ _('Rekisterinpitäjä ja yhteystiedot') }}</h2>
+    <p>{{ _('Rekisterinpitäjä on riippumattomana ja voittoa tavoittelemattomana projektina ylläpidettävä Mielenosoitukset.fi-palvelu.') }}</p>
+    <p>
+      {{ _('Tietosuojaa koskevat kysymykset ja rekisteröidyn oikeuksia koskevat pyynnöt:') }}
+      <a href="mailto:tuki@mielenosoitukset.fi">tuki@mielenosoitukset.fi</a>
+    </p>
+  </section>
+
+  <section class="section-card">
+    <h2>{{ _('Mitä henkilötietoja käsittelemme?') }}</h2>
     <ul>
-      <li><strong>{{ _('Yhteystiedot') }}</strong>: {{ _('kuten nimi ja sähköpostiosoite, jos olet yhteydessä meihin tai ilmoitat tapahtumasi sivustolla.') }}</li>
-      <li><strong>{{ _('Käyttäjätoiminta') }}</strong>: {{ _('tiedot, kuten selaushistoria, klikkaukset ja käyttämäsi laitteen tiedot.') }}</li>
-      <li><strong>{{ _('Evästetiedot') }}</strong>: {{ _('käytämme evästeitä parantaaksemme käyttökokemustasi ja kerätäksemme analytiikkaa sivuston toiminnasta.') }}</li>
+      <li><strong>{{ _('Käyttäjätilit ja profiilit:') }}</strong> {{ _('käyttäjänimi, sähköpostiosoite, salasanan tiiviste, näyttönimi, profiilitiedot, käyttöoikeudet, seuratut kohteet sekä tiliin liittyvät asetukset ja tunnisteet.') }}</li>
+      <li><strong>{{ _('Mielenosoitusten ilmoittajat ja järjestäjät:') }}</strong> {{ _('nimi, sähköpostiosoite, verkkosivut, organisaatiotiedot sekä valinnat siitä, mitkä järjestäjätiedot näytetään julkisesti. Ilmoitukseen liittyvä muokkaus- tai peruutuslinkki voi sisältää yksilöllisen tunnisteen.') }}</li>
+      <li><strong>{{ _('Muistutukset, yhteydenotot ja raportit:') }}</strong> {{ _('sähköpostiosoite ja viestin tai raportin sisältö sekä tarvittaessa siihen liittyvä käyttäjä- tai tapahtumatunniste.') }}</li>
+      <li><strong>{{ _('Tekniset ja turvallisuustiedot:') }}</strong> {{ _('IP-osoite, selaimen tai laitteen User-Agent-tieto, aikaleima, pyydetty osoite, toiminnon onnistuminen sekä turvallisuus- tai virhetilanteen syy.') }}</li>
+      <li><strong>{{ _('Hallinta-, muutos- ja virhelokit:') }}</strong> {{ _('ylläpidon ja automaattisten toimintojen lokit, muutosten historia sekä virhetilanteissa pyyntöön liittyviä metatietoja. Mielenosoituksen lähetysvirheen loki voi sisältää myös lähetetyn lomakkeen tietoja.') }}</li>
+      <li><strong>{{ _('Katseluanalytiikka:') }}</strong> {{ _('mielenosoituksen tunniste, katselun ajankohta sekä mahdollinen käyttäjä- tai sessiotunniste. Palvelu käyttää tietoja koontitilastojen muodostamiseen.') }}</li>
+    </ul>
+    <p>{{ _('Tiedot saadaan pääasiassa sinulta itseltäsi, käyttämästäsi laitteesta ja selaimesta sekä palvelun käytön yhteydessä syntyvistä lokeista.') }}</p>
+  </section>
+
+  <section class="section-card">
+    <h2>{{ _('Käsittelyn tarkoitukset ja oikeusperusteet') }}</h2>
+    <ul>
+      <li><strong>{{ _('Palvelun tarjoaminen ja käyttäjätilin ylläpito:') }}</strong> {{ _('käsittely on tarpeen pyytämäsi palvelun toteuttamiseksi ja käyttöehtojen mukaisen käyttäjäsuhteen hoitamiseksi.') }}</li>
+      <li><strong>{{ _('Mielenosoitusten julkaiseminen, yhteydenpito ja muistutukset:') }}</strong> {{ _('käsittely perustuu pyytämääsi palveluun ja antamiisi tietoihin. Julkisesti näytettävät järjestäjätiedot määräytyvät ilmoituksen yhteydessä tehtyjen valintojen perusteella.') }}</li>
+      <li><strong>{{ _('Tietoturva, väärinkäytösten estäminen ja palvelun virheiden selvittäminen:') }}</strong> {{ _('käsittely perustuu rekisterinpitäjän oikeutettuun etuun suojata palvelua, käyttäjiä ja tietoja sekä selvittää häiriöitä.') }}</li>
+      <li><strong>{{ _('Palvelun ylläpito ja kehittäminen:') }}</strong> {{ _('koontitilastojen ja hallintalokien käsittely perustuu oikeutettuun etuun ymmärtää palvelun toimintaa ja parantaa sitä.') }}</li>
+      <li><strong>{{ _('Lakisääteisten velvoitteiden ja oikeusvaateiden hoitaminen:') }}</strong> {{ _('tietoja voidaan käsitellä lakisääteisen velvoitteen täyttämiseksi tai oikeusvaateen laatimiseksi, esittämiseksi tai puolustamiseksi.') }}</li>
     </ul>
   </section>
+
   <section class="section-card">
-    <h2>{{ _('Mihin käytämme tietoja?') }}</h2>
-    <p>{{ _('Keräämiämme tietoja käytetään seuraaviin tarkoituksiin:') }}</p>
-    <ul>
-      <li>{{ _('Tarjotaksemme ja ylläpitääksemme palveluamme.') }}</li>
-      <li>{{ _('Parantaaksemme käyttökokemusta ja analysoidaksemme sivuston käyttöä.') }}</li>
-      <li>{{ _('Yhteydenottoon, jos olet ilmoittanut tapahtuman tai pyytänyt lisätietoja.') }}</li>
-    </ul>
+    <h2>{{ _('Julkiset tiedot') }}</h2>
+    <p>{{ _('Mielenosoitusten tiedot on tarkoitettu julkaistaviksi. Järjestäjän nimi, sähköposti tai muu yhteystieto näytetään julkisesti vain ilmoituksen yhteydessä tehtyjen näkyvyysvalintojen mukaisesti. Julkisia tietoja voivat lukea myös hakukoneet ja muut palvelut.') }}</p>
   </section>
+
   <section class="section-card">
-    <h2>{{ _('Kenelle jaamme tietoja?') }}</h2>
-    <p>{{ _('Emme jaa henkilötietojasi kolmansille osapuolille ilman suostumustasi, paitsi seuraavissa tilanteissa:') }}</p>
-    <ul>
-      <li><strong>{{ _('Lain vaatimukset') }}</strong>: {{ _('jos meidän on jaettava tietoja lain, viranomaispyynnön tai oikeusprosessin perusteella.') }}</li>
-      <li><strong>{{ _('Palveluntarjoajat') }}</strong>: {{ _('voimme käyttää kolmansia osapuolia teknisen tuen tai palvelun toimittamiseen (esim. analytiikka), jotka ovat GDPR:n mukaisia.') }}</li>
-    </ul>
+    <h2>{{ _('Evästeet ja vastaavat tunnisteet') }}</h2>
+    <p>{{ _('Palvelu käyttää välttämättömiä sessioevästeitä kirjautumiseen, tietoturvaan ja palvelun toimintaan. Lisäksi selain voi tallentaa käyttöliittymävalintoja ja mielenosoitusten tykkäystietoja. Katseluanalytiikka voi käyttää sessiotunnistetta saman istunnon tapahtumien yhdistämiseen.') }}</p>
+    <p>{{ _('Palvelun oma katseluanalytiikka ei edellytä kolmannen osapuolen analytiikkapalvelua. Voit poistaa tai estää evästeitä selaimesi asetuksista, mutta välttämättömien evästeiden estäminen voi rikkoa kirjautumisen tai muita toimintoja.') }}</p>
   </section>
+
   <section class="section-card">
-    <h2>{{ _('Kuinka kauan säilytämme tietojasi?') }}</h2>
-    <p>{{ _('Säilytämme henkilötietojasi vain niin kauan kuin on tarpeellista palvelun tarjoamisen ja lakisääteisten vaatimusten täyttämiseksi.') }}</p>
+    <h2>{{ _('Tietojen vastaanottajat ja siirrot') }}</h2>
+    <p>{{ _('Tietoja käsittelevät vain ne ylläpitäjät ja palveluntarjoajat, joille se on tarpeen palvelun tuottamiseksi, ylläpitämiseksi, sähköpostien lähettämiseksi, tietoturvan varmistamiseksi tai virheiden selvittämiseksi. Tietoja voidaan luovuttaa viranomaiselle lain tai sitovan pyynnön perusteella.') }}</p>
+    <p>{{ _('Tietoja ei myydä. Jos palveluntarjoaja käsittelee tietoja Euroopan talousalueen ulkopuolella, siirrossa käytetään soveltuvan tietosuojalainsäädännön edellyttämää siirtoperustetta ja suojatoimia.') }}</p>
   </section>
+
+  <section class="section-card">
+    <h2>{{ _('Tietojen säilytys') }}</h2>
+    <p>{{ _('Käyttäjätilin ja palvelupyyntöjen toteuttamiseksi tarvittavia tietoja säilytetään niin kauan kuin tili tai palvelusuhde on voimassa. Mielenosoituksiin liittyviä julkaisu-, järjestäjä- ja muutoshistoriatietoja voidaan säilyttää myös tapahtuman jälkeen palvelun historian, moderoinnin ja oikeusvaateiden vuoksi.') }}</p>
+    <p>{{ _('Muistutus-, yhteydenotto-, kirjautumis-, turvallisuus-, virhe- ja hallintalokit säilytetään niin kauan kuin niitä tarvitaan kyseisen toiminnon toteuttamiseen, väärinkäytösten ehkäisyyn, virheiden selvittämiseen tai oikeusvaateiden käsittelyyn. Kaikille nykyisille lokikokoelmille ei ole vielä toteutettu automaattista määräajan jälkeistä poistamista. Säilytysaikoja ja automaattista poistamista tarkennetaan osana palvelun tietosuojakehitystä.') }}</p>
+    <p>{{ _('Tietoja voidaan säilyttää pidempään, jos laki sitä edellyttää tai tieto on tarpeen oikeusvaateen laatimiseksi, esittämiseksi tai puolustamiseksi. Tarpeettomat tiedot poistetaan tai anonymisoidaan.') }}</p>
+  </section>
+
+  <section class="section-card">
+    <h2>{{ _('Tietojen suojaaminen') }}</h2>
+    <p>{{ _('Tietojen käyttö on rajattu käyttöoikeuksin. Palvelu käyttää teknisiä ja organisatorisia suojatoimia, kuten salattuja yhteyksiä, salasanojen tiivistämistä, käyttöoikeuksien hallintaa sekä turvallisuus- ja muutoslokeja. Täydellistä tietoturvaa ei voida taata, mutta havaittuihin riskeihin ja poikkeamiin pyritään reagoimaan viipymättä.') }}</p>
+  </section>
+
   <section class="section-card">
     <h2>{{ _('Sinun oikeutesi') }}</h2>
-    <p>{{ _('GDPR:n mukaisesti sinulla on seuraavat oikeudet:') }}</p>
+    <p>{{ _('Soveltuvan tietosuojalainsäädännön mukaisesti sinulla voi olla oikeus:') }}</p>
     <ul>
-      <li><strong>{{ _('Oikeus nähdä') }}</strong>: {{ _('voit pyytää kopion kaikista sinua koskevista henkilötiedoista.') }}</li>
-      <li><strong>{{ _('Oikeus korjata') }}</strong>: {{ _('voit pyytää virheellisten tietojen oikaisua.') }}</li>
-      <li><strong>{{ _('Oikeus poistamiseen') }}</strong>: {{ _('voit pyytää tietojesi poistamista, jos tietoja ei enää tarvita.') }}</li>
-      <li><strong>{{ _('Oikeus rajoittaa käsittelyä') }}</strong>: {{ _('voit pyytää tietojesi käsittelyn rajoittamista tietyissä tilanteissa.') }}</li>
-      <li><strong>{{ _('Oikeus vastustaa') }}</strong>: {{ _('sinulla on oikeus vastustaa tietojesi käsittelyä tietyissä tilanteissa.') }}</li>
+      <li>{{ _('saada tietoa henkilötietojesi käsittelystä ja tarkastaa sinua koskevat tiedot;') }}</li>
+      <li>{{ _('pyytää virheellisten tai puutteellisten tietojen oikaisua;') }}</li>
+      <li>{{ _('pyytää tietojen poistamista tai käsittelyn rajoittamista lain sallimissa tilanteissa;') }}</li>
+      <li>{{ _('vastustaa oikeutettuun etuun perustuvaa käsittelyä henkilökohtaiseen tilanteeseesi liittyvällä perusteella;') }}</li>
+      <li>{{ _('saada itse toimittamasi tiedot jäsennellyssä ja koneellisesti luettavassa muodossa, kun oikeus tietojen siirtämiseen soveltuu; sekä') }}</li>
+      <li>{{ _('tehdä valitus tietosuojavaltuutetun toimistolle, jos katsot henkilötietojesi käsittelyn olevan lainvastaista.') }}</li>
     </ul>
+    <p>{{ _('Oikeudet eivät ole ehdottomia. Pyyntö voidaan esimerkiksi rajata, jos tietojen säilyttäminen on tarpeen lakisääteisen velvoitteen tai oikeusvaateen vuoksi. Voimme pyytää tarpeellisia lisätietoja henkilöllisyytesi varmistamiseksi.') }}</p>
   </section>
-  <section class="section-card">
-    <h2>{{ _('Evästeiden käyttö') }}</h2>
-    <p>{{ _('Käytämme evästeitä ja vastaavia tekniikoita analysoidaksemme verkkosivun käyttöä ja parantaaksemme käyttökokemustasi. Voit hallita evästeasetuksia selaimesi asetuksissa.') }}</p>
-  </section>
+
   <section class="section-card">
     <h2>{{ _('Ota yhteyttä') }}</h2>
-    <p>{{ _('Jos sinulla on kysyttävää tietosuojakäytännöstämme tai haluat käyttää oikeuksiasi, voit ottaa yhteyttä sähköpostitse osoitteeseen') }} <a href="mailto:tuki@mielenosoitukset.fi">tuki@mielenosoitukset.fi</a>.</p>
+    <p>
+      {{ _('Voit käyttää oikeuksiasi tai kysyä henkilötietojesi käsittelystä lähettämällä sähköpostia osoitteeseen') }}
+      <a href="mailto:tuki@mielenosoitukset.fi">tuki@mielenosoitukset.fi</a>.
+      {{ _('Pyrimme vastaamaan ilman aiheetonta viivytystä ja viimeistään kuukauden kuluessa.') }}
+    </p>
+    <p>{{ _('Tietosuojavaltuutetun toimiston yhteystiedot löytyvät osoitteesta') }} <a href="https://tietosuoja.fi/" rel="noopener noreferrer">tietosuoja.fi</a>.</p>
   </section>
 </div>
 {% endblock %}

--- a/tests/test_privacy_policy.py
+++ b/tests/test_privacy_policy.py
@@ -1,0 +1,10 @@
+def test_privacy_policy_discloses_current_personal_data_processing(client):
+    response = client.get("/privacy")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Rekisterinpitäjä ja yhteystiedot" in page
+    assert "Hallinta-, muutos- ja virhelokit" in page
+    assert "Katseluanalytiikka" in page
+    assert "Kaikille nykyisille lokikokoelmille ei ole vielä toteutettu" in page
+    assert "Tietosuojavaltuutetun toimiston" in page


### PR DESCRIPTION
## Summary
- rewrite the public privacy notice to describe the personal data the service currently processes
- document purposes and legal bases, public organizer data, cookies and first-party analytics, recipients, security, retention limitations, and data-subject rights
- explicitly disclose that all current log collections do not yet have automated retention deletion
- add regression coverage for the policy’s key transparency disclosures

## Scope
This is the first, policy-first part of #596. It documents the current implementation honestly; it does not yet implement log redaction, retention TTLs, cookie consent, or account-deletion cascading.

## Validation
- `/tmp/mielenosoitukset-admin-editor-venv/bin/pytest -q --rootdir=tests --confcutdir=tests tests/test_privacy_policy.py tests/test_route_smoke.py tests/test_surface_manifest.py` (6 passed)
- `git diff --check`

Part of #596