### PR TITLE
[codex] Fix preview teardown for container-owned data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.
 
 ### Fixed
+* Closed pull request previews now remove container-owned MongoDB data successfully, preventing leaked Docker networks from exhausting the preview server's address pools.
 * Demo approval and rejection now close linked support cases consistently across direct admin actions, token links, and the auto-close background job; de-escalation also writes back to the correct `case_history` field.
 * Public demo change suggestions now use a guided normal-user form with clearer sectioning, plain-text/Markdown description editing plus live preview, and cleaner route/tag helpers so contributors never need to deal with raw HTML or Python-style list formatting; route points and tags can now also be edited directly by double-clicking their pills.
 * Public cancellation and error-reporting flows now explain more clearly whether an action cancels a demo immediately or only creates an admin-reviewed request, and organizer cancellation emails now spell out the verified-official-contact shortcut versus the normal approval path.

--- a/deploy/preview_deploy.sh
+++ b/deploy/preview_deploy.sh
@@ -175,6 +175,22 @@ create_network() {
   fi
 }
 
+remove_preview_dir() {
+  local preview_dir="$1"
+
+  if [[ ! -d "$preview_dir" ]]; then
+    return
+  fi
+
+  # MongoDB writes files as its container user, so remove mounted contents as
+  # container root before deleting the preview-owned directory itself.
+  docker run --rm \
+    -v "${preview_dir}:/preview" \
+    mongo:8 \
+    find /preview -mindepth 1 -depth -delete
+  rmdir "$preview_dir"
+}
+
 deploy_preview() {
   local pr_number="$1"
   local image_tag="$2"
@@ -290,8 +306,8 @@ destroy_preview() {
   docker rm -f "$mongo_container" >/dev/null 2>&1 || true
   docker rm -f "$mail_container" >/dev/null 2>&1 || true
   rm -f "$snippet_file"
-  rm -rf "$preview_dir"
   docker network rm "$network_name" >/dev/null 2>&1 || true
+  remove_preview_dir "$preview_dir"
 
   eval "$reload_cmd"
 }


### PR DESCRIPTION
## What changed

- remove preview directory contents through a short-lived root container before deleting the directory
- remove the preview network before filesystem cleanup so a filesystem error cannot leak another Docker subnet
- document the fix in `CHANGELOG.md`

## Root cause

The PR-close cleanup ran as the `preview` user, but MongoDB created files in its bind mount under a container-owned UID. `rm -rf` failed with `Permission denied`, and `set -e` stopped teardown before the preview Docker network was removed. Accumulated leaked networks exhausted Docker's default address pools and caused PR 616's preview deployment to fail.

## Validation

- `bash -n deploy/preview_deploy.sh`
- `git diff --check`
- verified the cleanup method on `lc-main` against a synthetic directory containing root-owned nested files
- removed 26 stale closed-PR preview environments from `lc-main` and reran PR 616's failed preview job

`ShellCheck` was not available locally.