### PR TITLE
[codex] Refresh admin management UI and request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.
 
 ### Fixed
+* Organization logos served through the production CDN now omit local and preview-page referrers when embedded or opened, preventing Cloudflare Hotlink Protection from rejecting valid lc-main assets during development and previews.
+* Request logging and rate limiting now restore the real visitor IP from `CF-Connecting-IP` only when the forwarding address belongs to Cloudflare, avoiding Cloudflare-edge IPs without trusting spoofed headers.
 * Admin notification job no longer repeatedly regenerates and logs approval/rejection/preview links for the same pending demonstrations every 5 minutes; completed notification jobs are now properly recognized to prevent duplicate link generation.
 * Demo approval and rejection now close linked support cases consistently across direct admin actions, token links, and the auto-close background job; de-escalation also writes back to the correct `case_history` field.
 * Authentication security checks and legacy settings updates now resolve the active MongoDB database per request, preventing stale database handles from causing order-dependent authorization and settings failures.
@@ -159,6 +161,19 @@
 * Added `docs/roadmap_2026.md`, a project roadmap that groups the April 27, 2026 backlog into admin UX, multilinguality, reliability, and cleanup workstreams with milestones for closing the 2026 baseline issues.
 
 ### Changed
+* Admin suggestion queue, suggestion review, and analytics views now use a calmer blue-and-orange visual style inspired by `/ohjeet`, replacing dense and neon treatments with clearer comparisons, cards, controls, and table hierarchy.
+* Organization management now has a clearer responsive page-number menu with nearby pages, first/last shortcuts, and readable previous/next controls.
+* User management was redesigned into a clearer workspace with account summaries, improved live search, recognizable user identity rows, status and role indicators, responsive pagination, and cleaner actions.
+* User management search, avatar, and summary-card icon alignment were corrected so controls and icon tiles remain centered.
+* The create-user modal now supports dark mode, matches the redesigned user-management workspace, suggests account names from email, explains roles clearly, and shows consistent validation and submission feedback.
+* Login history, forced-password-change, and delete-user modals now share the user-management dark-mode styling and provide clearer loading, confirmation, countdown, success, and error states.
+* Create-user and workflow confirmation buttons now keep readable foreground contrast in the admin light theme.
+* User action dropdowns now remain fully visible above the table footer instead of being clipped by the user-list card.
+* Organization management now matches the redesigned user workspace with profile summaries, clearer search and creation controls, recognizable organization rows, status indicators, themed actions, and responsive pagination.
+* Organization detail pages now use the refreshed admin visual system with a clearer profile summary, member and invitation workspaces, responsive tables, themed confirmations, and inline feedback; the visual system is also documented for future admin views.
+* Organization detail summary, fact, and member icons now remain properly centered instead of inheriting text-layout rules.
+* Organization create and edit forms now match the refreshed admin visual system with focused profile, logo, and social-link sections, clearer guidance, a responsive sticky save bar, and a dark-mode invitation modal.
+* Organization create-form guidance now reflects the first-time setup flow, and its profile-tip icons remain properly centered.
 * Redesigned `/ohjeet` into a clearer documentation-style guide with blue and orange site branding, a scannable table of contents, step-by-step submission help, improved troubleshooting, and mobile-friendly sections.
 * Removed the in-repository Mastobot runtime and Mastobot-specific admin counters from the main repo now that standalone cutover is handled in `mielenosoitukset-fi/mastobot`.
 

--- a/docs/admin_ui_style.md
+++ b/docs/admin_ui_style.md
@@ -1,0 +1,76 @@
+# Admin UI Visual Style
+
+This guide documents the visual language used by the refreshed admin user, organization, suggestion, and analytics pages. New admin views should feel calm, practical, and friendly rather than looking like a generic dashboard template.
+
+## Design Principles
+
+- **Content first.** Use hierarchy, spacing, and short labels before adding decoration.
+- **Calm, not sterile.** Blue carries structure and trust; orange is a small warm accent.
+- **Useful cards only.** A card should group related work or summarize a meaningful fact.
+- **Dark mode is a first-class theme.** Every surface, control, border, modal, and state must remain readable in both themes.
+- **Responsive by default.** Dense tables may scroll horizontally, while page-level grids should collapse cleanly.
+
+## Page Anatomy
+
+Use these elements when they fit the page:
+
+1. A blue gradient hero with a short uppercase kicker, one clear heading, concise supporting copy, and a small group of contextual actions.
+2. A summary row of two to four compact metric cards.
+3. White or dark themed work cards with muted headers and clear section titles.
+4. Tables with quiet borders, uppercase column labels, recognizable identity cells, and grouped row actions.
+5. Friendly empty states that explain what is missing and what can be done next.
+6. Longer edit forms split into focused cards with a responsive side guide and a sticky save bar.
+
+Avoid long instructional paragraphs at the top of operational pages. Put help near the action it explains.
+
+## Tokens
+
+Admin pages currently define scoped CSS custom properties because the refreshed visual system is being adopted incrementally:
+
+```css
+--admin-blue: light-dark(#0033a0, #8bb1ff);
+--admin-blue-dark: light-dark(#00267a, #c5d6ff);
+--admin-blue-soft: light-dark(#edf4ff, #17233b);
+--admin-orange: #ff6600;
+--admin-orange-soft: light-dark(#fff2e8, #3a2418);
+--admin-surface: light-dark(#ffffff, #20252d);
+--admin-surface-muted: light-dark(#f6f8fb, #292f39);
+--admin-border: light-dark(#dce3ec, #424b59);
+--admin-text: light-dark(#172033, #f2f5fa);
+--admin-muted: light-dark(#647083, #b7c0ce);
+```
+
+Page-specific prefixes such as `--orgs-*` or `--users-*` are acceptable until these tokens move into the shared admin stylesheet.
+
+## Shape And Spacing
+
+- Hero radius: `1.5rem`
+- Main card radius: about `1rem`
+- Button and control radius: `.65rem` to `.75rem`
+- Page and card gap: about `1rem`
+- Use subtle borders and restrained shadows. Avoid glowing borders, glass effects, and gradients outside the hero.
+
+## Type And Icons
+
+- Keep headings bold with slightly tight letter spacing.
+- Use compact uppercase kickers and table headers sparingly.
+- Pair icons with text when they improve recognition; icons should sit in small tinted tiles for summary cards and facts.
+- Prefer existing Font Awesome icons and keep icon choices literal.
+
+## Actions And Feedback
+
+- Primary actions use solid blue with white text.
+- Secondary actions use a muted surface and border.
+- Orange is for attention or unusual-but-safe actions.
+- Destructive actions use a soft red surface and explicit confirmation.
+- Use themed modals and inline toasts for workflow feedback instead of browser `alert()` dialogs.
+- Disable controls while their request is running and show a clear success or error result.
+- Keep primary save controls easy to reach on long forms with a restrained sticky save bar.
+
+## Reference Implementations
+
+- `templates/admin_V2/user/list.html`
+- `templates/admin_V2/organizations/dashboard.html`
+- `templates/admin_V2/organizations/view.html`
+- `templates/admin_V2/organizations/form.html`
+- `templates/admin_V2/analytics.html`

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -872,16 +872,10 @@ def _log_token_event(
         )
 
 def _client_ip() -> str:
-    """
-    Get the best-effort client IP.
-    If behind a trusted proxy, prefer X-Forwarded-For first value.
-    """
-    # If you terminate TLS behind a proxy/load balancer, make sure you trust only known proxies
-    xff = request.headers.get("X-Forwarded-For")
-    if xff:
-        # XFF may be a list "client, proxy1, proxy2"
-        return xff.split(",")[0].strip()
-    return request.remote_addr or "0.0.0.0"
+    """Return the trusted real-client IP for token auditing."""
+    from mielenosoitukset_fi.utils.request_ip import get_client_ip
+
+    return get_client_ip("0.0.0.0")
 
 def _user_agent() -> str:
     return request.headers.get("User-Agent", "")[:512]

--- a/mielenosoitukset_fi/admin/admin_org_bp.py
+++ b/mielenosoitukset_fi/admin/admin_org_bp.py
@@ -137,6 +137,26 @@ def organization_control():
     query = construct_query(search_query, org_limiter)
 
     total_count = mongo.organizations.count_documents(query)
+    summary_query = construct_query("", org_limiter)
+    organization_summary = {
+        "all": mongo.organizations.count_documents(summary_query),
+        "verified": mongo.organizations.count_documents(
+            {**summary_query, "verified": True}
+        ),
+        "missing_website": mongo.organizations.count_documents(
+            {
+                **summary_query,
+                "$or": [
+                    {"website": {"$exists": False}},
+                    {"website": None},
+                    {"website": ""},
+                ],
+            }
+        ),
+        "memberships": mongo.memberships.count_documents(
+            {"organization_id": {"$in": org_limiter}} if org_limiter is not None else {}
+        ),
+    }
     total_pages = (total_count + per_page - 1) // per_page if total_count else 1
     if page > total_pages:
         page = total_pages
@@ -162,6 +182,12 @@ def organization_control():
 
     prev_page_url = build_page_url(prev_page) if prev_page else None
     next_page_url = build_page_url(next_page) if next_page else None
+    page_window_start = max(1, page - 2)
+    page_window_end = min(total_pages, page + 2)
+    visible_pages = [
+        {"number": page_number, "url": build_page_url(page_number)}
+        for page_number in range(page_window_start, page_window_end + 1)
+    ]
 
     _log_org_event(
         "organization_dashboard_view",
@@ -181,6 +207,11 @@ def organization_control():
         next_page=next_page,
         prev_page_url=prev_page_url,
         next_page_url=next_page_url,
+        visible_pages=visible_pages,
+        first_page_url=build_page_url(1),
+        last_page_url=build_page_url(total_pages),
+        total_count=total_count,
+        organization_summary=organization_summary,
     )
 
 
@@ -209,7 +240,7 @@ def construct_query(search_query, org_limiter):
             ]
         }
 
-    if org_limiter:
+    if org_limiter is not None:
         query["_id"] = {"$in": org_limiter}
 
     return query

--- a/mielenosoitukset_fi/admin/admin_user_bp.py
+++ b/mielenosoitukset_fi/admin/admin_user_bp.py
@@ -46,6 +46,16 @@ def user_control():
     per_page = request.args.get("per_page", default=20, type=int) or 20
     per_page = min(max(per_page, 1), 100)
     pending_token_requests = mongo.api_token_requests.count_documents({"status": "pending"})
+    user_summary = {
+        "all": mongo.users.count_documents({}),
+        "confirmed": mongo.users.count_documents({"confirmed": True}),
+        "admins": mongo.users.count_documents(
+            {"role": {"$in": ["admin", "global_admin", "god"]}}
+        ),
+        "never_logged_in": mongo.users.count_documents(
+            {"$or": [{"last_login": {"$exists": False}}, {"last_login": None}]}
+        ),
+    }
     search_filter = {}
     if search_query:
         escaped_query = re.escape(search_query)
@@ -62,6 +72,9 @@ def user_control():
     page = min(page, total_pages)
     prev_page = page - 1 if page > 1 else None
     next_page = page + 1 if page < total_pages else None
+    page_window_start = max(1, page - 2)
+    page_window_end = min(total_pages, page + 2)
+    visible_pages = list(range(page_window_start, page_window_end + 1))
     users_cursor = (
         mongo.users.find(search_filter)
         .sort("username", 1)
@@ -79,6 +92,8 @@ def user_control():
         next_page=next_page,
         pending_token_requests=pending_token_requests,
         total_users=total_users,
+        user_summary=user_summary,
+        visible_pages=visible_pages,
     )
 
 
@@ -560,18 +575,19 @@ def create_user():
     """
     data = request.get_json() if request.is_json else request.form
 
-    email = data.get("email")
-    username = data.get("username") or email.split("@")[0]
-    displayname = data.get("displayname") or username
-    role = data.get("role") or "user"
-
-    # Basic validation
+    email = (data.get("email") or "").strip()
     if not email:
         flash_message("Sähköposti on pakollinen.", "error")
         return redirect(request.referrer or url_for("admin_user.user_control"))
     if not valid_email(email):
         flash_message("Virheellinen sähköpostimuoto.", "error")
         return redirect(request.referrer or url_for("admin_user.user_control"))
+
+    username = (data.get("username") or email.split("@")[0]).strip()
+    displayname = (data.get("displayname") or username).strip()
+    role = data.get("role") or "user"
+
+    # Basic validation
     if role not in ["user", "admin", "global_admin"]:
         flash_message("Rooli ei ole kelvollinen.", "error")
         return redirect(request.referrer or url_for("admin_user.user_control"))

--- a/mielenosoitukset_fi/admin/utils.py
+++ b/mielenosoitukset_fi/admin/utils.py
@@ -12,6 +12,7 @@ from flask_login import current_user
 from mielenosoitukset_fi.database_manager import DatabaseManager
 from mielenosoitukset_fi.utils.classes import Organization
 from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 from mielenosoitukset_fi.demonstrations.audit import log_super_audit
 
 db_manager = DatabaseManager().get_instance()
@@ -177,8 +178,8 @@ def capture_request_context() -> dict | None:
         return {
             "path": request.path,
             "method": request.method,
-            "remote_addr": request.headers.get("X-Forwarded-For", request.remote_addr),
-            "ip": request.remote_addr,
+            "remote_addr": get_client_ip(),
+            "ip": get_client_ip(),
             "args": request.args.to_dict(flat=False),
             "form_keys": list(request.form.keys()),
             "json_keys": list((request.get_json(silent=True) or {}).keys()),

--- a/mielenosoitukset_fi/api/routes.py
+++ b/mielenosoitukset_fi/api/routes.py
@@ -25,6 +25,7 @@ from mielenosoitukset_fi.utils.tokens import (
 )
 from mielenosoitukset_fi.api.exceptions import ApiException, Message
 from mielenosoitukset_fi.utils.cache import cache, should_skip_cache
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 
 mongo = DatabaseManager().get_instance().get_db()
 api_bp = Blueprint("api", __name__)
@@ -82,7 +83,7 @@ def token_required(required_scopes=None, auto_renew=True):
                 "timestamp": datetime.now(),
                 "endpoint": request.path,
                 "method": request.method,
-                "ip": request.remote_addr
+                "ip": get_client_ip()
             })
 
             # Attach token record to request

--- a/mielenosoitukset_fi/app.py
+++ b/mielenosoitukset_fi/app.py
@@ -40,7 +40,7 @@ babel = Babel()
 
 
 from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 
 
 def _configure_timezone(app):
@@ -73,7 +73,7 @@ def create_app(config_overrides=None) -> Flask:
     
     if app.config.get("ENFORCE_RATELIMIT", True):
         Limiter(
-            get_remote_address,
+            get_client_ip,
             app=app,
             default_limits=rate_limit_defaults,
             storage_uri=app.config["MONGO_URI"],

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -34,6 +34,7 @@ from mielenosoitukset_fi.utils.database import DEMO_FILTER
 from mielenosoitukset_fi.utils.analytics import log_demo_view
 from mielenosoitukset_fi.utils.wrappers import permission_required, depracated_endpoint
 from mielenosoitukset_fi.utils.media_helpers import get_demo_cover_image
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 from mielenosoitukset_fi.a import generate_demo_sentence
 from pymongo.errors import DuplicateKeyError
 from pymongo import ASCENDING, DESCENDING
@@ -255,7 +256,7 @@ def _log_submit_error(message, code, status=400, extra=None):
                 "request_path": request.path,
                 "request_method": request.method,
                 "query_args": request.args.to_dict(flat=False),
-                "ip": request.remote_addr,
+                "ip": get_client_ip(),
                 "user_agent": request.headers.get("User-Agent"),
                 "referer": request.headers.get("Referer"),
                 "form_snapshot": form_snapshot,
@@ -1196,7 +1197,7 @@ def init_routes(app):
                     "status": "processing",
                     "created_at": now,
                     "fingerprint": submission_fingerprint,
-                    "ip": request.remote_addr,
+                    "ip": get_client_ip(),
                 }
                 
                 try:
@@ -1239,7 +1240,7 @@ def init_routes(app):
                         "$set": {
                             "fingerprint": submission_fingerprint,
                             "updated_at": now,
-                            "ip": request.remote_addr,
+                            "ip": get_client_ip(),
                         }
                     },
                 )
@@ -1565,7 +1566,7 @@ def init_routes(app):
                         if current_user.is_authenticated
                         else None
                     ),
-                    "ip": request.remote_addr,
+                    "ip": get_client_ip(),
                 }
                 if mark_cancelled:
                     report_doc["cancelled_reported"] = True
@@ -1595,7 +1596,7 @@ def init_routes(app):
                             if current_user.is_authenticated
                             else None
                         ),
-                        "ip": request.remote_addr,
+                        "ip": get_client_ip(),
                         "reported_cancelled": mark_cancelled,
                         "reporter_email": reporter_email,
                     }
@@ -1620,7 +1621,7 @@ def init_routes(app):
                     "error": error,
                     "date": datetime.now(),
                     "user": current_user._id if current_user.is_authenticated else None,
-                    "ip": request.remote_addr,
+                    "ip": get_client_ip(),
                     "reported_cancelled": mark_cancelled,
                     "reporter_email": reporter_email,
                 }
@@ -2171,7 +2172,7 @@ def init_routes(app):
                 'reporter_comment': reporter_comment,
                 'reporter_email': reporter_email,
                 'created_at': utcnow(),
-                'ip': request.remote_addr,
+                'ip': get_client_ip(),
                 'user_agent': request.headers.get('User-Agent'),
                 'status': 'new',
             }
@@ -2468,7 +2469,7 @@ def init_routes(app):
             "created_at": utcnow(),
             "fields": {},
             "meta": {
-                "ip": request.remote_addr,
+                "ip": get_client_ip(),
                 "user_agent": request.headers.get("User-Agent"),
                 "submitter_email": request.form.get("email")
             },
@@ -2683,7 +2684,7 @@ def init_routes(app):
     @app.route("/subscribe_reminder/<demo_id>", methods=["POST"])
     def subscribe_reminder(demo_id):
         user_email = request.form.get("user_email")
-        user_ip = request.remote_addr
+        user_ip = get_client_ip()
         user_agent = request.headers.get("User-Agent", "")
 
         if not user_email:

--- a/mielenosoitukset_fi/demonstrations/audit.py
+++ b/mielenosoitukset_fi/demonstrations/audit.py
@@ -12,6 +12,7 @@ from flask_login import current_user
 
 from mielenosoitukset_fi.database_manager import DatabaseManager
 from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 
 mongo = DatabaseManager().get_instance().get_db()
 
@@ -86,7 +87,7 @@ def log_demo_audit_entry(
     ip = ip_address
     if ip is None and has_request_context():
         try:
-            ip = request.remote_addr
+            ip = get_client_ip()
         except RuntimeError:
             ip = None
 
@@ -191,7 +192,7 @@ def log_super_audit(
                 "method": request.method,
                 "args": request.args.to_dict(flat=False),
                 "form_keys": list(request.form.keys()),
-                "remote_addr": request.remote_addr,
+                "remote_addr": get_client_ip(),
                 "user_agent": getattr(request.user_agent, "string", str(request.user_agent)),
             }
         except Exception:

--- a/mielenosoitukset_fi/error_handlers.py
+++ b/mielenosoitukset_fi/error_handlers.py
@@ -1,5 +1,6 @@
 from mielenosoitukset_fi.utils.logger import logger
 from flask import Flask, render_template, request
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 
 
 def register_error_handlers(app: Flask):
@@ -54,11 +55,11 @@ def register_error_handlers(app: Flask):
         """
         # Log the 401 error details
         logger.warning(
-            f"401 Unauthorized: {request.path} attempted by {request.remote_addr}\n{error}"
+            f"401 Unauthorized: {request.path} attempted by {get_client_ip()}\n{error}"
         )
 
         # You could also send this data to a monitoring service, e.g.:
-        # monitor_service.log_401_error(path=request.path, ip=request.remote_addr)
+        # monitor_service.log_401_error(path=request.path, ip=get_client_ip())
 
         return render_template("errors/401.html"), 401
 

--- a/mielenosoitukset_fi/static/css/admin/stats.css
+++ b/mielenosoitukset_fi/static/css/admin/stats.css
@@ -1,372 +1,366 @@
-:root {
-    --holo-surface: rgba(23, 29, 54, 0.72);
-    --holo-highlight: #61f4f4;
-    --holo-accent: #a855f7;
-    --holo-grid: rgba(255, 255, 255, 0.08);
-    --holo-shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
-    --text-strong: #e8f0ff;
-    --text-muted: #8ca0c2;
-    --border-strong: rgba(255, 255, 255, 0.12);
-}
-
 .stats-shell {
-    position: relative;
+    --stats-blue: light-dark(#0033a0, #8bb1ff);
+    --stats-blue-dark: light-dark(#00267a, #b9ceff);
+    --stats-blue-soft: light-dark(#edf4ff, #17233b);
+    --stats-orange: #ff6600;
+    --stats-orange-soft: light-dark(#fff2e8, #3a2418);
+    --stats-surface: light-dark(#ffffff, #20252d);
+    --stats-surface-muted: light-dark(#f6f8fb, #292f39);
+    --stats-border: light-dark(#dce3ec, #424b59);
+    --stats-text: light-dark(#172033, #f2f5fa);
+    --stats-muted: light-dark(#647083, #b7c0ce);
+    --stats-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, 0.08), rgba(0, 0, 0, 0.18));
     display: flex;
     flex-direction: column;
-    gap: 1.75rem;
-    padding-bottom: 2rem;
-    isolation: isolate;
+    gap: 1.35rem;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 0.5rem 0 2rem;
+    color: var(--stats-text);
 }
 
-.stats-shell::before,
-.stats-shell::after {
+.stats-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.75rem, 4vw, 3.25rem);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+        radial-gradient(circle at 92% 5%, rgba(255, 102, 0, 0.38), transparent 18rem),
+        linear-gradient(135deg, #00236e, #0033a0 70%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, 0.18);
+}
+
+.stats-hero::after {
     content: "";
     position: absolute;
-    inset: -8rem auto auto -8rem;
-    width: 40rem;
-    height: 40rem;
-    background: radial-gradient(circle at 30% 30%, rgba(97, 244, 244, 0.18), transparent 60%),
-                radial-gradient(circle at 80% 10%, rgba(168, 85, 247, 0.22), transparent 55%);
-    filter: blur(32px);
-    z-index: -2;
-}
-.stats-shell::after {
-    inset: auto -12rem -6rem auto;
-    background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.1), transparent 60%);
+    right: -75px;
+    bottom: -125px;
+    width: 240px;
+    height: 240px;
+    border: 38px solid rgba(255, 255, 255, 0.08);
+    border-radius: 50%;
 }
 
-.holo-hero {
-    background: linear-gradient(120deg, rgba(17, 24, 39, 0.9), rgba(17, 24, 39, 0.75), rgba(34, 6, 58, 0.7));
-    border: 1px solid var(--border-strong);
-    border-radius: 18px;
-    padding: 1.75rem;
-    overflow: hidden;
-    box-shadow: var(--holo-shadow);
+.stats-hero-copy,
+.stats-hero-note {
     position: relative;
+    z-index: 1;
 }
 
-.holo-grid {
-    position: absolute;
-    inset: 0;
-    background-image:
-        linear-gradient(90deg, var(--holo-grid) 1px, transparent 1px),
-        linear-gradient(0deg, var(--holo-grid) 1px, transparent 1px);
-    background-size: 32px 32px;
-    opacity: 0.4;
-    pointer-events: none;
-}
-.holo-grid .beam {
-    position: absolute;
-    inset: auto auto 0 0;
-    width: 120%;
-    height: 2px;
-    background: linear-gradient(90deg, transparent, var(--holo-highlight), transparent);
-    filter: blur(1px);
-    animation: beam 8s linear infinite;
-}
-.holo-grid .beam:nth-child(2) { animation-delay: -2s; opacity: 0.6; }
-.holo-grid .beam:nth-child(3) { animation-delay: -4s; opacity: 0.4; }
-@keyframes beam {
-    from { transform: translateY(0); }
-    to { transform: translateY(-100%); }
-}
-
-.hero-copy {
-    position: relative;
-    max-width: 700px;
-    color: var(--text-strong);
-    display: grid;
-    gap: 0.5rem;
-}
-.hero-copy h1 {
-    font-family: 'Space Grotesk', 'Inter', system-ui, -apple-system, sans-serif;
-    font-size: clamp(1.9rem, 2vw + 1rem, 2.4rem);
-    letter-spacing: 0.01em;
-    margin: 0;
-}
-.hero-copy .lede {
-    color: var(--text-muted);
-    margin: 0;
-    line-height: 1.5;
-}
-.eyebrow {
+.stats-kicker {
+    margin: 0 0 0.55rem;
+    color: var(--stats-orange);
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    letter-spacing: 0.22em;
-    color: var(--holo-highlight);
-    font-weight: 700;
-    font-size: 0.82rem;
+}
+
+.stats-hero .stats-kicker {
+    color: #ffd6bc;
+}
+
+.stats-hero h1 {
     margin: 0;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    letter-spacing: -0.035em;
 }
 
-.hero-badges {
-    display: flex;
-    gap: 0.6rem;
-    flex-wrap: wrap;
-    margin-top: 0.3rem;
-}
-.badge-signal {
-    background: rgba(97, 244, 244, 0.12);
-    color: var(--holo-highlight);
-    border: 1px solid rgba(97, 244, 244, 0.4);
-}
-.badge-fresh {
-    background: rgba(168, 85, 247, 0.12);
-    color: var(--text-strong);
-    border: 1px solid rgba(168, 85, 247, 0.3);
+.stats-lede {
+    max-width: 680px;
+    margin: 0.8rem 0 0;
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 1rem;
+    line-height: 1.7;
 }
 
-.hero-panels {
-    position: absolute;
-    right: 1.5rem;
-    bottom: 1.5rem;
-    display: grid;
-    gap: 0.75rem;
-    width: min(320px, 40vw);
+.stats-hero-note {
+    min-width: 210px;
+    padding: 1rem 1.15rem;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
 }
-.pulse-card {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    padding: 0.9rem 1rem;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-.pulse-card .label {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-}
-.pulse-card .value {
-    color: var(--text-strong);
-    font-size: 1.5rem;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-}
-.pulse-bar {
-    margin-top: 0.6rem;
-    background: rgba(255, 255, 255, 0.06);
-    height: 8px;
-    border-radius: 999px;
-    overflow: hidden;
-}
-.pulse-bar span {
+
+.stats-hero-note span,
+.stats-hero-note strong {
     display: block;
-    height: 100%;
-    background: linear-gradient(90deg, var(--holo-highlight), #6ee7ff);
-    box-shadow: 0 0 12px rgba(97, 244, 244, 0.5);
 }
-.pulse-bar.alt span {
-    background: linear-gradient(90deg, #c084fc, #6ee7ff);
+
+.stats-hero-note span {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.82rem;
+}
+
+.stats-hero-note strong {
+    margin-top: 0.2rem;
+    color: #fff;
+    font-size: 1rem;
 }
 
 .stat-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.9rem;
 }
 
 .stat-card {
-    background: var(--holo-surface);
-    border: 1px solid var(--border-strong);
-    border-radius: 14px;
-    padding: 1.1rem 1.25rem;
-    box-shadow: var(--holo-shadow);
-    position: relative;
-    overflow: hidden;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.9rem;
+    align-items: start;
+    min-width: 0;
+    padding: 1.2rem;
+    border: 1px solid var(--stats-border);
+    border-radius: 1.1rem;
+    background: var(--stats-surface);
+    box-shadow: var(--stats-shadow);
 }
-.stat-card::after {
-    content: "";
-    position: absolute;
-    inset: -40% auto auto -40%;
-    width: 140%;
-    height: 140%;
-    background: radial-gradient(circle, rgba(97, 244, 244, 0.1), transparent 55%);
-    transform: rotate(-8deg);
-    pointer-events: none;
+
+.stat-icon {
+    display: inline-grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: 0.8rem;
+    color: var(--stats-blue);
+    background: var(--stats-blue-soft);
 }
-.stat-card.highlight::after {
-    background: radial-gradient(circle, rgba(168, 85, 247, 0.16), transparent 60%);
+
+.stat-card.highlight .stat-icon {
+    color: var(--stats-orange);
+    background: var(--stats-orange-soft);
 }
-.stat-card .stat-label {
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    font-weight: 700;
+
+.stat-label,
+.stat-sub {
+    margin: 0;
+    color: var(--stats-muted);
+}
+
+.stat-label {
     font-size: 0.8rem;
-    margin: 0;
+    font-weight: 700;
 }
-.stat-card .stat-value {
-    color: var(--text-strong);
-    font-size: 2rem;
+
+.stat-value {
+    margin: 0.08rem 0;
+    color: var(--stats-text);
+    font-size: clamp(1.6rem, 3vw, 2rem);
     font-weight: 800;
-    margin: 0.1rem 0 0.2rem 0;
-    letter-spacing: 0.01em;
+    line-height: 1.1;
 }
-.stat-card .stat-sub {
-    color: var(--text-muted);
-    margin: 0;
-    font-size: 0.95rem;
+
+.stat-sub {
+    font-size: 0.78rem;
 }
 
 .analytics-panel {
-    background: rgba(14, 19, 33, 0.82);
-    border: 1px solid var(--border-strong);
-    border-radius: 16px;
-    padding: 1.5rem;
-    box-shadow: var(--holo-shadow);
+    overflow: hidden;
+    border: 1px solid var(--stats-border);
+    border-radius: 1.3rem;
+    background: var(--stats-surface);
+    box-shadow: var(--stats-shadow);
 }
+
 .panel-header {
     display: flex;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 1.5rem;
     align-items: flex-start;
-    flex-wrap: wrap;
+    padding: 1.5rem;
+    border-bottom: 1px solid var(--stats-border);
 }
+
 .panel-header h2 {
-    color: var(--text-strong);
-    margin: 0.15rem 0;
-}
-.panel-header .lede {
-    color: var(--text-muted);
     margin: 0;
+    color: var(--stats-text);
+    font-size: 1.4rem;
 }
-.panel-header .lede.small { font-size: 0.95rem; }
+
+.panel-header .stats-description {
+    max-width: 680px;
+    margin: 0.4rem 0 0;
+    color: var(--stats-muted);
+    line-height: 1.6;
+}
 
 .cta-group {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.65rem;
     align-items: center;
     flex-wrap: wrap;
 }
-.btn.futuristic {
-    border-radius: 999px;
-    background: linear-gradient(120deg, #61f4f4, #a855f7);
-    border: none;
-    color: #0a0f1f;
-    box-shadow: 0 10px 40px rgba(97, 244, 244, 0.35);
-    font-weight: 700;
-}
-.ghost-link {
-    color: var(--text-strong);
-    text-decoration: none;
+
+.stats-control,
+.stats-action {
     display: inline-flex;
+    min-height: 2.55rem;
+    gap: 0.5rem;
     align-items: center;
-    gap: 0.3rem;
-    padding: 0.5rem 0.8rem;
-    border: 1px dashed var(--border-strong);
-    border-radius: 10px;
-    transition: border-color 0.2s ease, color 0.2s ease;
+    justify-content: center;
+    padding: 0.58rem 0.85rem;
+    border: 1px solid var(--stats-border);
+    border-radius: 0.75rem;
+    color: var(--stats-text);
+    background: var(--stats-surface-muted);
+    font-size: 0.88rem;
+    font-weight: 700;
+    text-decoration: none;
 }
-.ghost-link:hover {
-    border-color: var(--holo-highlight);
-    color: var(--holo-highlight);
+
+.stats-control {
+    cursor: pointer;
+}
+
+.stats-control input {
+    accent-color: var(--stats-blue);
+}
+
+.stats-action:hover,
+.stats-action:focus {
+    border-color: var(--stats-blue);
+    color: var(--stats-blue-dark);
+}
+
+.stats-action-primary {
+    border-color: var(--stats-blue);
+    color: #fff;
+    background: var(--stats-blue);
+}
+
+.stats-action-primary:hover,
+.stats-action-primary:focus {
+    color: #fff;
+    background: var(--stats-blue-dark);
 }
 
 .table-shell {
-    margin-top: 1.25rem;
-    border: 1px solid var(--border-strong);
-    border-radius: 12px;
-    overflow: hidden;
-    background: rgba(255, 255, 255, 0.02);
+    overflow-x: auto;
 }
+
 .table-shell table {
     width: 100%;
     border-collapse: collapse;
 }
+
 .table-shell th,
 .table-shell td {
-    padding: 0.85rem 1rem;
-    color: var(--text-strong);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 0.95rem 1.5rem;
+    border-bottom: 1px solid var(--stats-border);
+    color: var(--stats-text);
 }
+
 .table-shell th {
-    background: rgba(255, 255, 255, 0.04);
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    font-size: 0.95rem;
+    color: var(--stats-muted);
+    background: var(--stats-surface-muted);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
+
+.table-shell tbody tr:last-child td {
+    border-bottom: 0;
+}
+
 .table-shell tbody tr:hover {
-    background: rgba(97, 244, 244, 0.05);
+    background: var(--stats-blue-soft);
 }
+
 .demo-link {
-    color: var(--holo-highlight);
-    text-decoration: none;
+    color: var(--stats-blue-dark);
     font-weight: 700;
+    text-decoration: none;
 }
+
 .demo-link:hover {
     text-decoration: underline;
 }
+
 .views-cell {
+    width: 190px;
     text-align: right;
 }
-.chip {
+
+.view-count {
     display: inline-flex;
-    align-items: center;
+    min-width: 3rem;
     justify-content: center;
-    padding: 0.25rem 0.7rem;
+    padding: 0.28rem 0.62rem;
     border-radius: 999px;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-}
-.chip.neon {
-    background: rgba(97, 244, 244, 0.15);
-    color: var(--text-strong);
-    border: 1px solid rgba(97, 244, 244, 0.4);
-    box-shadow: 0 0 12px rgba(97, 244, 244, 0.35);
+    color: var(--stats-blue-dark);
+    background: var(--stats-blue-soft);
+    font-weight: 800;
 }
 
 .no-data {
-    color: var(--text-strong);
-    font-weight: 700;
-    background: rgba(255, 255, 255, 0.04);
-    padding: 1.5rem;
-    border: 1px dashed var(--border-strong);
-    border-radius: 12px;
+    padding: 2rem;
+    color: var(--stats-muted);
     text-align: center;
 }
 
 .pagination-shell .page-link {
-    border-radius: 12px;
-    margin: 0 0.15rem;
-    border-color: var(--border-strong);
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--text-strong);
-}
-.pagination-shell .page-link:hover {
-    border-color: var(--holo-highlight);
-    color: var(--holo-highlight);
+    margin: 0 0.12rem;
+    border-color: var(--stats-border);
+    border-radius: 0.65rem;
+    color: var(--stats-blue-dark);
+    background: var(--stats-surface);
 }
 
-.back-button {
-    margin-top: 1rem;
+.pagination-shell .active .page-link {
+    border-color: var(--stats-blue);
+    color: #fff;
+    background: var(--stats-blue);
 }
 
-@media (max-width: 992px) {
-    .hero-panels {
-        position: relative;
-        right: auto;
-        bottom: auto;
-        width: 100%;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        margin-top: 1rem;
+.back-button a {
+    color: var(--stats-blue-dark);
+    font-weight: 700;
+    text-decoration: none;
+}
+
+@media (max-width: 1100px) {
+    .stat-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+}
+
+@media (max-width: 800px) {
+    .stats-hero {
+        grid-template-columns: 1fr;
+    }
+
+    .stats-hero-note {
+        min-width: 0;
+    }
+
     .panel-header {
         flex-direction: column;
     }
-    .cta-group {
+
+    .cta-group,
+    .stats-control,
+    .stats-action {
         width: 100%;
     }
 }
 
-@media (max-width: 640px) {
-    .stats-shell {
-        padding-top: 0.5rem;
+@media (max-width: 560px) {
+    .stat-grid {
+        grid-template-columns: 1fr;
     }
-    .holo-hero {
-        padding: 1.25rem;
-    }
-    .stat-card .stat-value {
-        font-size: 1.7rem;
-    }
-    .panel-header h2 {
-        font-size: 1.3rem;
+
+    .table-shell th,
+    .table-shell td {
+        padding: 0.8rem 1rem;
     }
 }

--- a/mielenosoitukset_fi/templates/admin/suggestion_view.html
+++ b/mielenosoitukset_fi/templates/admin/suggestion_view.html
@@ -2,391 +2,502 @@
 
 {% block styles %}
 <style>
-  :root {
-    --color-text: light-dark(#1e293b, #e2e8f0);
-    --color-text-secondary: light-dark(#64748b, #94a3b8);
-    --color-primary: light-dark(#0033a0, #4d79cc);
-    --color-card-bg: light-dark(#ffffff, #1e1e2e);
-    --color-border: light-dark(#e2e8f0, #404050);
-    --color-shadow: light-dark(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.2));
-    --color-success: light-dark(#10b981, #10b981);
-    --color-success-bg: light-dark(rgba(16, 185, 129, 0.1), rgba(16, 185, 129, 0.2));
-    --color-danger: light-dark(#ef4444, #f87171);
-    --color-danger-hover: light-dark(#dc2626, #fca5a5);
+  .suggestion-review {
+    --review-blue: light-dark(#0033a0, #8bb1ff);
+    --review-blue-dark: light-dark(#00267a, #b9ceff);
+    --review-blue-soft: light-dark(#edf4ff, #17233b);
+    --review-orange: #ff6600;
+    --review-orange-soft: light-dark(#fff2e8, #3a2418);
+    --review-surface: light-dark(#ffffff, #20252d);
+    --review-surface-muted: light-dark(#f6f8fb, #292f39);
+    --review-border: light-dark(#dce3ec, #424b59);
+    --review-text: light-dark(#172033, #f2f5fa);
+    --review-muted: light-dark(#647083, #b7c0ce);
+    --review-success: light-dark(#087f5b, #65d6ac);
+    --review-success-soft: light-dark(#eaf8f2, #17382e);
+    --review-danger: light-dark(#b42318, #ff9b93);
+    --review-danger-soft: light-dark(#fff1f0, #3c2022);
+    max-width: 1200px;
+    margin: 0 auto;
+    color: var(--review-text);
   }
 
-  .view-header {
-    display: flex;
-    justify-content: space-between;
+  .review-back {
+    display: inline-flex;
+    gap: .45rem;
     align-items: center;
-    margin-bottom: 2rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 2px solid var(--color-border);
+    margin-bottom: .85rem;
+    color: var(--review-blue-dark);
+    font-size: .88rem;
+    font-weight: 700;
+    text-decoration: none;
   }
 
-  .view-header h1 {
+  .review-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1.5rem;
+    align-items: end;
+    margin-bottom: 1rem;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .4), transparent 17rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
+
+  .review-kicker {
     margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--color-text);
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+
+  .review-hero h1 {
+    margin: .25rem 0 .55rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3rem);
+    letter-spacing: -.035em;
+  }
+
+  .review-hero p:last-child {
+    max-width: 650px;
+    margin: 0;
+    color: rgba(255,255,255,.8);
+    line-height: 1.65;
   }
 
   .status-badge {
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    font-weight: 600;
-    font-size: 0.9rem;
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    padding: .55rem .85rem;
+    border: 1px solid rgba(255,255,255,.2);
+    border-radius: 999px;
+    color: #fff;
+    background: rgba(255,255,255,.12);
+    font-size: .84rem;
+    font-weight: 800;
   }
 
-  .status-badge.new {
-    background: light-dark(#dcfce7, #1f3a3a);
-    color: light-dark(#166534, #86efac);
-  }
-
-  .status-badge.applied {
-    background: light-dark(#dbeafe, #1e3a5f);
-    color: light-dark(#1e40af, #93c5fd);
-  }
-
-  .status-badge.rejected {
-    background: light-dark(#fee2e2, #3a1f1f);
-    color: light-dark(#991b1b, #fca5a5);
-  }
-
-  .info-panel {
-    background: var(--color-card-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .info-grid {
+  .review-info {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: .75rem;
+    margin-bottom: 1.5rem;
   }
 
   .info-item {
-    display: flex;
-    flex-direction: column;
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid var(--review-border);
+    border-radius: .9rem;
+    background: var(--review-surface);
+  }
+
+  .info-label,
+  .info-value {
+    display: block;
   }
 
   .info-label {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--color-text-secondary);
+    margin-bottom: .35rem;
+    color: var(--review-muted);
+    font-size: .7rem;
+    font-weight: 800;
+    letter-spacing: .07em;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: 0.5rem;
   }
 
   .info-value {
-    font-size: 1rem;
-    color: var(--color-text);
-    word-break: break-all;
+    overflow-wrap: anywhere;
+    color: var(--review-text);
+    font-size: .88rem;
+    font-weight: 650;
   }
 
-  .section-title {
+  .info-value a {
+    color: var(--review-blue-dark);
+  }
+
+  .review-section {
+    margin-top: 1.5rem;
+  }
+
+  .section-heading {
+    display: flex;
+    gap: .8rem;
+    align-items: flex-start;
+    margin-bottom: .9rem;
+  }
+
+  .section-icon {
+    display: inline-grid;
+    flex: 0 0 auto;
+    width: 2.4rem;
+    height: 2.4rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--review-blue);
+    background: var(--review-blue-soft);
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    color: var(--review-text);
     font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text);
-    margin: 2rem 0 1rem 0;
-    padding-bottom: 0.75rem;
-    border-bottom: 2px solid var(--color-border);
   }
 
-  .changes-table {
-    width: 100%;
-    border-collapse: collapse;
-    background: var(--color-card-bg);
-    border-radius: 12px;
+  .section-heading p {
+    margin: .2rem 0 0;
+    color: var(--review-muted);
+    font-size: .88rem;
+  }
+
+  .change-list {
+    display: grid;
+    gap: .85rem;
+  }
+
+  .change-card {
     overflow: hidden;
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--review-border);
+    border-radius: 1rem;
+    background: var(--review-surface);
+    box-shadow: 0 10px 28px light-dark(rgba(28, 48, 82, .06), rgba(0, 0, 0, .14));
   }
 
-  .changes-table thead {
-    background: var(--color-shadow);
+  .change-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: .8rem 1rem;
+    border-bottom: 1px solid var(--review-border);
+    background: var(--review-surface-muted);
   }
 
-  .changes-table th {
-    padding: 1rem;
-    text-align: left;
-    font-weight: 600;
-    color: var(--color-text);
-    border-bottom: 1px solid var(--color-border);
+  .field-name {
+    color: var(--review-text);
+    font-weight: 800;
   }
 
-  .changes-table td {
-    padding: 1rem;
-    border-bottom: 1px solid var(--color-border);
-    color: var(--color-text);
-  }
-
-  .changes-table tbody tr:last-child td {
-    border-bottom: none;
-  }
-
-  .changes-table input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
+  .apply-toggle {
+    display: inline-flex;
+    gap: .5rem;
+    align-items: center;
+    margin: 0;
+    color: var(--review-blue-dark);
+    font-size: .82rem;
+    font-weight: 800;
     cursor: pointer;
-    accent-color: var(--color-primary);
   }
 
-  .original-value {
-    background: var(--color-shadow);
-    padding: 0.75rem;
-    border-radius: 6px;
-    font-family: monospace;
-    font-size: 0.9rem;
-    max-height: 200px;
-    overflow-y: auto;
-    color: var(--color-text);
+  .apply-toggle input {
+    width: 1.05rem;
+    height: 1.05rem;
+    accent-color: var(--review-blue);
   }
 
-  .suggested-value {
-    background: var(--color-success-bg);
-    padding: 0.75rem;
-    border-radius: 6px;
-    border-left: 3px solid var(--color-success);
-    font-family: monospace;
-    font-size: 0.9rem;
-    max-height: 200px;
-    overflow-y: auto;
-    color: var(--color-text);
+  .change-comparison {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .change-value {
+    min-width: 0;
+    padding: 1rem;
+  }
+
+  .change-value + .change-value {
+    border-left: 1px solid var(--review-border);
+  }
+
+  .change-value-label {
+    display: block;
+    margin-bottom: .55rem;
+    color: var(--review-muted);
+    font-size: .7rem;
+    font-weight: 800;
+    letter-spacing: .07em;
+    text-transform: uppercase;
+  }
+
+  .change-value-content {
+    min-height: 3.25rem;
+    max-height: 260px;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    padding: .8rem;
+    border-radius: .7rem;
+    color: var(--review-text);
+    background: var(--review-surface-muted);
+    font-size: .9rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+  }
+
+  .change-value-proposed .change-value-label {
+    color: var(--review-success);
+  }
+
+  .change-value-proposed .change-value-content {
+    border-left: 3px solid var(--review-success);
+    background: var(--review-success-soft);
   }
 
   .comment-box {
-    background: var(--color-card-bg);
-    border-left: 4px solid var(--color-primary);
-    padding: 1.25rem;
-    border-radius: 8px;
-    margin-bottom: 1.5rem;
-    border: 1px solid var(--color-border);
-    color: var(--color-text);
+    padding: 1.1rem 1.2rem;
+    border: 1px solid var(--review-border);
+    border-left: 4px solid var(--review-orange);
+    border-radius: .85rem;
+    color: var(--review-text);
+    background: var(--review-surface);
+    line-height: 1.7;
   }
 
   .actions-panel {
     display: flex;
-    gap: 1rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--color-border);
-    margin-top: 2rem;
-  }
-
-  .btn-apply {
-    background: var(--color-success);
-    color: white;
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
-
-  .btn-apply:hover {
-    background: light-dark(#059669, #059669);
-    transform: translateY(-2px);
-  }
-
-  .btn-reject {
-    background: var(--color-danger);
-    color: white;
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 8px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
-
-  .btn-reject:hover {
-    background: var(--color-danger-hover);
-    transform: translateY(-2px);
-  }
-
-  .btn-back {
-    color: var(--color-primary);
-    text-decoration: none;
-    display: inline-flex;
+    gap: .75rem;
     align-items: center;
-    gap: 0.5rem;
-    font-weight: 600;
-    transition: all 0.3s ease;
+    margin-top: 1rem;
   }
 
-  .btn-back:hover {
-    transform: translateX(-2px);
+  .review-button {
+    display: inline-flex;
+    gap: .5rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.7rem;
+    padding: .65rem 1rem;
+    border: 1px solid transparent;
+    border-radius: .75rem;
+    font-size: .88rem;
+    font-weight: 800;
+    cursor: pointer;
   }
 
-  @media (max-width: 768px) {
-    .view-header {
-      flex-direction: column;
-      align-items: flex-start;
+  .review-button-apply {
+    color: #fff;
+    background: var(--review-blue);
+  }
+
+  .review-button-apply:hover {
+    background: var(--review-blue-dark);
+  }
+
+  .danger-zone {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    margin-top: 2rem;
+    padding: 1rem 1.15rem;
+    border: 1px solid light-dark(#f1c7c3, #684045);
+    border-radius: 1rem;
+    background: var(--review-danger-soft);
+  }
+
+  .danger-zone strong,
+  .danger-zone span {
+    display: block;
+  }
+
+  .danger-zone strong {
+    color: var(--review-danger);
+  }
+
+  .danger-zone span {
+    margin-top: .2rem;
+    color: var(--review-muted);
+    font-size: .84rem;
+  }
+
+  .review-button-reject {
+    flex: 0 0 auto;
+    border-color: var(--review-danger);
+    color: var(--review-danger);
+    background: transparent;
+  }
+
+  .not-found {
+    padding: 3rem 1.5rem;
+    border: 1px dashed var(--review-border);
+    border-radius: 1rem;
+    background: var(--review-surface);
+    text-align: center;
+  }
+
+  @media (max-width: 1000px) {
+    .review-info {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+  }
 
-    .info-grid {
+  @media (max-width: 700px) {
+    .review-hero,
+    .change-comparison {
       grid-template-columns: 1fr;
     }
 
-    .actions-panel {
+    .review-info {
+      grid-template-columns: 1fr;
+    }
+
+    .change-value + .change-value {
+      border-top: 1px solid var(--review-border);
+      border-left: 0;
+    }
+
+    .danger-zone {
+      align-items: stretch;
       flex-direction: column;
     }
 
-    .actions-panel button,
-    .actions-panel a {
+    .review-button {
       width: 100%;
-    }
-
-    .changes-table {
-      font-size: 0.9rem;
-    }
-
-    .changes-table th,
-    .changes-table td {
-      padding: 0.75rem;
     }
   }
 </style>
 {% endblock %}
 
 {% block main_content %}
-<div class="admin-page">
+<div class="admin-page suggestion-review">
   {% if suggestion %}
-    <div class="view-header">
+    <a href="{{ url_for('admin_demo.suggestions_list') }}" class="review-back">
+      <i class="fas fa-arrow-left" aria-hidden="true"></i> {{ _('Takaisin ehdotuksiin') }}
+    </a>
+
+    <header class="review-hero">
       <div>
-        <a href="{{ url_for('admin_demo.suggestions_list') }}" class="btn-back">
-          <i class="fas fa-arrow-left"></i> {{ _('Takaisin') }}
-        </a>
-        <h1 style="margin-top: 1rem;">💬 {{ _('Ehdotuksen tarkastelu') }}</h1>
+        <p class="review-kicker">{{ _('Ehdotuksen tarkastelu') }}</p>
+        <h1>{{ suggestion.original_values.get('title', _('Mielenosoituksen muutosehdotus')) }}</h1>
+        <p>{{ _('Vertaa tietoja rauhassa ja valitse vain ne muutokset, jotka haluat julkaista.') }}</p>
       </div>
       <span class="status-badge {{ suggestion.status }}">
         {% if suggestion.status == 'new' %}
-          <i class="fas fa-star me-1"></i>{{ _('Uusi') }}
+          <i class="fas fa-star" aria-hidden="true"></i>{{ _('Uusi') }}
         {% elif suggestion.status == 'applied' %}
-          <i class="fas fa-check me-1"></i>{{ _('Hyväksytty') }}
+          <i class="fas fa-check" aria-hidden="true"></i>{{ _('Hyväksytty') }}
         {% elif suggestion.status == 'rejected' %}
-          <i class="fas fa-times me-1"></i>{{ _('Hylätty') }}
+          <i class="fas fa-times" aria-hidden="true"></i>{{ _('Hylätty') }}
         {% else %}
           {{ suggestion.status }}
         {% endif %}
       </span>
-    </div>
+    </header>
 
-    <!-- Info Panel -->
-    <div class="info-panel">
-      <div class="info-grid">
-        <div class="info-item">
-          <span class="info-label">{{ _('Mielenosoitus') }}</span>
-          <span class="info-value">
-            <a href="{{ url_for('demonstration_detail', demo_id=suggestion.demo_id) }}" target="_blank" style="color: var(--color-primary);">
-              {{ suggestion.demo_id[:12] }}...
-              <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8rem;"></i>
-            </a>
-          </span>
-        </div>
-        <div class="info-item">
-          <span class="info-label">{{ _('Lähettäjä') }}</span>
-          <span class="info-value">{{ suggestion.reporter_email or _('Tuntematon') }}</span>
-        </div>
-        <div class="info-item">
-          <span class="info-label">{{ _('Luontiaika') }}</span>
-          <span class="info-value">{{ suggestion.created_at.strftime('%d.%m.%Y %H:%M:%S') if suggestion.created_at else '—' }}</span>
-        </div>
-        <div class="info-item">
-          <span class="info-label">{{ _('IP-osoite') }}</span>
-          <span class="info-value">{{ suggestion.ip or '—' }}</span>
-        </div>
+    <section class="review-info" aria-label="{{ _('Ehdotuksen tiedot') }}">
+      <div class="info-item">
+        <span class="info-label">{{ _('Mielenosoitus') }}</span>
+        <span class="info-value">
+          <a href="{{ url_for('demonstration_detail', demo_id=suggestion.demo_id) }}" target="_blank">
+            {{ suggestion.demo_id[:12] }}... <i class="fas fa-external-link-alt ms-1" aria-hidden="true"></i>
+          </a>
+        </span>
       </div>
-    </div>
+      <div class="info-item">
+        <span class="info-label">{{ _('Lähettäjä') }}</span>
+        <span class="info-value">{{ suggestion.reporter_email or _('Tuntematon') }}</span>
+      </div>
+      <div class="info-item">
+        <span class="info-label">{{ _('Luontiaika') }}</span>
+        <span class="info-value">{{ suggestion.created_at.strftime('%d.%m.%Y %H:%M:%S') if suggestion.created_at else '—' }}</span>
+      </div>
+      <div class="info-item">
+        <span class="info-label">{{ _('IP-osoite') }}</span>
+        <span class="info-value">{{ suggestion.ip or '—' }}</span>
+      </div>
+    </section>
 
-    <!-- Suggested Changes -->
     {% if suggestion.suggested_fields %}
-      <h2 class="section-title">📝 {{ _('Ehdotetut muutokset') }}</h2>
-      <form method="POST" action="{{ url_for('admin_demo.suggestion_apply', suggestion_id=suggestion._id) }}">
-        <div style="overflow-x: auto; margin-bottom: 1.5rem;">
-          <table class="changes-table">
-            <thead>
-              <tr>
-                <th style="width: 50px;">{{ _('Valitse') }}</th>
-                <th style="width: 120px;">{{ _('Kenttä') }}</th>
-                <th>{{ _('Nykyinen arvo') }}</th>
-                <th>{{ _('Ehdotettu arvo') }}</th>
-              </tr>
-            </thead>
-            <tbody>
+      <section class="review-section">
+        <div class="section-heading">
+          <span class="section-icon"><i class="fas fa-code-compare" aria-hidden="true"></i></span>
+          <div>
+            <h2>{{ _('Ehdotetut muutokset') }}</h2>
+            <p>{{ _('Valitut muutokset päivitetään mielenosoitukseen yhdellä kertaa.') }}</p>
+          </div>
+        </div>
+
+        <form method="POST" action="{{ url_for('admin_demo.suggestion_apply', suggestion_id=suggestion._id) }}">
+          <div class="change-list">
             {% for k, v in suggestion.suggested_fields.items() %}
-              <tr>
-                <td style="text-align: center;">
-                  <input type="checkbox" name="apply_field" value="{{ k }}" checked>
-                </td>
-                <td style="font-weight: 600; color: var(--color-primary);">{{ k }}</td>
-                <td>
-                  <div class="original-value">
-                    {% if k == 'tags' and suggestion.original_values.get(k) is iterable and suggestion.original_values.get(k) is not string %}
-                      {{ suggestion.original_values.get(k, '') | join(', ') }}
-                    {% else %}
-                      {{ suggestion.original_values.get(k, '') }}
-                    {% endif %}
+              <article class="change-card">
+                <div class="change-card-header">
+                  <span class="field-name">{{ k }}</span>
+                  <label class="apply-toggle">
+                    <input type="checkbox" name="apply_field" value="{{ k }}" checked>
+                    {{ _('Ota tämä muutos käyttöön') }}
+                  </label>
+                </div>
+                <div class="change-comparison">
+                  <div class="change-value">
+                    <span class="change-value-label">{{ _('Nykyinen arvo') }}</span>
+                    <div class="change-value-content">{% if k == 'tags' and suggestion.original_values.get(k) is iterable and suggestion.original_values.get(k) is not string %}{{ suggestion.original_values.get(k, '') | join(', ') }}{% else %}{{ suggestion.original_values.get(k, '') }}{% endif %}</div>
                   </div>
-                </td>
-                <td>
-                  <div class="suggested-value">
-                    {% if k == 'tags' and v is iterable and v is not string %}
-                      {{ v | join(', ') }}
-                    {% else %}
-                      {{ v }}
-                    {% endif %}
+                  <div class="change-value change-value-proposed">
+                    <span class="change-value-label">{{ _('Ehdotettu arvo') }}</span>
+                    <div class="change-value-content">{% if k == 'tags' and v is iterable and v is not string %}{{ v | join(', ') }}{% else %}{{ v }}{% endif %}</div>
                   </div>
-                </td>
-              </tr>
+                </div>
+              </article>
             {% endfor %}
-            </tbody>
-          </table>
-        </div>
+          </div>
 
-        <div class="actions-panel">
-          <button type="submit" class="btn-apply">
-            <i class="fas fa-check me-2"></i>{{ _('Päivitä valitut kentät') }}
-          </button>
-        </div>
-      </form>
+          <div class="actions-panel">
+            <button type="submit" class="review-button review-button-apply">
+              <i class="fas fa-check" aria-hidden="true"></i>{{ _('Päivitä valitut kentät') }}
+            </button>
+          </div>
+        </form>
+      </section>
     {% else %}
-      <div class="comment-box">
-        <i class="fas fa-info-circle me-2"></i>
-        {{ suggestion.suggestion or _('Ei strukturoituja ehdotuksia.') }}
-      </div>
+      <section class="review-section">
+        <div class="section-heading">
+          <span class="section-icon"><i class="fas fa-message" aria-hidden="true"></i></span>
+          <div><h2>{{ _('Ehdotus') }}</h2></div>
+        </div>
+        <div class="comment-box">{{ suggestion.suggestion or _('Ei strukturoituja ehdotuksia.') }}</div>
+      </section>
     {% endif %}
 
-    <!-- Reporter Comment -->
     {% if suggestion.reporter_comment %}
-      <h2 class="section-title">💬 {{ _('Lähettäjän kommentti') }}</h2>
-      <div class="comment-box" style="border-left-color: #f59e0b;">
-        {{ suggestion.reporter_comment }}
-      </div>
+      <section class="review-section">
+        <div class="section-heading">
+          <span class="section-icon"><i class="fas fa-comment" aria-hidden="true"></i></span>
+          <div><h2>{{ _('Lähettäjän kommentti') }}</h2></div>
+        </div>
+        <div class="comment-box">{{ suggestion.reporter_comment }}</div>
+      </section>
     {% endif %}
 
-    <!-- Reject Action -->
-    <div style="margin-top: 2rem;">
-      <h2 class="section-title">⚙️ {{ _('Muut toiminnot') }}</h2>
+    <section class="danger-zone">
+      <div>
+        <strong>{{ _('Hylkää ehdotus') }}</strong>
+        <span>{{ _('Ehdotettuja muutoksia ei julkaista.') }}</span>
+      </div>
       <form method="POST" action="{{ url_for('admin_demo.suggestion_status_update', suggestion_id=suggestion._id) }}">
-        <input type="hidden" name="status" value="rejected" />
-        <button type="submit" class="btn-reject" onclick="return confirm('{{ _('Oletko varma että haluat hylätä tämän ehdotuksen?') }}')">
-          <i class="fas fa-ban me-2"></i>{{ _('Hylkää ehdotus') }}
+        <input type="hidden" name="status" value="rejected">
+        <button type="submit" class="review-button review-button-reject" onclick="return confirm('{{ _('Oletko varma että haluat hylätä tämän ehdotuksen?') }}')">
+          <i class="fas fa-ban" aria-hidden="true"></i>{{ _('Hylkää ehdotus') }}
         </button>
       </form>
-    </div>
-
+    </section>
   {% else %}
-    <div style="text-align: center; padding: 3rem;">
-      <i class="fas fa-exclamation-triangle" style="font-size: 2rem; color: #ef4444; margin-bottom: 1rem;"></i>
+    <div class="not-found">
+      <i class="fas fa-exclamation-triangle fs-2 mb-3 text-danger" aria-hidden="true"></i>
       <h2>{{ _('Ehdotusta ei löytynyt') }}</h2>
       <p class="text-muted">{{ _('Pyydetty ehdotus ei ole olemassa tai se on poistettu.') }}</p>
-      <a href="{{ url_for('admin_demo.suggestions_list') }}" class="btn btn-primary mt-3">
-        {{ _('Takaisin ehdotuksiin') }}
-      </a>
+      <a href="{{ url_for('admin_demo.suggestions_list') }}" class="btn btn-primary mt-2">{{ _('Takaisin ehdotuksiin') }}</a>
     </div>
   {% endif %}
 </div>

--- a/mielenosoitukset_fi/templates/admin/suggestions_list.html
+++ b/mielenosoitukset_fi/templates/admin/suggestions_list.html
@@ -3,32 +3,97 @@
 {% block styles %}
 <style>
   :root {
-    --color-text: light-dark(#1e293b, #e2e8f0);
-    --color-text-secondary: light-dark(#64748b, #94a3b8);
-    --color-primary: light-dark(#0033a0, #4d79cc);
-    --color-card-bg: light-dark(#ffffff, #1e1e2e);
-    --color-border: light-dark(#e2e8f0, #404050);
-    --color-shadow: light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3));
+    --suggestion-text: light-dark(#172033, #f2f5fa);
+    --suggestion-muted: light-dark(#647083, #b7c0ce);
+    --suggestion-blue: light-dark(#0033a0, #8bb1ff);
+    --suggestion-blue-soft: light-dark(#edf4ff, #17233b);
+    --suggestion-orange: #ff6600;
+    --suggestion-orange-soft: light-dark(#fff2e8, #3a2418);
+    --suggestion-card-bg: light-dark(#ffffff, #20252d);
+    --suggestion-border: light-dark(#dce3ec, #424b59);
+    --suggestion-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, 0.08), rgba(0, 0, 0, 0.18));
+  }
+
+  .suggestions-page {
+    max-width: 1200px;
+    margin: 0 auto;
   }
 
   .suggestions-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 2rem;
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1.5rem;
+    align-items: end;
+    margin-bottom: 1.25rem;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .4), transparent 17rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
   }
 
   .suggestions-header h1 {
+    margin: .25rem 0 .5rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3rem);
+    letter-spacing: -.035em;
+  }
+
+  .suggestions-header p {
+    max-width: 620px;
+    color: rgba(255,255,255,.8) !important;
+    line-height: 1.65;
+  }
+
+  .suggestions-kicker {
     margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--color-text);
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+
+  .suggestions-count {
+    position: relative;
+    z-index: 1;
+    min-width: 110px;
+    padding: .9rem 1rem;
+    border: 1px solid rgba(255,255,255,.2);
+    border-radius: 1rem;
+    background: rgba(255,255,255,.1);
+    text-align: center;
+  }
+
+  .suggestions-count strong, .suggestions-count span { display: block; }
+  .suggestions-count strong { color: #fff; font-size: 1.7rem; line-height: 1; }
+  .suggestions-count span { margin-top: .3rem; color: rgba(255,255,255,.72); font-size: .78rem; }
+
+  .suggestions-intro {
+    display: flex;
+    gap: .75rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding: .8rem 1rem;
+    border: 1px solid var(--suggestion-border);
+    border-radius: .9rem;
+    color: var(--suggestion-muted);
+    background: light-dark(#f8fafc, #252b35);
+    font-size: .88rem;
+  }
+
+  .suggestions-intro i {
+    color: var(--suggestion-orange);
   }
 
   .suggestion-badge {
     font-size: 0.85rem;
     padding: 0.5rem 1rem;
-    border-radius: 8px;
+    border-radius: 999px;
     font-weight: 600;
   }
 
@@ -48,17 +113,19 @@
   }
 
   .suggestion-card {
-    background: var(--color-card-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
+    background: var(--suggestion-card-bg);
+    border: 1px solid var(--suggestion-border);
+    border-left: 4px solid var(--suggestion-blue);
+    border-radius: 1rem;
     padding: 1.5rem;
     margin-bottom: 1rem;
-    transition: all 0.3s ease;
+    box-shadow: var(--suggestion-shadow);
+    transition: border-color .2s ease, transform .2s ease;
   }
 
   .suggestion-card:hover {
-    box-shadow: 0 10px 25px var(--color-shadow);
-    transform: translateY(-2px);
+    border-left-color: var(--suggestion-orange);
+    transform: translateY(-1px);
   }
 
   .suggestion-card-header {
@@ -71,13 +138,13 @@
   .suggestion-card-title {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--color-text);
+    color: var(--suggestion-text);
     margin: 0 0 0.5rem 0;
   }
 
   .suggestion-card-meta {
     font-size: 0.9rem;
-    color: var(--color-text-secondary);
+    color: var(--suggestion-muted);
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
@@ -91,16 +158,16 @@
 
   .suggestion-changes-summary {
     font-size: 0.9rem;
-    color: var(--color-text-secondary);
+    color: var(--suggestion-muted);
     margin-top: 0.75rem;
   }
 
   .suggestion-changes-count {
     display: inline-block;
-    background: var(--color-primary);
-    color: white;
+    background: var(--suggestion-blue-soft);
+    color: var(--suggestion-blue);
     padding: 0.25rem 0.75rem;
-    border-radius: 16px;
+    border-radius: 999px;
     font-weight: 600;
     font-size: 0.8rem;
   }
@@ -120,7 +187,10 @@
   .empty-state {
     text-align: center;
     padding: 3rem 2rem;
-    color: var(--color-text-secondary);
+    border: 1px dashed var(--suggestion-border);
+    border-radius: 1rem;
+    color: var(--suggestion-muted);
+    background: var(--suggestion-card-bg);
   }
 
   .empty-state i {
@@ -131,8 +201,7 @@
 
   @media (max-width: 768px) {
     .suggestions-header {
-      flex-direction: column;
-      align-items: flex-start;
+      grid-template-columns: 1fr;
     }
 
     .suggestion-card-header {
@@ -151,20 +220,24 @@
 {% endblock %}
 
 {% block main_content %}
-<div class="admin-page">
+<div class="admin-page suggestions-page">
   <div class="suggestions-header">
     <div>
-      <h1>💬 {{ _('Ehdotukset') }}</h1>
-      <p class="text-muted mb-0">{{ _('Käyttäjien ehdottamat muutokset mielenosoituksiin') }}</p>
+      <p class="suggestions-kicker">{{ _('Ylläpidon työjono') }}</p>
+      <h1>{{ _('Ehdotukset') }}</h1>
+      <p class="text-muted mb-0">{{ _('Tarkista käyttäjien ehdottamat korjaukset ja pidä tapahtumatiedot ajan tasalla.') }}</p>
     </div>
-    <div class="d-none d-md-block">
-      <span class="badge bg-primary" style="font-size: 1.1rem; padding: 0.5rem 1rem;">
-        {{ suggestions|length }} {{ _('ehdotusta') }}
-      </span>
+    <div class="suggestions-count">
+      <strong>{{ suggestions|length }}</strong>
+      <span>{{ _('ehdotusta') }}</span>
     </div>
   </div>
 
   {% if suggestions %}
+    <div class="suggestions-intro">
+      <i class="fas fa-circle-info" aria-hidden="true"></i>
+      <span>{{ _('Avaa ehdotus nähdäksesi alkuperäiset ja ehdotetut tiedot rinnakkain.') }}</span>
+    </div>
     <div class="suggestions-list">
       {% for s in suggestions %}
         <div class="suggestion-card">

--- a/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_modals_users.html
@@ -1,46 +1,55 @@
 <!-- Force Password Modal -->
-<!-- Force Password Modal -->
-<div class="modal fade" id="forcePwdModal" tabindex="-1" aria-labelledby="forcePwdModalLabel" aria-hidden="true">
+<div class="modal fade user-workflow-modal" id="forcePwdModal" tabindex="-1" aria-labelledby="forcePwdModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-header bg-warning">
-        <h5 class="modal-title" id="forcePwdModalLabel">
-          <i class="fas fa-key me-2"></i>{{ _('Pakota salasananvaihto') }}
-        </h5>
+      <div class="modal-header">
+        <div class="workflow-heading">
+          <span class="workflow-heading-icon warning"><i class="fas fa-key" aria-hidden="true"></i></span>
+          <div>
+            <h5 class="modal-title" id="forcePwdModalLabel">{{ _('Pakota salasananvaihto') }}</h5>
+            <p>{{ _('Käyttäjän on vaihdettava salasana seuraavan kirjautumisen yhteydessä.') }}</p>
+          </div>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button>
       </div>
       <div class="modal-body">
-        <p id="forcePwdMessage"></p>
+        <div class="workflow-note warning" id="forcePwdMessage"></div>
+        <div class="workflow-status" id="forcePwdStatus" aria-live="polite"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Peruuta') }}</button>
-        <button type="button" id="confirmForcePwdBtn" class="btn btn-warning">
-          <i class="fas fa-key me-1"></i>{{ _('Pakota vaihto') }}
+        <button type="button" class="workflow-button" data-bs-dismiss="modal">{{ _('Peruuta') }}</button>
+        <button type="button" id="confirmForcePwdBtn" class="workflow-button workflow-button-warning">
+          <i class="fas fa-key" aria-hidden="true"></i>{{ _('Pakota vaihto') }}
         </button>
       </div>
     </div>
   </div>
 </div>
 <!-- Delete User Modal -->
-<div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade user-workflow-modal" id="deleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{{ _('Poista käyttäjä') }}</h5>
+        <div class="workflow-heading">
+          <span class="workflow-heading-icon danger"><i class="fas fa-user-xmark" aria-hidden="true"></i></span>
+          <div>
+            <h5 class="modal-title">{{ _('Poista käyttäjä') }}</h5>
+            <p>{{ _('Poistamista ei voi perua. Vahvista toiminto huolellisesti.') }}</p>
+          </div>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button>
       </div>
       <div class="modal-body">
-        <p>{{ _('Haluatko poistaa käyttäjän:') }} <strong id="userTitle"></strong>?</p>
-        <div id="vahvistaContainer" style="margin-top:15px;">
-          <label for="confirmInput">{{ _('Kirjoita VAHVISTA vahvistaaksesi poiston') }}</label>
-          <input type="text" id="confirmInput" class="form-control">
-        </div>
-        <p id="countdownText" style="display:none; margin-top:10px;"></p>
+        <div class="workflow-note">{{ _('Poistettava käyttäjä:') }} <strong id="userTitle"></strong></div>
+        <label class="workflow-confirm-label" for="confirmInput">{{ _('Kirjoita VAHVISTA vahvistaaksesi poiston') }}</label>
+        <input type="text" id="confirmInput" class="form-control" autocomplete="off" placeholder="VAHVISTA">
+        <div id="countdownText" class="workflow-status danger" aria-live="polite"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" id="cancelDeleteBtn" data-bs-dismiss="modal">{{ _('Peruuta')
-          }}</button>
-        <button type="button" class="btn btn-danger" id="finalDeleteBtn" disabled>{{ _('Poista käyttäjä') }}</button>
+        <button type="button" class="workflow-button" id="cancelDeleteBtn" data-bs-dismiss="modal">{{ _('Peruuta') }}</button>
+        <button type="button" class="workflow-button workflow-button-danger" id="finalDeleteBtn" disabled>
+          <i class="fas fa-trash" aria-hidden="true"></i>{{ _('Poista käyttäjä') }}
+        </button>
       </div>
     </div>
   </div>
@@ -59,68 +68,63 @@
     const countdownText = document.getElementById('countdownText');
     const cancelBtn = document.getElementById('cancelDeleteBtn');
 
-    // Reset modal
     userTitle.textContent = username;
     confirmInput.value = "";
     finalDeleteBtn.disabled = true;
-    countdownText.style.display = "none";
     countdownText.textContent = "";
+    finalDeleteBtn.innerHTML = '<i class="fas fa-trash" aria-hidden="true"></i>{{ _("Poista käyttäjä") }}';
     clearInterval(countdown3Sec);
     clearInterval(countdownInterval);
 
-    // Cancel button stops everything
     const stopAll = () => {
       clearInterval(countdown3Sec);
       clearInterval(countdownInterval);
       finalDeleteBtn.disabled = true;
-      countdownText.style.display = "none";
+      finalDeleteBtn.innerHTML = '<i class="fas fa-trash" aria-hidden="true"></i>{{ _("Poista käyttäjä") }}';
+      countdownText.textContent = "";
     };
 
     cancelBtn.onclick = stopAll;
     document.querySelector('#deleteModal .btn-close').onclick = stopAll;
 
-    // Input listener for VAHVISTA
     confirmInput.oninput = () => {
       clearInterval(countdown3Sec);
       finalDeleteBtn.disabled = true;
-      countdownText.style.display = "none";
+      countdownText.textContent = "";
 
       if (confirmInput.value.toUpperCase() === "VAHVISTA") {
         let countdown = 3;
-        countdownText.style.display = "block";
-        countdownText.textContent = `Poisto käytettävissä ${countdown}...`;
+        countdownText.textContent = `{{ _('Poistopainike avautuu') }} ${countdown}...`;
 
         countdown3Sec = setInterval(() => {
           countdown--;
           if (countdown > 0) {
-            countdownText.textContent = `Poisto käytettävissä ${countdown}...`;
+            countdownText.textContent = `{{ _('Poistopainike avautuu') }} ${countdown}...`;
           } else {
             clearInterval(countdown3Sec);
-            countdownText.style.display = "none";
+            countdownText.textContent = "{{ _('Poistaminen on nyt vahvistettavissa.') }}";
             finalDeleteBtn.disabled = false;
           }
         }, 1000);
       } else {
-        // Wrong input cancels countdown immediately
         clearInterval(countdown3Sec);
         finalDeleteBtn.disabled = true;
-        countdownText.style.display = "none";
       }
     };
 
-    // Delete button click → start 5-second countdown
     finalDeleteBtn.onclick = () => {
       let countdown = 5;
       finalDeleteBtn.disabled = true;
-      countdownText.style.display = "block";
-      countdownText.textContent = `Käyttäjä poistetaan ${countdown} sekunnin kuluttua...`;
+      finalDeleteBtn.innerHTML = '<i class="fas fa-circle-notch fa-spin" aria-hidden="true"></i>{{ _("Valmistellaan poistoa") }}';
+      countdownText.textContent = `{{ _('Käyttäjä poistetaan') }} ${countdown} {{ _('sekunnin kuluttua...') }}`;
 
       countdownInterval = setInterval(() => {
         countdown--;
         if (countdown > 0) {
-          countdownText.textContent = `Käyttäjä poistetaan ${countdown} sekunnin kuluttua...`;
+          countdownText.textContent = `{{ _('Käyttäjä poistetaan') }} ${countdown} {{ _('sekunnin kuluttua...') }}`;
         } else {
           clearInterval(countdownInterval);
+          countdownText.textContent = "{{ _('Poistetaan käyttäjää...') }}";
           sendDeleteRequest(userId);
         }
       }, 1000);
@@ -129,7 +133,6 @@
     const modal = new bootstrap.Modal(document.getElementById('deleteModal'));
     modal.show();
 
-    // Stop all if modal is hidden via backdrop click or ESC
     document.getElementById('deleteModal').addEventListener('hidden.bs.modal', stopAll, { once: true });
   }
 
@@ -146,12 +149,21 @@
           if (row) row.remove();
           showToast(data.message);
         } else {
-          showToast("Virhe: " + data.message);
+          countdownText.textContent = data.message || "{{ _('Käyttäjän poistaminen epäonnistui.') }}";
+          finalDeleteBtn.disabled = false;
+          finalDeleteBtn.innerHTML = '<i class="fas fa-trash" aria-hidden="true"></i>{{ _("Poista käyttäjä") }}';
+          showToast("Virhe: " + data.message, "danger");
+          return;
         }
         const deleteModal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
         deleteModal.hide();
       })
-      .catch(err => showToast("Virhe pyynnössä: " + err));
+      .catch(() => {
+        countdownText.textContent = "{{ _('Käyttäjän poistaminen epäonnistui.') }}";
+        finalDeleteBtn.disabled = false;
+        finalDeleteBtn.innerHTML = '<i class="fas fa-trash" aria-hidden="true"></i>{{ _("Poista käyttäjä") }}';
+        showToast("{{ _('Käyttäjän poistaminen epäonnistui.') }}", "danger");
+      });
   }
 </script>
 
@@ -160,54 +172,54 @@
   <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{{ _('Luo uusi käyttäjä') }}</h5>
+        <div>
+          <h5 class="modal-title"><i class="fas fa-user-plus me-2" aria-hidden="true"></i>{{ _('Luo uusi käyttäjä') }}</h5>
+          <p>{{ _('Uusi käyttäjä saa kirjautumistiedot sähköpostitse ja vaihtaa salasanan ensimmäisellä kirjautumisella.') }}</p>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button>
       </div>
       <div class="modal-body">
-
-        <!-- Notification / Info -->
-        <div class="alert alert-info align-items-start mb-3" role="alert">
-          <i class="fa-solid fa-circle-info me-2 mt-1"></i>
-          <div class="flex-grow-1">
-            Huomio: <strong>Superkäyttäjä / global_admin</strong> -roolia voidaan myöntää vain automaattisesti 
-            sen jälkeen, kun hallitus on antanut kirjallisen hyväksynnän ja turvaluokituksen. 
-            Roolia ei voi valita tai myöntää manuaalisesti tässä muodossa.
-            <br><br>
-            Mikä tahansa yritys myöntää roolin manuaalisesti ohittaa hyväksynnän, ei onnistu järjestelmässä.
+        <div class="create-user-note" role="note">
+          <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
+          <div>
+            <strong>{{ _('Superkäyttäjäroolia ei voi myöntää tästä lomakkeesta.') }}</strong>
+            {{ _('Rooli vaatii erillisen hyväksynnän ja turvaluokituksen.') }}
+            <a href="{{ url_for('admin.manual_page', page='users/about_roles') }}" target="_blank">{{ _('Lue roolien ohje') }}</a>
           </div>
-        </div>
-
-        <!-- User Manual Link -->
-        <div class="mb-3">
-          <a href="{{ url_for('admin.manual_page', page='users/about_roles') }}" target="_blank" class="btn btn-info">
-            <i class="fa-solid fa-book me-1"></i> Roolin valintaohje
-          </a>
         </div>
 
         <form id="createUserForm" method="POST" action="{{ url_for('admin_user.create_user') }}">
-          <div class="mb-3">
-            <label for="username" class="form-label">{{ _('Käyttäjänimi') }}</label>
-            <input type="text" class="form-control" id="username" name="username" required>
+          <div class="create-user-grid">
+            <div class="create-user-field create-user-field-wide">
+              <label for="create-user-email">{{ _('Sähköposti') }}</label>
+              <input type="email" class="form-control" id="create-user-email" name="email" autocomplete="off" required>
+              <small>{{ _('Kirjautumistiedot lähetetään tähän osoitteeseen.') }}</small>
+            </div>
+            <div class="create-user-field">
+              <label for="create-user-username">{{ _('Käyttäjänimi') }}</label>
+              <input type="text" class="form-control" id="create-user-username" name="username" autocomplete="off" required>
+              <small>{{ _('Ehdotetaan automaattisesti sähköpostista.') }}</small>
+            </div>
+            <div class="create-user-field">
+              <label for="create-user-displayname">{{ _('Näyttönimi') }}</label>
+              <input type="text" class="form-control" id="create-user-displayname" name="displayname" autocomplete="off">
+              <small>{{ _('Näkyy käyttäjän nimenä hallinnassa.') }}</small>
+            </div>
+            <div class="create-user-field create-user-field-wide">
+              <label for="create-user-role">{{ _('Rooli') }}</label>
+              <select class="form-select" id="create-user-role" name="role" required>
+                <option value="user">{{ _('Käyttäjä') }}</option>
+                <option value="admin">{{ _('Admin') }}</option>
+              </select>
+              <small id="create-user-role-help">{{ _('Tavallinen käyttäjä saa perustilin ilman ylläpito-oikeuksia.') }}</small>
+            </div>
           </div>
-          <div class="mb-3">
-            <label for="displayname" class="form-label">{{ _('Näyttönimi') }}</label>
-            <input type="text" class="form-control" id="displayname" name="displayname">
-          </div>
-          <div class="mb-3">
-            <label for="email" class="form-label">{{ _('Sähköposti') }}</label>
-            <input type="email" class="form-control" id="email" name="email" required>
-          </div>
-          <div class="mb-3">
-            <label for="role" class="form-label">{{ _('Rooli') }}</label>
-            <select class="form-select" id="role" name="role" required>
-              <option value="user">{{ _('Käyttäjä') }}</option>
-              <option value="admin">{{ _('Admin') }}</option>
-              <option value="global_admin" disabled>{{ _('Superkäyttäjä (vain hallituksen hyväksynnän jälkeen)') }}</option>
-            </select>
-          </div>
+          <div id="create-user-status" class="create-user-status" aria-live="polite"></div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Peruuta') }}</button>
-            <button type="submit" class="btn btn-success">{{ _('Luo käyttäjä') }}</button>
+            <button type="button" class="create-user-cancel" data-bs-dismiss="modal">{{ _('Peruuta') }}</button>
+            <button type="submit" id="create-user-submit" class="create-user-submit">
+              <i class="fas fa-user-plus" aria-hidden="true"></i>{{ _('Luo käyttäjä') }}
+            </button>
           </div>
         </form>
       </div>
@@ -216,19 +228,25 @@
 </div>
 
 <!-- Login History Modal -->
-<div class="modal fade" id="loginHistoryModal" tabindex="-1" aria-labelledby="loginHistoryModalLabel" aria-hidden="true">
+<div class="modal fade user-workflow-modal" id="loginHistoryModal" tabindex="-1" aria-labelledby="loginHistoryModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="loginHistoryModalLabel">{{ _('Kirjautumishistoria') }}</h5>
+        <div class="workflow-heading">
+          <span class="workflow-heading-icon"><i class="fas fa-clock-rotate-left" aria-hidden="true"></i></span>
+          <div>
+            <h5 class="modal-title" id="loginHistoryModalLabel">{{ _('Kirjautumishistoria') }}</h5>
+            <p>{{ _('Viimeisimmät onnistuneet ja epäonnistuneet kirjautumisyritykset.') }}</p>
+          </div>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button>
       </div>
       <div class="modal-body">
-        <div id="loginHistoryStatus" class="text-muted text-center py-4">
+        <div id="loginHistoryStatus" class="login-history-status">
           {{ _('Valitse käyttäjä nähdäksesi kirjautumishistorian.') }}
         </div>
         <div id="loginHistoryTableWrapper" class="table-responsive d-none">
-          <table class="table table-sm align-middle mb-0">
+          <table class="login-history-table">
             <thead>
               <tr>
                 <th>{{ _('Aika') }}</th>
@@ -242,7 +260,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Sulje') }}</button>
+        <button type="button" class="workflow-button workflow-button-primary" data-bs-dismiss="modal">{{ _('Sulje') }}</button>
       </div>
     </div>
   </div>
@@ -250,36 +268,42 @@
 
 <script>
 function openForcePwdModal(username, userId) {
-  // Update modal text
-  $('#forcePwdMessage').text(
-    `Haluatko varmasti pakottaa käyttäjän "${username}" vaihtamaan salasanansa seuraavan kirjautumisen yhteydessä?`
-  );
+  const modalEl = document.getElementById('forcePwdModal');
+  const messageEl = document.getElementById('forcePwdMessage');
+  const statusEl = document.getElementById('forcePwdStatus');
+  const confirmBtn = document.getElementById('confirmForcePwdBtn');
+  const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
 
-  // Attach event to confirm button
-  $('#confirmForcePwdBtn')
-    .off('click')
-    .on('click', function () {
-      $.ajax({
-        url: '/admin/user/api/force_password_change',
-        type: 'POST',
-        contentType: 'application/json',
-        data: JSON.stringify({ user_id: userId }),
-        success: function (resp) {
-          $('#forcePwdModal').modal('hide');
-          showToast(resp.message || 'Salasanan vaihto pakotettu onnistuneesti.', 'success');
-        },
-        error: function (xhr) {
-          $('#forcePwdModal').modal('hide');
-          showToast(
-            xhr.responseJSON?.message || 'Virhe: salasananvaihtoa ei voitu pakottaa.',
-            'danger'
-          );
-        }
+  messageEl.textContent = `{{ _('Käyttäjä') }} "${username}" {{ _('ohjataan vaihtamaan salasana seuraavan kirjautumisen yhteydessä.') }}`;
+  statusEl.textContent = '';
+  statusEl.classList.remove('danger');
+  confirmBtn.disabled = false;
+  confirmBtn.innerHTML = '<i class="fas fa-key" aria-hidden="true"></i>{{ _("Pakota vaihto") }}';
+
+  confirmBtn.onclick = async () => {
+    confirmBtn.disabled = true;
+    confirmBtn.innerHTML = '<i class="fas fa-circle-notch fa-spin" aria-hidden="true"></i>{{ _("Tallennetaan...") }}';
+    statusEl.textContent = "{{ _('Päivitetään käyttäjätiliä...') }}";
+
+    try {
+      const response = await fetch("{{ url_for('admin_user.api_force_password_change') }}", {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId })
       });
-    });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.message || '');
+      modal.hide();
+      showToast(payload.message || "{{ _('Salasanan vaihto pakotettu onnistuneesti.') }}", 'success');
+    } catch (error) {
+      statusEl.textContent = error.message || "{{ _('Salasananvaihtoa ei voitu pakottaa.') }}";
+      statusEl.classList.add('danger');
+      confirmBtn.disabled = false;
+      confirmBtn.innerHTML = '<i class="fas fa-key" aria-hidden="true"></i>{{ _("Yritä uudelleen") }}';
+    }
+  };
 
-  // Show modal
-  $('#forcePwdModal').modal('show');
+  modal.show();
 }
 
 </script>
@@ -318,7 +342,6 @@ function escapeHtml(text) {
 function showLoginHistoryStatus(message, isError = false) {
   loginHistoryStatusEl.textContent = message;
   loginHistoryStatusEl.classList.toggle('text-danger', isError);
-  loginHistoryStatusEl.classList.toggle('text-muted', !isError);
   loginHistoryStatusEl.classList.remove('d-none');
   loginHistoryTableWrapper.classList.add('d-none');
 }
@@ -332,15 +355,15 @@ function renderLoginHistoryTable(logs) {
   const rows = logs
     .map((log) => {
       const statusBadge = log.success
-        ? `<span class="badge bg-success">${loginHistoryMessages.successLabel}</span>`
-        : `<span class="badge bg-danger">${loginHistoryMessages.failedLabel}</span>`;
+        ? `<span class="login-history-result success"><i class="fas fa-check"></i>${loginHistoryMessages.successLabel}</span>`
+        : `<span class="login-history-result failed"><i class="fas fa-xmark"></i>${loginHistoryMessages.failedLabel}</span>`;
 
       const reason = log.success
         ? loginHistoryMessages.successReason
         : (log.reason ? escapeHtml(log.reason) : loginHistoryMessages.noReason);
 
       const userAgentRow = log.user_agent
-        ? `<div class="small text-muted">${escapeHtml(log.user_agent)}</div>`
+        ? `<div class="login-history-agent">${escapeHtml(log.user_agent)}</div>`
         : '';
 
       return `

--- a/mielenosoitukset_fi/templates/admin_V2/_users_table.html
+++ b/mielenosoitukset_fi/templates/admin_V2/_users_table.html
@@ -1,143 +1,340 @@
-<table class="table table-hover align-middle">
-  <thead class="table-light">
-    <tr>
-      <th class="sortable" data-sort-key="username">{{ _('Nimi') }}</th>
-      <th class="sortable" data-sort-key="username">{{ _('Käyttäjänimi') }}</th>
-      <th class="sortable" data-sort-key="email">{{ _('Sähköpostiosoite') }}</th>
-      <th class="sortable" data-sort-key="role">{{ _('Rooli') }}</th>
-      <th>{{ _('Viimeksi kirjautunut') }}</th>
-      <th>{{ _('Toiminnot') }}</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for user in users %}
-    <tr id="user-{{ user._id }}">
-      <td>{{ user.displayname or user.username }}</td>
-      <td>{{ user.username }}</td>
-      <td>{{ user.email }}</td>
+<style>
+  .users-results-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: .9rem 1.1rem;
+    border-bottom: 1px solid var(--users-border);
+    color: var(--users-muted);
+    background: var(--users-surface-muted);
+    font-size: .8rem;
+    font-weight: 700;
+  }
 
-      <!-- Role badge -->
-      <td>
-        {% if user.role == 'admin' %}
-          <span class="badge bg-warning text-dark">{{ _('Admin') }}</span>
-        {% elif user.role == 'global_admin' %}
-          <span class="badge bg-danger">{{ _('Superkäyttäjä') }}</span>
-        {% else %}
-          <span class="badge bg-secondary">{{ _('Käyttäjä') }}</span>
-        {% endif %}
-      </td>
+  .users-results-heading strong { color: var(--users-text); }
+  .users-table-scroll { overflow: visible; }
 
+  .users-table {
+    width: 100%;
+    min-width: 920px;
+    border-collapse: collapse;
+  }
 
+  .users-table th,
+  .users-table td {
+    padding: .85rem 1rem;
+    border-bottom: 1px solid var(--users-border);
+    color: var(--users-text);
+    text-align: left;
+    vertical-align: middle;
+  }
 
-      <!-- Last login -->
-    <td>
-    {% if user.last_login %}
-        {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
-    {% else %}
-        {{ _('Ei kirjautunut') }}
-    {% endif %}
-    </td>
+  .users-table th {
+    color: var(--users-muted);
+    background: var(--users-surface);
+    font-size: .7rem;
+    font-weight: 800;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
 
-      <!-- Actions -->
-      <td>
-        {% if current_user.has_permission("EDIT_USER") or current_user.has_permission("DELETE_USER") or current_user.has_permission("FORCE_PASSWORD_CHANGE") or current_user.has_permission("VIEW_USER") %}
-        <div class="dropdown">
-          <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
-                  id="userActions-{{ user._id }}" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="fa-solid fa-ellipsis-vertical"></i> {{ _('Toiminnot') }}
-          </button>
-          <ul class="dropdown-menu" aria-labelledby="userActions-{{ user._id }}">
-            
-            {% if current_user.has_permission("EDIT_USER") %}
-            <li>
-              <a class="dropdown-item" href="{{ url_for('admin_user.edit_user', user_id=user._id) }}"
-                 data-bs-toggle="tooltip" title="{{ _('Muokkaa käyttäjää') }}">
-                <i class="fas fa-edit me-2"></i>{{ _('Muokkaa') }}
-              </a>
-            </li>
-            {% endif %}
-            
-            {% if current_user.has_permission("FORCE_PASSWORD_CHANGE") %}
-            <li>
-              <button class="dropdown-item text-warning" type="button"
-                      onclick="openForcePwdModal('{{ user.displayname or user.username }}', '{{ user._id }}')"
-                      data-bs-toggle="tooltip" title="{{ _('Pakota käyttäjä vaihtamaan salasanan seuraavan kirjautumisen yhteydessä') }}">
-                <i class="fas fa-key me-2"></i>{{ _('Pakota salasananvaihto') }}
-              </button>
-            </li>
-            {% endif %}
+  .users-table tbody tr:hover { background: var(--users-blue-soft); }
+  .users-table tbody tr:last-child td { border-bottom: 0; }
 
-            {% if current_user.has_permission("VIEW_USER") %}
-            <li>
-              <button class="dropdown-item" type="button"
-                      onclick='openLoginHistoryModal("{{ user._id }}", {{ (user.displayname or user.username)|tojson|e }}, {{ user.username|tojson|e }})'
-                      data-bs-toggle="tooltip" title="{{ _('Näytä käyttäjän kirjautumishistoria') }}">
-                <i class="fas fa-clock-rotate-left me-2"></i>{{ _('Kirjautumishistoria') }}
-              </button>
-            </li>
-            {% endif %}
+  .users-table th.sortable {
+    position: relative;
+    cursor: pointer;
+  }
 
-            {% if current_user.has_permission("DELETE_USER") %}
-            <li>
-              <button class="dropdown-item text-danger" type="button"
-                      onclick="openDeleteModal(event, '{{ user.displayname or user.username }}', '{{ user._id }}', 'user')"
-                      data-bs-toggle="tooltip" title="{{ _('Poista käyttäjä') }}">
-                <i class="fas fa-trash-alt me-2"></i>{{ _('Poista') }}
-              </button>
-            </li>
-            {% endif %}
+  .users-table th.sortable::after {
+    content: "\f0dc";
+    margin-left: .45rem;
+    color: var(--users-muted);
+    font-family: "Font Awesome 6 Free";
+    font-size: .68rem;
+    font-weight: 900;
+  }
 
-          </ul>
-        </div>
-        {% else %}
-        <span class="text-muted">{{ _('Ei riittäviä oikeuksia.') }}</span>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+  .users-table th.sortable.asc::after { content: "\f0de"; }
+  .users-table th.sortable.desc::after { content: "\f0dd"; }
+
+  .user-identity {
+    display: flex;
+    gap: .7rem;
+    align-items: center;
+    min-width: 210px;
+  }
+
+  .user-avatar {
+    display: grid;
+    flex: 0 0 auto;
+    width: 2.45rem;
+    height: 2.45rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--users-blue);
+    background: var(--users-blue-soft);
+    font-weight: 900;
+    line-height: 1;
+    overflow: hidden;
+    text-transform: uppercase;
+  }
+
+  .user-identity strong,
+  .user-identity div span {
+    display: block;
+  }
+
+  .user-identity strong { color: var(--users-text); font-size: .9rem; }
+  .user-identity div span { color: var(--users-muted); font-size: .76rem; }
+
+  .user-email {
+    color: var(--users-muted);
+    font-size: .84rem;
+  }
+
+  .user-status {
+    display: inline-flex;
+    gap: .35rem;
+    align-items: center;
+    margin-top: .25rem;
+    color: var(--users-muted);
+    font-size: .7rem;
+  }
+
+  .user-status.confirmed { color: light-dark(#087f5b, #65d6ac); }
+
+  .user-role {
+    display: inline-flex;
+    gap: .35rem;
+    align-items: center;
+    padding: .28rem .58rem;
+    border-radius: 999px;
+    color: var(--users-muted);
+    background: var(--users-surface-muted);
+    font-size: .72rem;
+    font-weight: 800;
+  }
+
+  .user-role.admin { color: light-dark(#9a4d00, #ffd098); background: var(--users-orange-soft); }
+  .user-role.global-admin { color: var(--users-blue-dark); background: var(--users-blue-soft); }
+
+  .user-login {
+    color: var(--users-text);
+    font-size: .82rem;
+  }
+
+  .user-login.never { color: var(--users-muted); }
+
+  .user-actions-button {
+    display: inline-flex;
+    gap: .4rem;
+    align-items: center;
+    padding: .45rem .65rem;
+    border: 1px solid var(--users-border);
+    border-radius: .65rem;
+    color: var(--users-text);
+    background: var(--users-surface-muted);
+    font-size: .78rem;
+    font-weight: 800;
+  }
+
+  .users-table .dropdown-menu {
+    z-index: 1080;
+    min-width: 14rem;
+    border-color: var(--users-border);
+    border-radius: .75rem;
+    color: var(--users-text);
+    background: var(--users-surface);
+    box-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .16), rgba(0, 0, 0, .36));
+  }
+
+  .users-table .dropdown-item {
+    color: var(--users-text);
+    font-size: .82rem;
+  }
+
+  .users-table .dropdown-item:hover,
+  .users-table .dropdown-item:focus {
+    color: var(--users-blue-dark);
+    background: var(--users-blue-soft);
+  }
+
+  .users-pagination {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: .8rem 1rem;
+    border-top: 1px solid var(--users-border);
+    background: var(--users-surface);
+  }
+
+  .users-pagination-info {
+    color: var(--users-muted);
+    font-size: .8rem;
+    font-weight: 700;
+  }
+
+  .users-pagination .pagination {
+    display: flex;
+    gap: .3rem;
+    flex-wrap: wrap;
+    margin: 0;
+  }
+
+  .users-pagination .page-link {
+    display: inline-flex;
+    min-width: 2.3rem;
+    min-height: 2.3rem;
+    align-items: center;
+    justify-content: center;
+    gap: .35rem;
+    padding: .42rem .65rem;
+    border: 1px solid var(--users-border);
+    border-radius: .62rem !important;
+    color: var(--users-blue-dark);
+    background: var(--users-surface-muted);
+    font-size: .78rem;
+    font-weight: 800;
+  }
+
+  .users-pagination .page-item.active .page-link {
+    border-color: var(--users-blue);
+    color: #fff;
+    background: var(--users-blue);
+  }
+
+  .users-pagination .page-item.disabled .page-link { opacity: .45; pointer-events: none; }
+
+  .users-empty {
+    padding: 3rem 1.5rem;
+    color: var(--users-muted);
+    text-align: center;
+  }
+
+  @media (max-width: 760px) {
+    .users-table-scroll { overflow-x: auto; }
+    .users-table .dropdown-menu.show {
+      position: static !important;
+      transform: none !important;
+      margin-top: .4rem !important;
+    }
+    .users-pagination { align-items: stretch; flex-direction: column; }
+    .users-pagination .pagination { justify-content: center; }
+    .users-pagination-label { display: none; }
+  }
+</style>
+
+<div class="users-results-heading">
+  <span><strong>{{ total_users }}</strong> {{ _('käyttäjää löytyi') }}</span>
+  {% if search_query %}<span>{{ _('Haku') }}: “{{ search_query }}”</span>{% endif %}
+</div>
 
 {% if users %}
-<nav aria-label="User pagination">
-  <ul class="pagination justify-content-center mt-3">
-    {% if prev_page %}
-      <li class="page-item">
-        <a class="page-link" href="?page={{ prev_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}">
-          <i class="fas fa-angle-left"></i> {{ _('Edellinen') }}
-        </a>
+<div class="users-table-scroll">
+  <table class="users-table">
+    <thead>
+      <tr>
+        <th class="sortable">{{ _('Käyttäjä') }}</th>
+        <th class="sortable">{{ _('Sähköpostiosoite') }}</th>
+        <th class="sortable">{{ _('Rooli') }}</th>
+        <th class="sortable">{{ _('Viimeksi kirjautunut') }}</th>
+        <th>{{ _('Toiminnot') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in users %}
+      <tr id="user-{{ user._id }}">
+        <td>
+          <div class="user-identity">
+            <span class="user-avatar">{{ (user.displayname or user.username or '?')[:1] }}</span>
+            <div>
+              <strong>{{ user.displayname or user.username }}</strong>
+              <span>@{{ user.username }}</span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <div class="user-email">{{ user.email }}</div>
+          {% if user.confirmed %}
+            <span class="user-status confirmed"><i class="fas fa-circle-check" aria-hidden="true"></i>{{ _('Vahvistettu') }}</span>
+          {% else %}
+            <span class="user-status"><i class="fas fa-clock" aria-hidden="true"></i>{{ _('Vahvistamaton') }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if user.role == 'admin' %}
+            <span class="user-role admin"><i class="fas fa-shield" aria-hidden="true"></i>{{ _('Admin') }}</span>
+          {% elif user.role in ['global_admin', 'god'] %}
+            <span class="user-role global-admin"><i class="fas fa-shield-halved" aria-hidden="true"></i>{{ _('Superkäyttäjä') }}</span>
+          {% else %}
+            <span class="user-role"><i class="fas fa-user" aria-hidden="true"></i>{{ _('Käyttäjä') }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if user.last_login %}
+            <span class="user-login">{{ user.last_login.strftime('%d.%m.%Y %H:%M') }}</span>
+          {% else %}
+            <span class="user-login never">{{ _('Ei kirjautunut') }}</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if current_user.has_permission("EDIT_USER") or current_user.has_permission("DELETE_USER") or current_user.has_permission("FORCE_PASSWORD_CHANGE") or current_user.has_permission("VIEW_USER") %}
+          <div class="dropdown">
+            <button class="user-actions-button dropdown-toggle" type="button" id="userActions-{{ user._id }}" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="fa-solid fa-ellipsis" aria-hidden="true"></i>{{ _('Toiminnot') }}
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="userActions-{{ user._id }}">
+              {% if current_user.has_permission("EDIT_USER") %}
+              <li><a class="dropdown-item" href="{{ url_for('admin_user.edit_user', user_id=user._id) }}"><i class="fas fa-edit me-2"></i>{{ _('Muokkaa') }}</a></li>
+              {% endif %}
+              {% if current_user.has_permission("FORCE_PASSWORD_CHANGE") %}
+              <li><button class="dropdown-item text-warning" type="button" onclick="openForcePwdModal('{{ user.displayname or user.username }}', '{{ user._id }}')"><i class="fas fa-key me-2"></i>{{ _('Pakota salasananvaihto') }}</button></li>
+              {% endif %}
+              {% if current_user.has_permission("VIEW_USER") %}
+              <li><button class="dropdown-item" type="button" onclick='openLoginHistoryModal("{{ user._id }}", {{ (user.displayname or user.username)|tojson|e }}, {{ user.username|tojson|e }})'><i class="fas fa-clock-rotate-left me-2"></i>{{ _('Kirjautumishistoria') }}</button></li>
+              {% endif %}
+              {% if current_user.has_permission("DELETE_USER") %}
+              <li><button class="dropdown-item text-danger" type="button" onclick="openDeleteModal(event, '{{ user.displayname or user.username }}', '{{ user._id }}', 'user')"><i class="fas fa-trash-alt me-2"></i>{{ _('Poista') }}</button></li>
+              {% endif %}
+            </ul>
+          </div>
+          {% else %}
+            <span class="user-status">{{ _('Ei riittäviä oikeuksia.') }}</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<nav class="users-pagination" aria-label="{{ _('Käyttäjien sivutus') }}">
+  <div class="users-pagination-info">{{ _('Sivu') }} {{ current_page }} / {{ total_pages }}</div>
+  <ul class="pagination">
+    <li class="page-item {% if not prev_page %}disabled{% endif %}">
+      <a class="page-link" href="?page={{ prev_page or 1 }}&per_page={{ per_page }}&search={{ search_query|urlencode }}">
+        <i class="fas fa-angle-left" aria-hidden="true"></i><span class="users-pagination-label">{{ _('Edellinen') }}</span>
+      </a>
+    </li>
+    {% for page_number in visible_pages %}
+      <li class="page-item {% if page_number == current_page %}active{% endif %}">
+        <a class="page-link" href="?page={{ page_number }}&per_page={{ per_page }}&search={{ search_query|urlencode }}" {% if page_number == current_page %}aria-current="page"{% endif %}>{{ page_number }}</a>
       </li>
-    {% else %}
-      <li class="page-item disabled"><span class="page-link"><i class="fas fa-angle-left"></i> {{ _('Edellinen') }}</span></li>
-    {% endif %}
-    <li class="page-item disabled"><span class="page-link">{{ _('Sivu') }} {{ current_page }} / {{ total_pages }}</span></li>
-    {% if next_page %}
-      <li class="page-item">
-        <a class="page-link" href="?page={{ next_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}">
-          {{ _('Seuraava') }} <i class="fas fa-angle-right"></i>
-        </a>
-      </li>
-    {% else %}
-      <li class="page-item disabled"><span class="page-link">{{ _('Seuraava') }} <i class="fas fa-angle-right"></i></span></li>
-    {% endif %}
+    {% endfor %}
+    <li class="page-item {% if not next_page %}disabled{% endif %}">
+      <a class="page-link" href="?page={{ next_page or total_pages }}&per_page={{ per_page }}&search={{ search_query|urlencode }}">
+        <span class="users-pagination-label">{{ _('Seuraava') }}</span><i class="fas fa-angle-right" aria-hidden="true"></i>
+      </a>
+    </li>
   </ul>
 </nav>
 {% else %}
-<div class="alert alert-light border mt-3 mb-0">
-  {{ _('Ei käyttäjiä tällä haulla.') }}
+<div class="users-empty">
+  <i class="fas fa-user-slash fs-2 mb-3" aria-hidden="true"></i>
+  <h3>{{ _('Ei käyttäjiä tällä haulla.') }}</h3>
+  <p class="mb-0">{{ _('Kokeile käyttäjänimeä, näyttönimeä tai sähköpostiosoitetta.') }}</p>
 </div>
 {% endif %}
-
-<style>
-/* Hover effect + pointer */
-.table-hover tbody tr:hover {
-  background-color: #f1f3f5;
-  cursor: pointer;
-}
-
-/* Optional: role badges spacing */
-.badge-role {
-  font-size: 0.85rem;
-  padding: 0.35em 0.65em;
-}
-</style>

--- a/mielenosoitukset_fi/templates/admin_V2/analytics.html
+++ b/mielenosoitukset_fi/templates/admin_V2/analytics.html
@@ -3,86 +3,249 @@
 {% block title %}{{ _('Mielenosoitusanalytiikka') }}{% endblock %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/form.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/table.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/admin_actions_cell.css') }}">
-<link rel="stylesheet" href="{{ url_for('static', filename='css/admin_actions_cell_btns.css') }}">
-
 <style>
-  .no-data {
-    color: var(--text_error);
-    font-weight: bold;
-    background: var(--background_alert);
-    padding: 1.5rem;
-    border: 1px dashed var(--border_alert);
-    border-radius: 8px;
+  .analytics-page {
+    --analytics-blue: light-dark(#0033a0, #8bb1ff);
+    --analytics-blue-dark: light-dark(#00267a, #b9ceff);
+    --analytics-blue-soft: light-dark(#edf4ff, #17233b);
+    --analytics-orange: #ff6600;
+    --analytics-surface: light-dark(#ffffff, #20252d);
+    --analytics-surface-muted: light-dark(#f6f8fb, #292f39);
+    --analytics-border: light-dark(#dce3ec, #424b59);
+    --analytics-text: light-dark(#172033, #f2f5fa);
+    --analytics-muted: light-dark(#647083, #b7c0ce);
+    max-width: 1300px;
+    margin: 0 auto;
+    color: var(--analytics-text);
+  }
+
+  .analytics-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    margin-bottom: 1.25rem;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .4), transparent 17rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
+
+  .analytics-kicker {
+    margin: 0;
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+
+  .analytics-hero h1 {
+    margin: .25rem 0 .5rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3rem);
+    letter-spacing: -.035em;
+  }
+
+  .analytics-hero p:last-child {
+    max-width: 650px;
+    margin: 0;
+    color: rgba(255,255,255,.8);
+    line-height: 1.65;
+  }
+
+  .analytics-summary {
+    position: relative;
+    z-index: 1;
+    min-width: 150px;
+    padding: .9rem 1rem;
+    border: 1px solid rgba(255,255,255,.2);
+    border-radius: 1rem;
+    background: rgba(255,255,255,.1);
     text-align: center;
-    margin: 2rem 0;
   }
 
-  .analytics-table td,
-  .analytics-table th {
-    text-align: left;
-    padding: 1rem;
+  .analytics-summary strong,
+  .analytics-summary span {
+    display: block;
   }
 
-  .analytics-table thead {
-    background-color: var(--table_header_bg);
+  .analytics-summary strong {
+    color: #fff;
+    font-size: 1.7rem;
+    line-height: 1;
   }
 
-  .analytics-table tr:hover {
-    background-color: var(--table_row_hover);
+  .analytics-summary span {
+    margin-top: .3rem;
+    color: rgba(255,255,255,.72);
+    font-size: .78rem;
+  }
+
+  .no-data {
+    color: var(--analytics-muted);
+    background: var(--analytics-surface);
+    padding: 3rem 1.5rem;
+    border: 1px dashed var(--analytics-border);
+    border-radius: 1rem;
+    text-align: center;
+  }
+
+  .analytics-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(300px, .55fr);
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .analytics-panel {
+    overflow: hidden;
+    border: 1px solid var(--analytics-border);
+    border-radius: 1.1rem;
+    background: var(--analytics-surface);
+    box-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .08), rgba(0, 0, 0, .18));
+  }
+
+  .analytics-panel-heading {
+    padding: 1.1rem 1.25rem;
+    border-bottom: 1px solid var(--analytics-border);
+  }
+
+  .analytics-panel-heading h2 {
+    margin: 0;
+    color: var(--analytics-text);
+    font-size: 1.05rem;
+  }
+
+  .analytics-panel-heading p {
+    margin: .25rem 0 0;
+    color: var(--analytics-muted);
+    font-size: .84rem;
   }
 
   .chart-container {
-    background: var(--container_background);
-    padding: 1rem;
-    border-radius: 12px;
-    border: 1px solid var(--border_color);
-    margin-bottom: 2rem;
-    height: 400px;
+    height: 430px;
+    padding: 1.25rem;
+  }
+
+  .analytics-table-wrap {
+    max-height: 500px;
+    overflow: auto;
+  }
+
+  .analytics-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .analytics-table th,
+  .analytics-table td {
+    padding: .85rem 1.1rem;
+    border-bottom: 1px solid var(--analytics-border);
+    color: var(--analytics-text);
+    text-align: left;
+  }
+
+  .analytics-table th {
+    position: sticky;
+    top: 0;
+    color: var(--analytics-muted);
+    background: var(--analytics-surface-muted);
+    font-size: .72rem;
+    font-weight: 800;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
+
+  .analytics-table tbody tr:hover {
+    background: var(--analytics-blue-soft);
+  }
+
+  .analytics-table td:last-child {
+    color: var(--analytics-blue-dark);
+    font-weight: 800;
+  }
+
+  @media (max-width: 1000px) {
+    .analytics-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 700px) {
+    .analytics-hero {
+      grid-template-columns: 1fr;
+    }
+
+    .analytics-summary {
+      min-width: 0;
+    }
   }
 </style>
 {% endblock %}
 
 {% block main_content %}
-<section class="dashboard-container">
-  <!-- Header -->
-  <div class="introduction">
-    <h1 id="tabletitle">{{ _('Mielenosoitusanalytiikka') }}</h1>
-    <p class="muted">
+<section class="analytics-page">
+  <header class="analytics-hero">
+    <div>
+      <p class="analytics-kicker">{{ _('Analytiikka') }}</p>
+      <h1 id="tabletitle">{{ _('Mielenosoitusanalytiikka') }}</h1>
+      <p>
       {{ _('Täältä näet mielenosoitusten katselukerrat järjestyksessä.') }}
-    </p>
-  </div>
+      </p>
+    </div>
+    <div class="analytics-summary">
+      <strong>{{ data|length }}</strong>
+      <span>{{ _('mielenosoitusta') }}</span>
+    </div>
+  </header>
 
   {% if data %}
-  <!-- Chart -->
-  <div class="chart-container">
-    <canvas id="viewsChart"></canvas>
-  </div>
+  <div class="analytics-grid">
+    <div class="analytics-panel">
+      <div class="analytics-panel-heading">
+        <h2>{{ _('Katselukerrat vertailussa') }}</h2>
+        <p>{{ _('Palkit näyttävät suosituimmat mielenosoitukset nopeasti.') }}</p>
+      </div>
+      <div class="chart-container">
+        <canvas id="viewsChart"></canvas>
+      </div>
+    </div>
 
-  <!-- Table -->
-  <div class="table-container" style="background: none;">
-    <table class="analytics-table">
-      <thead>
-        <tr>
-          <th>{{ _('Mielenosoituksen ID') }}</th>
-          <th>{{ _('Katselukerrat') }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for demo in data %}
-        <tr>
-          <td>{{ demo.id }}</td>
-          <td>{{ demo.views }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="analytics-panel">
+      <div class="analytics-panel-heading">
+        <h2>{{ _('Kaikki luvut') }}</h2>
+        <p>{{ _('Tarkat katselukerrat mielenosoituksittain.') }}</p>
+      </div>
+      <div class="analytics-table-wrap">
+        <table class="analytics-table">
+          <thead>
+            <tr>
+              <th>{{ _('Mielenosoituksen ID') }}</th>
+              <th>{{ _('Katselukerrat') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for demo in data %}
+            <tr>
+              <td>{{ demo.id }}</td>
+              <td>{{ demo.views }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
   {% else %}
   <div class="no-data">
-    <i class="fa-solid fa-circle-exclamation"></i> {{ _('Ei tietoja saatavilla.') }}
+    <i class="fa-solid fa-chart-column mb-2"></i>
+    <p class="mb-0">{{ _('Ei tietoja saatavilla.') }}</p>
   </div>
   {% endif %}
 </section>
@@ -96,64 +259,67 @@
   const demoLabels = {{ data | map(attribute='id') | list | tojson }};
   const demoViews = {{ data | map(attribute='views') | list | tojson }};
 
-  const ctx = document.getElementById('viewsChart').getContext('2d');
+  const chartElement = document.getElementById('viewsChart');
 
-  const isDark = document.documentElement.classList.contains('dark') || document.body.classList.contains('dark');
+  if (chartElement) {
+    const ctx = chartElement.getContext('2d');
+    const isDark = document.documentElement.classList.contains('dark') || document.body.classList.contains('dark');
 
-  const chartColors = {
-    text: isDark ? '#eee' : '#222',
-    grid: isDark ? '#444' : '#ccc',
-    background: isDark ? '#1e1e2f' : '#fff',
-    bars: isDark ? '#64b5f6' : '#1976d2',
-  };
+    const chartColors = {
+      text: isDark ? '#d9e0ea' : '#647083',
+      grid: isDark ? 'rgba(255,255,255,.08)' : 'rgba(28,48,82,.1)',
+      background: isDark ? '#20252d' : '#fff',
+      bars: isDark ? '#8bb1ff' : '#0033a0',
+    };
 
-  const viewsChart = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: demoLabels,
-      datasets: [{
-        label: '{{ _("Katselukerrat") }}',
-        data: demoViews,
-        backgroundColor: chartColors.bars,
-        borderRadius: 4,
-        barPercentage: 0.6
-      }]
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      scales: {
-        x: {
-          ticks: {
-            color: chartColors.text
-          },
-          grid: {
-            color: chartColors.grid
-          }
-        },
-        y: {
-          beginAtZero: true,
-          ticks: {
-            color: chartColors.text
-          },
-          grid: {
-            color: chartColors.grid
-          }
-        }
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: demoLabels,
+        datasets: [{
+          label: '{{ _("Katselukerrat") }}',
+          data: demoViews,
+          backgroundColor: chartColors.bars,
+          borderRadius: 7,
+          barPercentage: 0.65
+        }]
       },
-      plugins: {
-        legend: {
-          labels: {
-            color: chartColors.text
-          }
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            ticks: {
+              color: chartColors.text
+            },
+            grid: {
+              display: false
+            }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              color: chartColors.text
+            },
+            grid: {
+              color: chartColors.grid
+            }
+          },
         },
-        tooltip: {
-          backgroundColor: chartColors.background,
-          titleColor: chartColors.text,
-          bodyColor: chartColors.text,
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            backgroundColor: chartColors.background,
+            titleColor: chartColors.text,
+            bodyColor: chartColors.text,
+            borderColor: chartColors.grid,
+            borderWidth: 1
+          }
         }
       }
-    }
-  });
+    });
+  }
 </script>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/admin_V2/organizations/dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/organizations/dashboard.html
@@ -1,192 +1,343 @@
 {% extends 'admin_base.html' %}
 
+{% block styles %}
+<style>
+  .orgs-page {
+    --orgs-blue: light-dark(#0033a0, #8bb1ff);
+    --orgs-blue-dark: light-dark(#00267a, #b9ceff);
+    --orgs-blue-soft: light-dark(#edf4ff, #17233b);
+    --orgs-orange: #ff6600;
+    --orgs-orange-soft: light-dark(#fff2e8, #3a2418);
+    --orgs-surface: light-dark(#ffffff, #20252d);
+    --orgs-surface-muted: light-dark(#f6f8fb, #292f39);
+    --orgs-border: light-dark(#dce3ec, #424b59);
+    --orgs-text: light-dark(#172033, #f2f5fa);
+    --orgs-muted: light-dark(#647083, #b7c0ce);
+    --orgs-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .08), rgba(0, 0, 0, .18));
+    display: grid;
+    gap: 1rem;
+    max-width: 1450px;
+    margin: 0 auto;
+    color: var(--orgs-text);
+  }
 
-{% block main_content %}
-<section class="dashboard-container">
-    <!-- Intro card -->
-    <div class="introduction">
-        <h1 id="tabletitle">{{ _('Organisaatiot') }}</h1>
-        <p class="muted">
-            {{ _('Täältä voit hallita organisaatioita, joihin sinulla on käyttöoikeus.') }}<br>
-            {{ _('Lisätietoja hallinnoimisesta löydät hallinnoijan käsikirjasta, kappaleesta 2.1: Organisaatioiden
-            hallintapaneeli, etusivu.') }}
-        </p>
-    </div>
+  .orgs-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .42), transparent 18rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
 
-    <!-- Action panel -->
-    <div class="dashboard-panel">
+  .orgs-kicker {
+    margin: 0;
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
 
-        <div class="flex justify-center mb-4">
-            {% if current_user.has_permission("CREATE_ORGANIZATION", strict=true) %}
-            <a href="{{ url_for('admin_org.create_organization') }}" class="btn new-item">
-                <i class="fas fa-plus"></i>{{ _('Luo uusi organisaatio') }}
-            </a>
-            {% else %}
-            <a class="non-suffperm" data-tooltip="Ei käyttöoikeutta"><i class="fas fa-ban"></i> {{ _('Luo uusi
-                organisaatio') }}</a>
-            {% endif %}
-        </div>
+  .orgs-hero h1 {
+    margin: .25rem 0 .5rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    letter-spacing: -.035em;
+  }
 
-        <form class="search-bar" method="get" action="{{ url_for('admin_org.organization_control') }}">
-            <label for="search" class="sr-only">{{ _('Hae organisaatioita:') }}</label>
-            <input type="search" id="search" name="search" class="search-input"
-                placeholder="{{ _('Hae organisaatioita...') }}" aria-label="{{ _('Hae organisaatioita') }}"
-                value="{{ search_query }}">
-            <input type="hidden" name="per_page" value="{{ per_page }}">
-            <button type="submit" class="search-button">
-                <i class="fas fa-search"></i>{{ _('Hae') }}
-            </button>
-        </form>
-    </div>
+  .orgs-hero p:last-child {
+    max-width: 680px;
+    margin: 0;
+    color: rgba(255,255,255,.8);
+    line-height: 1.65;
+  }
 
-    <!-- Table of organisations -->
-    {% if organizations %}
-    <div class="table-container" style="background:none;">
-        <table id="org-table">
-            <thead>
-                <tr>
-                    <th class="cbox-cell"><input type="checkbox" id="select-all" /></th>
-                    <th>{{ _('Nimi') }}</th>
-                    <th>{{ _('Kuvaus') }}</th>
-                    <th>{{ _('Sähköpostiosoite') }}</th>
-                    <th>{{ _('Verkkosivu') }}</th>
-                    <th class="actions-cell-header">{{ _('Toiminnot') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for org in organizations %}
-                <tr>
-                    <td class="cbox-cell"><input type="checkbox" name="selected_orgs" value="{{ org._id }}"></td>
-                    <td>{{ org.name }}</td>
-                    <td>{{ org.description }}</td>
-                    <td>{{ org.email }}</td>
-                    <td><a href="{{ org.website }}" target="_blank" class="link">{{ org.website }}</a></td>
-                    <td class="actions-cell">
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
-                                id="actionsDropdown-{{ org._id }}" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="fa-solid fa-ellipsis-vertical"></i> {{ _('Toiminnot') }}
-                            </button>
-                            <ul class="dropdown-menu" aria-labelledby="actionsDropdown-{{ org._id }}">
-                                {% if current_user.has_permission("EDIT_ORGANIZATION", org._id) %}
-                                <li>
-                                    <a class="dropdown-item"
-                                        href="{{ url_for('admin_org.edit_organization', org_id=org._id) }}">
-                                        <i class="fas fa-edit me-2"></i>{{ _('Muokkaa') }}
-                                    </a>
-                                </li>
-                                {% else %}
-                                <li>
-                                    <span class="dropdown-item disabled" data-tooltip="Ei käyttöoikeutta">
-                                        <i class="fas fa-ban me-2"></i>{{ _('Muokkaa') }}
-                                    </span>
-                                </li>
-                                {% endif %}
+  .orgs-hero-actions {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: .6rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
 
-                                {% if current_user.has_permission("DELETE_ORGANIZATION", org._id) %}
-                                <li>
-                                    <a class="dropdown-item text-danger"
-                                        href="{{ url_for('admin_org.confirm_delete_organization', org_id=org._id) }}">
-                                        <i class="fas fa-trash-alt me-2"></i>{{ _('Poista') }}
-                                    </a>
-                                </li>
-                                {% else %}
-                                <li>
-                                    <span class="dropdown-item disabled" data-tooltip="Ei käyttöoikeutta">
-                                        <i class="fas fa-ban me-2"></i>{{ _('Poista') }}
-                                    </span>
-                                </li>
-                                {% endif %}
+  .orgs-hero-action {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    min-height: 2.65rem;
+    padding: .62rem .85rem;
+    border: 1px solid rgba(255,255,255,.22);
+    border-radius: .75rem;
+    color: #fff;
+    background: rgba(255,255,255,.1);
+    font-size: .84rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
 
-                                {% if current_user.has_permission("VIEW_ORGANIZATION", org._id) %}
-                                <li>
-                                    <a class="dropdown-item"
-                                        href="{{ url_for('admin_org.view_organization', org_id=org._id) }}">
-                                        <i class="fa-solid fa-eye me-2"></i>{{ _('Yhteenveto') }}
-                                    </a>
-                                </li>
-                                {% else %}
-                                <li>
-                                    <span class="dropdown-item disabled" data-tooltip="Ei käyttöoikeutta">
-                                        <i class="fas fa-ban me-2"></i>{{ _('Yhteenveto') }}
-                                    </span>
-                                </li>
-                                {% endif %}
+  .orgs-hero-action:hover { color: #fff; background: rgba(255,255,255,.18); }
 
-                                <!-- Always visible link to public org page -->
-                                <li>
-                                    <a class="dropdown-item" href="{{ url_for('org', org_id=org._id) }}">
-                                        <i class="fa-solid fa-eye me-2"></i>{{ _('Katsele') }}
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </td>
+  .orgs-summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: .8rem;
+  }
 
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+  .orgs-summary-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: .8rem;
+    align-items: center;
+    padding: 1rem;
+    border: 1px solid var(--orgs-border);
+    border-radius: 1rem;
+    background: var(--orgs-surface);
+    box-shadow: var(--orgs-shadow);
+  }
 
-    <div class="pagination-container d-flex justify-content-between align-items-center mt-3">
-        <div class="pagination-info">
-            {{ _('Sivu') }} {{ current_page }} / {{ total_pages }}
-        </div>
-        <div class="pagination-controls">
-            <ul class="pagination mb-0">
-                <li class="page-item {% if not prev_page %}disabled{% endif %}">
-                    <a class="page-link" href="{{ prev_page_url or '#' }}"
-                        aria-label="{{ _('Edellinen sivu') }}">
-                        <span aria-hidden="true">&laquo;</span>
-                    </a>
-                </li>
-                <li class="page-item disabled"><span class="page-link">{{ current_page }}</span></li>
-                <li class="page-item {% if not next_page %}disabled{% endif %}">
-                    <a class="page-link" href="{{ next_page_url or '#' }}"
-                        aria-label="{{ _('Seuraava sivu') }}">
-                        <span aria-hidden="true">&raquo;</span>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-    {% else %}
-    <div class="no-orgs">
-        <p>{{ _('Organisaatioita ei löytynyt.') }}</p>
-    </div>
-    {% endif %}
-</section>
+  .orgs-summary-icon {
+    display: grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--orgs-blue);
+    background: var(--orgs-blue-soft);
+  }
+
+  .orgs-summary-card:last-child .orgs-summary-icon { color: var(--orgs-orange); background: var(--orgs-orange-soft); }
+  .orgs-summary-card div span, .orgs-summary-card strong { display: block; }
+  .orgs-summary-card div span { color: var(--orgs-muted); font-size: .72rem; font-weight: 800; }
+  .orgs-summary-card strong { color: var(--orgs-text); font-size: 1.55rem; line-height: 1.1; }
+
+  .orgs-toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: .9rem;
+    border: 1px solid var(--orgs-border);
+    border-radius: 1rem;
+    background: var(--orgs-surface);
+  }
+
+  .orgs-search {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: .65rem;
+    align-items: center;
+    flex: 1;
+    max-width: 720px;
+  }
+
+  .orgs-search i { color: var(--orgs-blue); }
+  .orgs-search input {
+    width: 100%;
+    min-width: 0;
+    padding: .7rem .8rem;
+    border: 1px solid var(--orgs-border);
+    border-radius: .7rem;
+    color: var(--orgs-text);
+    background: var(--orgs-surface-muted);
+    outline: none;
+  }
+
+  .orgs-search input:focus { border-color: var(--orgs-blue); box-shadow: 0 0 0 3px light-dark(rgba(0,51,160,.1), rgba(139,177,255,.12)); }
+
+  .orgs-search-button,
+  .orgs-create {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.65rem;
+    padding: .62rem .85rem;
+    border: 1px solid var(--orgs-blue);
+    border-radius: .72rem;
+    color: #fff !important;
+    background: light-dark(#0033a0, #315ea8);
+    font-size: .82rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .orgs-table-shell {
+    overflow: visible;
+    border: 1px solid var(--orgs-border);
+    border-radius: 1.1rem;
+    background: var(--orgs-surface);
+    box-shadow: var(--orgs-shadow);
+  }
+
+  .orgs-results-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: .9rem 1.1rem;
+    border-bottom: 1px solid var(--orgs-border);
+    color: var(--orgs-muted);
+    background: var(--orgs-surface-muted);
+    font-size: .8rem;
+    font-weight: 700;
+  }
+
+  .orgs-results-heading strong { color: var(--orgs-text); }
+  .orgs-table-scroll { overflow: visible; }
+  .orgs-table { width: 100%; min-width: 980px; border-collapse: collapse; }
+  .orgs-table th, .orgs-table td { padding: .85rem 1rem; border-bottom: 1px solid var(--orgs-border); color: var(--orgs-text); vertical-align: middle; }
+  .orgs-table th { color: var(--orgs-muted); background: var(--orgs-surface); font-size: .7rem; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+  .orgs-table tbody tr:hover { background: var(--orgs-blue-soft); }
+  .orgs-table tbody tr:last-child td { border-bottom: 0; }
+
+  .org-identity { display: flex; gap: .7rem; align-items: center; min-width: 210px; }
+  .org-avatar { display: grid; flex: 0 0 auto; width: 2.45rem; height: 2.45rem; place-items: center; border-radius: .75rem; color: var(--orgs-blue); background: var(--orgs-blue-soft); font-weight: 900; line-height: 1; text-transform: uppercase; }
+  .org-identity strong, .org-identity div span { display: block; }
+  .org-identity strong { color: var(--orgs-text); font-size: .9rem; }
+  .org-identity div span { margin-top: .18rem; color: var(--orgs-muted); font-size: .7rem; }
+  .org-description { max-width: 340px; color: var(--orgs-muted); font-size: .8rem; line-height: 1.45; }
+  .org-contact { color: var(--orgs-muted); font-size: .8rem; overflow-wrap: anywhere; }
+  .org-contact a { color: var(--orgs-blue-dark); }
+  .org-status { display: inline-flex; gap: .35rem; align-items: center; padding: .24rem .5rem; border-radius: 999px; color: var(--orgs-muted); background: var(--orgs-surface-muted); font-size: .68rem; font-weight: 800; }
+  .org-status.verified { color: light-dark(#087f5b, #65d6ac); background: light-dark(#eaf8f2, #17382e); }
+  .org-select { width: 1rem; height: 1rem; accent-color: var(--orgs-blue); }
+
+  .org-action-button { display: inline-flex; gap: .4rem; align-items: center; padding: .45rem .65rem; border: 1px solid var(--orgs-border); border-radius: .65rem; color: var(--orgs-text); background: var(--orgs-surface-muted); font-size: .78rem; font-weight: 800; }
+  .orgs-table .dropdown-menu { z-index: 1080; min-width: 13rem; border-color: var(--orgs-border); border-radius: .75rem; color: var(--orgs-text); background: var(--orgs-surface); box-shadow: 0 14px 38px light-dark(rgba(28,48,82,.16), rgba(0,0,0,.36)); }
+  .orgs-table .dropdown-item { color: var(--orgs-text); font-size: .82rem; }
+  .orgs-table .dropdown-item:hover { color: var(--orgs-blue-dark); background: var(--orgs-blue-soft); }
+
+  .org-pagination { display: flex; justify-content: space-between; gap: 1rem; align-items: center; padding: .8rem 1rem; border-top: 1px solid var(--orgs-border); background: var(--orgs-surface); }
+  .org-pagination-info { color: var(--orgs-muted); font-size: .8rem; font-weight: 700; }
+  .org-pagination .pagination { display: flex; gap: .3rem; flex-wrap: wrap; margin: 0; }
+  .org-pagination .page-link { display: inline-flex; min-width: 2.3rem; min-height: 2.3rem; align-items: center; justify-content: center; gap: .35rem; padding: .42rem .65rem; border: 1px solid var(--orgs-border); border-radius: .62rem !important; color: var(--orgs-blue-dark); background: var(--orgs-surface-muted); font-size: .78rem; font-weight: 800; }
+  .org-pagination .page-item.active .page-link { border-color: var(--orgs-blue); color: #fff; background: var(--orgs-blue); }
+  .org-pagination .page-item.disabled .page-link { opacity: .45; pointer-events: none; }
+  .org-pagination-ellipsis { display: inline-grid; min-width: 1.8rem; min-height: 2.3rem; place-items: center; color: var(--orgs-muted); }
+  .orgs-empty { padding: 3rem 1.5rem; color: var(--orgs-muted); text-align: center; }
+
+  @media (max-width: 1050px) { .orgs-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+  @media (max-width: 760px) {
+    .orgs-hero { grid-template-columns: 1fr; }
+    .orgs-hero-actions { justify-content: flex-start; }
+    .orgs-toolbar { align-items: stretch; flex-direction: column; }
+    .orgs-search { max-width: none; }
+    .orgs-create { width: 100%; }
+    .orgs-table-scroll { overflow-x: auto; }
+    .orgs-table .dropdown-menu.show { position: static !important; transform: none !important; margin-top: .4rem !important; }
+    .org-pagination { align-items: stretch; flex-direction: column; }
+    .org-pagination .pagination { justify-content: center; }
+    .org-pagination-label { display: none; }
+  }
+  @media (max-width: 520px) { .orgs-summary { grid-template-columns: 1fr; } .orgs-hero-action { width: 100%; justify-content: center; } .orgs-search { grid-template-columns: auto minmax(0,1fr); } .orgs-search-button { grid-column: 1 / -1; } }
+</style>
 {% endblock %}
 
+{% block main_content %}
+<div class="orgs-page">
+  <header class="orgs-hero">
+    <div>
+      <p class="orgs-kicker">{{ _('Organisaatiohallinta') }}</p>
+      <h1>{{ _('Organisaatiot') }}</h1>
+      <p>{{ _('Etsi organisaatioita, tarkista profiilien tiedot ja hoida jäsenyyksien tärkeimmät ylläpitotoimet.') }}</p>
+    </div>
+    <div class="orgs-hero-actions">
+      {% if current_user.has_permission("CREATE_ORGANIZATION", strict=true) %}
+        <a href="{{ url_for('admin_org.create_organization') }}" class="orgs-hero-action"><i class="fas fa-plus" aria-hidden="true"></i>{{ _('Luo uusi organisaatio') }}</a>
+      {% endif %}
+    </div>
+  </header>
+
+  <section class="orgs-summary" aria-label="{{ _('Organisaatioiden yhteenveto') }}">
+    <article class="orgs-summary-card"><span class="orgs-summary-icon"><i class="fas fa-building" aria-hidden="true"></i></span><div><span>{{ _('Kaikki organisaatiot') }}</span><strong>{{ organization_summary.all }}</strong></div></article>
+    <article class="orgs-summary-card"><span class="orgs-summary-icon"><i class="fas fa-circle-check" aria-hidden="true"></i></span><div><span>{{ _('Vahvistetut profiilit') }}</span><strong>{{ organization_summary.verified }}</strong></div></article>
+    <article class="orgs-summary-card"><span class="orgs-summary-icon"><i class="fas fa-user-group" aria-hidden="true"></i></span><div><span>{{ _('Jäsenyyksiä') }}</span><strong>{{ organization_summary.memberships }}</strong></div></article>
+    <article class="orgs-summary-card"><span class="orgs-summary-icon"><i class="fas fa-link-slash" aria-hidden="true"></i></span><div><span>{{ _('Verkkosivu puuttuu') }}</span><strong>{{ organization_summary.missing_website }}</strong></div></article>
+  </section>
+
+  <section class="orgs-toolbar">
+    <form class="orgs-search" method="get" action="{{ url_for('admin_org.organization_control') }}">
+      <i class="fas fa-search" aria-hidden="true"></i>
+      <input type="search" id="search" name="search" placeholder="{{ _('Hae organisaatioita...') }}" aria-label="{{ _('Hae organisaatioita') }}" value="{{ search_query }}">
+      <input type="hidden" name="per_page" value="{{ per_page }}">
+      <button type="submit" class="orgs-search-button">{{ _('Hae') }}</button>
+    </form>
+    {% if current_user.has_permission("CREATE_ORGANIZATION", strict=true) %}
+      <a href="{{ url_for('admin_org.create_organization') }}" class="orgs-create"><i class="fas fa-plus" aria-hidden="true"></i>{{ _('Luo uusi organisaatio') }}</a>
+    {% endif %}
+  </section>
+
+  <section class="orgs-table-shell">
+    <div class="orgs-results-heading">
+      <span><strong>{{ total_count }}</strong> {{ _('organisaatiota löytyi') }}</span>
+      {% if search_query %}<span>{{ _('Haku') }}: “{{ search_query }}”</span>{% endif %}
+    </div>
+    {% if organizations %}
+    <div class="orgs-table-scroll">
+      <table class="orgs-table" id="org-table">
+        <thead><tr><th><input class="org-select" type="checkbox" id="select-all" aria-label="{{ _('Valitse kaikki') }}"></th><th>{{ _('Organisaatio') }}</th><th>{{ _('Kuvaus') }}</th><th>{{ _('Yhteystiedot') }}</th><th>{{ _('Tila') }}</th><th>{{ _('Toiminnot') }}</th></tr></thead>
+        <tbody>
+          {% for org in organizations %}
+          <tr>
+            <td><input class="org-select" type="checkbox" name="selected_orgs" value="{{ org._id }}" aria-label="{{ _('Valitse organisaatio') }} {{ org.name }}"></td>
+            <td><div class="org-identity"><span class="org-avatar">{{ (org.name or '?')[:1] }}</span><div><strong>{{ org.name }}</strong><span>{{ org.email or _('Ei sähköpostia') }}</span></div></div></td>
+            <td><div class="org-description">{{ org.description or _('Ei kuvausta.') }}</div></td>
+            <td><div class="org-contact">{% if org.website %}<a href="{{ org.website }}" target="_blank">{{ org.website }}</a>{% else %}{{ _('Ei verkkosivua') }}{% endif %}</div></td>
+            <td>{% if org.verified %}<span class="org-status verified"><i class="fas fa-check" aria-hidden="true"></i>{{ _('Vahvistettu') }}</span>{% else %}<span class="org-status"><i class="fas fa-clock" aria-hidden="true"></i>{{ _('Vahvistamaton') }}</span>{% endif %}</td>
+            <td>
+              <div class="dropdown">
+                <button class="org-action-button dropdown-toggle" type="button" id="actionsDropdown-{{ org._id }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-ellipsis" aria-hidden="true"></i>{{ _('Toiminnot') }}</button>
+                <ul class="dropdown-menu" aria-labelledby="actionsDropdown-{{ org._id }}">
+                  {% if current_user.has_permission("EDIT_ORGANIZATION", org._id) %}<li><a class="dropdown-item" href="{{ url_for('admin_org.edit_organization', org_id=org._id) }}"><i class="fas fa-edit me-2"></i>{{ _('Muokkaa') }}</a></li>{% endif %}
+                  {% if current_user.has_permission("VIEW_ORGANIZATION", org._id) %}<li><a class="dropdown-item" href="{{ url_for('admin_org.view_organization', org_id=org._id) }}"><i class="fa-solid fa-chart-simple me-2"></i>{{ _('Yhteenveto') }}</a></li>{% endif %}
+                  <li><a class="dropdown-item" href="{{ url_for('org', org_id=org._id) }}"><i class="fa-solid fa-arrow-up-right-from-square me-2"></i>{{ _('Julkinen sivu') }}</a></li>
+                  {% if current_user.has_permission("DELETE_ORGANIZATION", org._id) %}<li><a class="dropdown-item text-danger" href="{{ url_for('admin_org.confirm_delete_organization', org_id=org._id) }}"><i class="fas fa-trash-alt me-2"></i>{{ _('Poista') }}</a></li>{% endif %}
+                </ul>
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <nav class="org-pagination" aria-label="{{ _('Organisaatioiden sivutus') }}">
+      <div class="org-pagination-info">{{ _('Sivu') }} {{ current_page }} / {{ total_pages }}</div>
+      <ul class="pagination">
+        <li class="page-item {% if not prev_page %}disabled{% endif %}"><a class="page-link" href="{{ prev_page_url or '#' }}"><i class="fas fa-angle-left" aria-hidden="true"></i><span class="org-pagination-label">{{ _('Edellinen') }}</span></a></li>
+        {% if visible_pages and visible_pages[0].number > 1 %}<li class="page-item"><a class="page-link" href="{{ first_page_url }}">1</a></li>{% if visible_pages[0].number > 2 %}<li class="page-item disabled"><span class="org-pagination-ellipsis">…</span></li>{% endif %}{% endif %}
+        {% for pagination_page in visible_pages %}<li class="page-item {% if pagination_page.number == current_page %}active{% endif %}"><a class="page-link" href="{{ pagination_page.url }}" {% if pagination_page.number == current_page %}aria-current="page"{% endif %}>{{ pagination_page.number }}</a></li>{% endfor %}
+        {% if visible_pages and visible_pages[-1].number < total_pages %}{% if visible_pages[-1].number < total_pages - 1 %}<li class="page-item disabled"><span class="org-pagination-ellipsis">…</span></li>{% endif %}<li class="page-item"><a class="page-link" href="{{ last_page_url }}">{{ total_pages }}</a></li>{% endif %}
+        <li class="page-item {% if not next_page %}disabled{% endif %}"><a class="page-link" href="{{ next_page_url or '#' }}"><span class="org-pagination-label">{{ _('Seuraava') }}</span><i class="fas fa-angle-right" aria-hidden="true"></i></a></li>
+      </ul>
+    </nav>
+    {% else %}
+    <div class="orgs-empty"><i class="fas fa-building-circle-xmark fs-2 mb-3" aria-hidden="true"></i><h3>{{ _('Organisaatioita ei löytynyt.') }}</h3><p class="mb-0">{{ _('Kokeile toista hakusanaa.') }}</p></div>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}
 
 {% block scripts %}
 <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const selectAll = document.getElementById('select-all');
-        const checkBoxes = document.querySelectorAll("input[name='selected_orgs']");
-
-        selectAll?.addEventListener('change', () => {
-            checkBoxes.forEach(cb => {
-                cb.checked = selectAll.checked;
-                cb.closest('tr').classList.toggle('selected', cb.checked);
-            });
-        });
-
-        checkBoxes.forEach(cb => {
-            cb.addEventListener('change', () => {
-                cb.closest('tr').classList.toggle('selected', cb.checked);
-            });
-        });
+  document.addEventListener('DOMContentLoaded', () => {
+    const selectAll = document.getElementById('select-all');
+    const checkBoxes = document.querySelectorAll("input[name='selected_orgs']");
+    selectAll?.addEventListener('change', () => {
+      checkBoxes.forEach((checkbox) => {
+        checkbox.checked = selectAll.checked;
+        checkbox.closest('tr').classList.toggle('selected', checkbox.checked);
+      });
     });
+    checkBoxes.forEach((checkbox) => checkbox.addEventListener('change', () => checkbox.closest('tr').classList.toggle('selected', checkbox.checked)));
+  });
 </script>
-{% endblock %}
-
-{% block extra_buttons %}
-<div class="extra-buttons">
-    <a href="{{ url_for('admin_org.invite_to_organization') }}" class="button invite-button"><i
-            class="fas fa-user-plus"></i>{{ _('Kutsu henkilö') }}</a>
-    <a href="{{ url_for('admin_org.manage_roles') }}" class="button manage-roles-button"><i
-            class="fas fa-user-cog"></i>{{ _('Hallitse rooleja') }}</a>
-</div>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/admin_V2/organizations/form.html
+++ b/mielenosoitukset_fi/templates/admin_V2/organizations/form.html
@@ -1,432 +1,351 @@
 {% extends 'admin_base.html' %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/admin/recu_dash.css') }}">
-
 <style>
-    /* ---------- Card wrapper ---------- */
-    .container {
-        /* background-color and color vars are covered in .dashboard-container */
-        border-radius: 16px;
-        padding: 2rem 2.5rem;
-        max-width: 1000px;
-        margin: 2rem auto;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, .08);
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-    }
+  .org-form-page {
+    --form-blue: light-dark(#0033a0, #8bb1ff);
+    --form-blue-dark: light-dark(#00267a, #c5d6ff);
+    --form-blue-soft: light-dark(#edf4ff, #17233b);
+    --form-orange: #ff6600;
+    --form-orange-soft: light-dark(#fff2e8, #3a2418);
+    --form-surface: light-dark(#ffffff, #20252d);
+    --form-surface-muted: light-dark(#f6f8fb, #292f39);
+    --form-border: light-dark(#dce3ec, #424b59);
+    --form-text: light-dark(#172033, #f2f5fa);
+    --form-muted: light-dark(#647083, #b7c0ce);
+    --form-danger: light-dark(#b42318, #ff9b91);
+    --form-danger-soft: light-dark(#fff0ee, #3b2021);
+    --form-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .08), rgba(0, 0, 0, .18));
+    display: grid;
+    gap: 1rem;
+    max-width: 1320px;
+    margin: 0 auto;
+    color: var(--form-text);
+  }
 
-    .form-title {
-        font-size: 2rem;
-        font-weight: 700;
-        /* color var already defined for primary */
-        text-shadow: 0 1px 3px rgba(0, 0, 0, .05);
-        margin-bottom: 1.5rem;
-    }
+  .org-form-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .42), transparent 18rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
+  .org-form-kicker { margin: 0; color: #ffd6bc; font-size: .76rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+  .org-form-hero h1 { margin: .25rem 0 .5rem; color: #fff; font-size: clamp(2rem, 4vw, 3.2rem); letter-spacing: -.035em; }
+  .org-form-hero p:last-child { max-width: 720px; margin: 0; color: rgba(255, 255, 255, .8); line-height: 1.65; }
+  .org-form-hero-actions { display: flex; gap: .6rem; flex-wrap: wrap; justify-content: flex-end; }
 
-    /* ---------- Generic form controls ---------- */
-    .form-group {
-        display: flex;
-        flex-direction: column;
-        gap: .5rem;
-    }
+  .org-form-button {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.65rem;
+    padding: .62rem .85rem;
+    border: 1px solid var(--form-border);
+    border-radius: .72rem;
+    color: var(--form-text) !important;
+    background: var(--form-surface-muted);
+    font-size: .82rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+  .org-form-button:hover { border-color: var(--form-blue); color: var(--form-blue-dark) !important; }
+  .org-form-button.hero { border-color: rgba(255, 255, 255, .22); color: #fff !important; background: rgba(255, 255, 255, .1); }
+  .org-form-button.hero:hover { color: #fff !important; background: rgba(255, 255, 255, .18); }
+  .org-form-button.primary { border-color: var(--form-blue); color: #fff !important; background: light-dark(#0033a0, #315ea8); }
+  .org-form-button.orange { border-color: transparent; color: light-dark(#a74400, #ffad75) !important; background: var(--form-orange-soft); }
+  .org-form-button.danger { border-color: transparent; color: var(--form-danger) !important; background: var(--form-danger-soft); }
 
-    .form-group label {
-        font-weight: 600;
-        /* color var for text already defined */
-    }
+  .org-form-layout { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(280px, .65fr); gap: 1rem; align-items: start; }
+  .org-form-stack { display: grid; gap: 1rem; }
+  .org-form-card { overflow: hidden; border: 1px solid var(--form-border); border-radius: 1.1rem; background: var(--form-surface); box-shadow: var(--form-shadow); }
+  .org-form-card-header { display: flex; gap: .8rem; align-items: center; padding: 1rem 1.1rem; border-bottom: 1px solid var(--form-border); background: var(--form-surface-muted); }
+  .org-form-card-icon { display: grid; flex: 0 0 auto; width: 2.35rem; height: 2.35rem; place-items: center; border-radius: .7rem; color: var(--form-blue); background: var(--form-blue-soft); }
+  .org-form-card-header h2, .org-form-card-header p { margin: 0; }
+  .org-form-card-header h2 { color: var(--form-text); font-size: 1rem; font-weight: 850; }
+  .org-form-card-header p { margin-top: .15rem; color: var(--form-muted); font-size: .72rem; }
+  .org-form-card-body { display: grid; gap: 1rem; padding: 1.1rem; }
+  .org-form-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
+  .org-form-field { display: grid; gap: .42rem; min-width: 0; }
+  .org-form-field.full { grid-column: 1 / -1; }
+  .org-form-label { color: var(--form-text); font-size: .78rem; font-weight: 800; }
+  .org-form-required { color: var(--form-orange); }
+  .org-form-help { margin: 0; color: var(--form-muted); font-size: .7rem; line-height: 1.5; }
+  .org-form-control {
+    width: 100%;
+    min-width: 0;
+    padding: .72rem .8rem;
+    border: 1px solid var(--form-border);
+    border-radius: .72rem;
+    color: var(--form-text);
+    background: var(--form-surface-muted);
+    font-size: .85rem;
+    outline: none;
+  }
+  textarea.org-form-control { min-height: 9rem; resize: vertical; line-height: 1.6; }
+  .org-form-control:focus { border-color: var(--form-blue); box-shadow: 0 0 0 3px light-dark(rgba(0, 51, 160, .1), rgba(139, 177, 255, .12)); }
+  .org-form-control::file-selector-button { margin: -.35rem .65rem -.35rem -.35rem; padding: .45rem .65rem; border: 0; border-radius: .5rem; color: #fff; background: light-dark(#0033a0, #315ea8); font-weight: 750; }
 
-    .form-control {
-        background-color: var(--input-bg);
-        color: var(--input-text);
-        border: 1px solid var(--input-border);
-        border-radius: 8px;
-        padding: .6rem 1rem;
-        font-size: .95rem;
-        width: 100%;
-    }
+  .org-form-switch { display: flex; gap: .75rem; align-items: center; padding: .8rem; border: 1px solid var(--form-border); border-radius: .8rem; background: var(--form-surface-muted); }
+  .org-form-switch input { width: 2.6rem; height: 1.35rem; accent-color: var(--form-blue); }
+  .org-form-switch strong, .org-form-switch span { display: block; }
+  .org-form-switch strong { color: var(--form-text); font-size: .8rem; }
+  .org-form-switch span { margin-top: .1rem; color: var(--form-muted); font-size: .68rem; }
 
-    input.form-control::placeholder {
-        color: light-dark(#1a1a1a, #ccc);
-    }
+  .logo-preview { display: grid; grid-template-columns: 5.5rem minmax(0, 1fr); gap: .85rem; align-items: center; padding: .8rem; border: 1px solid var(--form-border); border-radius: .85rem; background: var(--form-surface-muted); }
+  .logo-preview img { width: 5.5rem; height: 5.5rem; object-fit: contain; border: 1px solid var(--form-border); border-radius: .75rem; background: var(--form-surface); padding: .45rem; }
+  .logo-preview strong, .logo-preview span { display: block; }
+  .logo-preview strong { font-size: .8rem; }
+  .logo-preview span { margin: .18rem 0 .55rem; color: var(--form-muted); font-size: .68rem; }
+  .logo-preview-actions { display: flex; gap: .45rem; flex-wrap: wrap; }
+  .remove-logo-toggle { display: inline-flex; gap: .35rem; align-items: center; color: var(--form-danger); font-size: .72rem; font-weight: 800; }
+  .remove-logo-toggle input { accent-color: var(--form-danger); }
 
-    /* ---------- Social media section ---------- */
-    .social-media-container {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        margin-bottom: 0.75rem;
-        flex-wrap: wrap;
-        flex: 1;
-    }
+  #social-media-list { display: grid; gap: .65rem; }
+  .social-media-row { display: grid; grid-template-columns: minmax(145px, .35fr) minmax(0, 1fr) auto; gap: .55rem; align-items: center; padding: .65rem; border: 1px solid var(--form-border); border-radius: .8rem; background: var(--form-surface-muted); }
+  .social-media-row .org-form-control { background: var(--form-surface); }
+  .social-remove { width: 2.55rem; min-width: 2.55rem; padding: 0; }
+  .social-empty { padding: 1.5rem 1rem; border: 1px dashed var(--form-border); border-radius: .8rem; color: var(--form-muted); background: var(--form-surface-muted); text-align: center; }
+  .social-empty i { display: block; margin-bottom: .5rem; color: var(--form-blue); font-size: 1.4rem; }
+  .social-empty strong { display: block; margin-bottom: .2rem; color: var(--form-text); font-size: .82rem; }
+  .social-empty span { font-size: .7rem; }
 
-    .custom-dropdown {
-        position: relative;
-        flex: 0 0 auto;
-        min-width: 160px;
-        max-width: 200px;
-    }
+  .org-form-tips { display: grid; gap: .65rem; }
+  .org-form-tip { display: grid; grid-template-columns: 2.15rem minmax(0, 1fr); gap: .65rem; align-items: start; padding: .72rem; border-radius: .8rem; background: var(--form-surface-muted); }
+  .org-form-tip-icon { display: grid; width: 2.15rem; height: 2.15rem; place-items: center; border-radius: .65rem; color: var(--form-blue); background: var(--form-blue-soft); }
+  .org-form-tip:last-child .org-form-tip-icon { color: var(--form-orange); background: var(--form-orange-soft); }
+  .org-form-tip > div > strong, .org-form-tip > div > span { display: block; }
+  .org-form-tip > div > strong { font-size: .78rem; }
+  .org-form-tip > div > span { margin-top: .15rem; color: var(--form-muted); font-size: .68rem; line-height: 1.45; }
 
-    .dropdown-selected {
-        background-color: var(--input-bg);
-        color: var(--input-text);
-        border: 1px solid var(--input-border);
-        border-radius: 8px;
-        padding: 0.5rem 0.75rem;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        cursor: pointer;
-        font-size: 0.9rem;
-    }
+  .org-form-savebar { position: sticky; z-index: 10; bottom: .75rem; display: flex; gap: .65rem; align-items: center; justify-content: space-between; padding: .8rem; border: 1px solid var(--form-border); border-radius: 1rem; background: light-dark(rgba(255, 255, 255, .94), rgba(32, 37, 45, .94)); box-shadow: 0 18px 45px rgba(0, 0, 0, .16); backdrop-filter: blur(12px); }
+  .org-form-savebar-copy strong, .org-form-savebar-copy span { display: block; }
+  .org-form-savebar-copy strong { font-size: .8rem; }
+  .org-form-savebar-copy span { margin-top: .1rem; color: var(--form-muted); font-size: .68rem; }
+  .org-form-savebar-actions { display: flex; gap: .5rem; }
 
-    .dropdown-selected i {
-        margin-left: 0.5rem;
-    }
+  .org-form-page .modal-content { border: 1px solid var(--form-border) !important; border-radius: 1.1rem !important; color: var(--form-text); background: var(--form-surface); box-shadow: 0 24px 70px rgba(0, 0, 0, .25); }
+  .org-form-page .modal-header, .org-form-page .modal-footer { border-color: var(--form-border); }
+  .org-form-page .modal-title { color: var(--form-text); font-weight: 850; }
+  .org-form-page .btn-close { filter: light-dark(none, invert(1)); }
 
-    .dropdown-list {
-        display: none;
-        position: absolute;
-        top: calc(100% + 0.2rem);
-        left: 0;
-        width: 100%;
-        background-color: var(--input-bg);
-        border: 1px solid var(--input-border);
-        border-radius: 8px;
-        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-        z-index: 10;
-        overflow: hidden;
-    }
-
-    .dropdown-list div {
-        padding: 0.5rem 1rem;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        font-size: 0.9rem;
-        gap: 0.5rem;
-        transition: background-color 0.2s;
-    }
-
-    .dropdown-list div:hover {
-        background-color: var(--row-hover);
-    }
-
-    .social-media-container input[type="url"] {
-        flex-grow: 1;
-        min-width: 150px;
-        background-color: var(--input-bg);
-        color: var(--input-text);
-        border: 1px solid var(--input-border);
-        border-radius: 8px;
-        padding: 0.5rem 0.75rem;
-        font-size: 0.9rem;
-    }
-
-    .remove-btn {
-        color: var(--danger);
-        font-size: 1.2rem;
-        cursor: pointer;
-        padding: 0.4rem;
-        transition: color 0.2s ease;
-    }
-
-    .remove-btn:hover {
-        color: var(--primary-hover);
-    }
-
-    /* Button inside social media group */
-    #add-social-media {
-        margin-top: 0.5rem;
-        background-color: var(--primary);
-        color: white;
-        border: none;
-        border-radius: 8px;
-        padding: 0.6rem 1.2rem;
-        font-weight: 500;
-        font-size: 0.95rem;
-        cursor: pointer;
-        transition: background-color 0.2s ease-in-out;
-    }
-
-    #add-social-media:hover {
-        background-color: var(--primary-hover);
-    }
-
-    /* Remove button top right corner in dashboard-panel */
-    .dashboard-panel .remove-btn {
-        position: relative;
-        top: 8px;
-        left: 8px;
-        background: transparent;
-        border-radius: 50%;
-        transition: color 0.2s ease;
-        z-index: 5;
-        user-select: none;
-    }
-
-    .dashboard-panel .remove-btn:hover {
-        color: var(--danger-dark, #a00);
-        background-color: rgba(255, 0, 0, 0.1);
-    }
-
-    #social-media-list {
-        display: flex;
-        gap: 0.5em;
-        /*! flex-basis: max-content; */
-        flex-flow: row;
-        flex-wrap: wrap;
-    }
+  @media (max-width: 1000px) { .org-form-layout { grid-template-columns: 1fr; } }
+  @media (max-width: 760px) {
+    .org-form-hero { grid-template-columns: 1fr; }
+    .org-form-hero-actions { justify-content: flex-start; }
+    .org-form-fields { grid-template-columns: 1fr; }
+    .org-form-field.full { grid-column: auto; }
+    .social-media-row { grid-template-columns: 1fr auto; }
+    .social-media-row input[type="url"] { grid-column: 1 / -1; grid-row: 2; }
+    .org-form-savebar { align-items: stretch; flex-direction: column; }
+    .org-form-savebar-actions { width: 100%; }
+    .org-form-savebar-actions .org-form-button { flex: 1; }
+  }
+  @media (max-width: 520px) {
+    .org-form-button.hero { width: 100%; }
+    .logo-preview { grid-template-columns: 1fr; }
+    .logo-preview img { width: 100%; height: 8rem; }
+  }
 </style>
+{% endblock %}
+
+{% block main_content %}
+<div class="org-form-page">
+  <header class="org-form-hero">
+    <div>
+      <p class="org-form-kicker">{{ _('Organisaatiohallinta') }}</p>
+      <h1>{{ _('Muokkaa organisaatiota') if organization else _('Uusi organisaatio') }}</h1>
+      <p>{% if organization %}{{ _('Pidä organisaation profiili selkeänä, ajantasaisena ja helposti tunnistettavana.') }}{% else %}{{ _('Luo organisaatiolle selkeä profiili, jonka tiedot ovat valmiina julkaisemista ja jäsenhallintaa varten.') }}{% endif %}</p>
+    </div>
+    <div class="org-form-hero-actions">
+      {% if organization %}<a class="org-form-button hero" href="{{ url_for('admin_org.view_organization', org_id=organization._id) }}"><i class="fas fa-chart-simple" aria-hidden="true"></i>{{ _('Yhteenveto') }}</a>{% endif %}
+      <a class="org-form-button hero" href="{{ url_for('admin_org.organization_control') }}"><i class="fas fa-arrow-left" aria-hidden="true"></i>{{ _('Organisaatiot') }}</a>
+      {% if organization %}<button class="org-form-button hero" type="button" data-bs-toggle="modal" data-bs-target="#inviteModal"><i class="fas fa-user-plus" aria-hidden="true"></i>{{ _('Kutsu käyttäjä') }}</button>{% endif %}
+    </div>
+  </header>
+
+  <form id="organization-form" method="POST" enctype="multipart/form-data" action="{{ url_for('admin_org.create_organization' if not organization else 'admin_org.edit_organization', org_id=organization._id if organization else None) }}">
+    <div class="org-form-layout">
+      <div class="org-form-stack">
+        <section class="org-form-card">
+          <div class="org-form-card-header"><span class="org-form-card-icon"><i class="fas fa-building" aria-hidden="true"></i></span><div><h2>{{ _('Perustiedot') }}</h2><p>{{ _('Nämä tiedot näkyvät organisaation profiilissa.') }}</p></div></div>
+          <div class="org-form-card-body">
+            <div class="org-form-fields">
+              <div class="org-form-field full">
+                <label class="org-form-label" for="name">{{ _('Nimi') }} <span class="org-form-required">*</span></label>
+                <input id="name" name="name" class="org-form-control" required autocomplete="organization" value="{{ organization.name if organization else '' }}" placeholder="{{ _('Organisaation nimi') }}">
+              </div>
+              <div class="org-form-field full">
+                <label class="org-form-label" for="description">{{ _('Kuvaus') }} <span class="org-form-required">*</span></label>
+                <textarea id="description" name="description" class="org-form-control" required placeholder="{{ _('Kerro lyhyesti organisaation toiminnasta ja tavoitteista.') }}">{{ organization.description if organization else '' }}</textarea>
+                <p class="org-form-help">{{ _('Selkeä, lyhyt kuvaus auttaa ylläpitäjiä ja kävijöitä tunnistamaan organisaation.') }}</p>
+              </div>
+              <div class="org-form-field">
+                <label class="org-form-label" for="email">{{ _('Sähköpostiosoite') }} <span class="org-form-required">*</span></label>
+                <input type="email" id="email" name="email" class="org-form-control" required autocomplete="email" value="{{ organization.email if organization else '' }}" placeholder="yhteys@example.fi">
+              </div>
+              <div class="org-form-field">
+                <label class="org-form-label" for="website">{{ _('Verkkosivu') }}</label>
+                <input type="url" id="website" name="website" class="org-form-control" value="{{ organization.website if organization else '' }}" placeholder="https://example.fi">
+              </div>
+              {% if organization %}
+              <div class="org-form-field full">
+                <label class="org-form-switch" for="verified"><input type="checkbox" id="verified" name="verified" {% if organization.verified %}checked{% endif %}><span><strong>{{ _('Vahvistettu organisaatio') }}</strong><span>{{ _('Vahvistettu tila näkyy organisaation yhteydessä ylläpidossa.') }}</span></span></label>
+              </div>
+              {% endif %}
+            </div>
+          </div>
+        </section>
+
+        <section class="org-form-card">
+          <div class="org-form-card-header"><span class="org-form-card-icon"><i class="fas fa-image" aria-hidden="true"></i></span><div><h2>{{ _('Logo') }}</h2><p>{{ _('Lisää tunnistettava logo kuvalinkillä tai lataamalla tiedosto.') }}</p></div></div>
+          <div class="org-form-card-body">
+            <div class="org-form-fields">
+              <div class="org-form-field">
+                <label class="org-form-label" for="logo_url">{{ _('Logon URL') }}</label>
+                <input type="url" id="logo_url" name="logo_url" class="org-form-control" placeholder="https://example.fi/logo.png" value="{{ organization.logo if organization and organization.logo else '' }}">
+                <p class="org-form-help">{{ _('Käytä tätä, jos logo on jo verkossa.') }}</p>
+              </div>
+              <div class="org-form-field">
+                <label class="org-form-label" for="logo_file">{{ _('Lataa logo tiedostona') }}</label>
+                <input type="file" id="logo_file" name="logo_file" class="org-form-control" accept="image/*">
+                <p class="org-form-help">{{ _('Ladattu tiedosto korvaa URL-osoitteen tallennettaessa.') }}</p>
+              </div>
+              {% if organization and organization.logo %}
+              <div class="org-form-field full">
+                <div class="logo-preview">
+                  <img src="{{ organization.logo }}" alt="{{ _('Nykyinen logo: %(name)s', name=organization.name) }}" loading="lazy" referrerpolicy="no-referrer">
+                  <div><strong>{{ _('Nykyinen logo') }}</strong><span>{{ _('Voit vaihtaa logon yllä olevilla kentillä tai poistaa sen tallennuksen yhteydessä.') }}</span><div class="logo-preview-actions"><a class="org-form-button" href="{{ organization.logo }}" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer"><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i>{{ _('Avaa logo') }}</a><label class="remove-logo-toggle"><input type="checkbox" name="remove_logo">{{ _('Poista tallennettaessa') }}</label></div></div>
+                </div>
+              </div>
+              {% endif %}
+            </div>
+          </div>
+        </section>
+
+        <section class="org-form-card">
+          <div class="org-form-card-header"><span class="org-form-card-icon"><i class="fas fa-hashtag" aria-hidden="true"></i></span><div><h2>{{ _('Sosiaalinen media') }}</h2><p>{{ _('Lisää vain profiilit, joita organisaatio käyttää aktiivisesti.') }}</p></div></div>
+          <div class="org-form-card-body">
+            <div id="social-media-list"></div>
+            <button type="button" id="add-social-media" class="org-form-button"><i class="fas fa-plus" aria-hidden="true"></i>{{ _('Lisää some-linkki') }}</button>
+          </div>
+        </section>
+      </div>
+
+      <aside class="org-form-stack">
+        <section class="org-form-card">
+          <div class="org-form-card-header"><span class="org-form-card-icon"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i></span><div><h2>{{ _('Ennen julkaisua') if not organization else _('Hyvä profiili') }}</h2><p>{{ _('Luo hyvä pohja heti ensimmäisellä tallennuksella.') if not organization else _('Pieni tarkistus ennen tallentamista.') }}</p></div></div>
+          <div class="org-form-card-body org-form-tips">
+            {% if not organization %}<div class="org-form-tip"><span class="org-form-tip-icon"><i class="fas fa-seedling" aria-hidden="true"></i></span><div><strong>{{ _('Aloita perustiedoista') }}</strong><span>{{ _('Nimi, kuvaus ja sähköposti riittävät uuden organisaation luomiseen. Loput voi täydentää myöhemmin.') }}</span></div></div>{% endif %}
+            <div class="org-form-tip"><span class="org-form-tip-icon"><i class="fas fa-align-left" aria-hidden="true"></i></span><div><strong>{{ _('Kerro olennainen') }}</strong><span>{{ _('Kuvaa toiminta ymmärrettävästi ilman pitkää esittelytekstiä.') }}</span></div></div>
+            <div class="org-form-tip"><span class="org-form-tip-icon"><i class="fas fa-link" aria-hidden="true"></i></span><div><strong>{{ _('Tarkista linkit') }}</strong><span>{{ _('Käytä kokonaisia https-osoitteita verkkosivulle, logolle ja some-profiileille.') }}</span></div></div>
+            <div class="org-form-tip"><span class="org-form-tip-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span><div><strong>{{ _('Pidä yhteystieto ajan tasalla') }}</strong><span>{{ _('Yhteyssähköpostin tulisi tavoittaa organisaation aktiivinen ylläpitäjä.') }}</span></div></div>
+          </div>
+        </section>
+      </aside>
+    </div>
+
+    <div class="org-form-savebar">
+      <div class="org-form-savebar-copy"><strong>{{ _('Valmis luomaan organisaation?') if not organization else _('Valmis tallentamaan?') }}</strong><span>{{ _('Pakolliset kentät on merkitty oranssilla tähdellä.') }}</span></div>
+      <div class="org-form-savebar-actions"><a href="{{ url_for('admin_org.view_organization', org_id=organization._id) if organization else url_for('admin_org.organization_control') }}" class="org-form-button">{{ _('Peruuta') }}</a><button type="submit" class="org-form-button primary"><i class="fas fa-check" aria-hidden="true"></i>{{ _('Tallenna muutokset') if organization else _('Luo organisaatio') }}</button></div>
+    </div>
+  </form>
+
+  {% if organization %}
+  <div class="modal fade" id="inviteModal" tabindex="-1" aria-labelledby="inviteModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <form method="POST" action="{{ url_for('admin_org.invite') }}">
+          <div class="modal-header"><div><p class="org-form-kicker mb-1">{{ _('Uusi jäsen') }}</p><h2 class="modal-title" id="inviteModalLabel">{{ _('Kutsu käyttäjä') }}</h2></div><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button></div>
+          <div class="modal-body"><p class="org-form-help mb-3">{{ _('Lähetämme käyttäjälle sähköpostitse linkin, jolla hän voi liittyä organisaatioon.') }}</p><label for="invitee_email" class="org-form-label">{{ _('Kutsuttavan sähköpostiosoite') }}</label><input type="email" id="invitee_email" name="invitee_email" class="org-form-control mt-2" required autocomplete="email" placeholder="nimi@example.fi"><input type="hidden" name="organization_id" value="{{ organization._id }}"></div>
+          <div class="modal-footer"><button type="button" class="org-form-button" data-bs-dismiss="modal">{{ _('Peruuta') }}</button><button type="submit" class="org-form-button primary"><i class="fas fa-paper-plane" aria-hidden="true"></i>{{ _('Lähetä kutsu') }}</button></div>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-    // ---------- Dropdown helpers ----------
-    function toggleDropdown(sel) {
-        const list = sel.nextElementSibling;
-        list.style.display = list.style.display === 'block' ? 'none' : 'block';
+  document.addEventListener('DOMContentLoaded', () => {
+    const list = document.getElementById('social-media-list');
+    const platforms = [
+      ['facebook', 'Facebook'], ['twitter', 'Twitter'], ['mastodon', 'Mastodon'],
+      ['instagram', 'Instagram'], ['linkedin', 'LinkedIn'], ['tiktok', 'TikTok'],
+      ['youtube', 'YouTube'], ['snapchat', 'Snapchat']
+    ];
+
+    function updateEmptyState() {
+      const empty = list.querySelector('.social-empty');
+      const hasRows = Boolean(list.querySelector('.social-media-row'));
+      if (hasRows && empty) empty.remove();
+      if (!hasRows && !empty) {
+        const element = document.createElement('div');
+        element.className = 'social-empty';
+        element.innerHTML = '<i class="fas fa-link" aria-hidden="true"></i><strong>{{ _("Ei vielä some-linkkejä") }}</strong><span>{{ _("Lisää ensimmäinen profiili alla olevasta painikkeesta.") }}</span>';
+        list.appendChild(element);
+      }
     }
 
-    document.addEventListener('click', e => {
-        const opt = e.target.closest('.dropdown-list div');
-        if (opt) {
-            const value = opt.dataset.value;
-            const text = opt.innerHTML;
-            const dropdown = opt.closest('.custom-dropdown');
-            dropdown.querySelector('.dropdown-selected').innerHTML = text + ' <i class="fas fa-caret-down"></i>';
-            dropdown.querySelector('input[type="hidden"]').value = value;
-            dropdown.querySelector('.dropdown-list').style.display = 'none';
-        }
-        if (!e.target.closest('.custom-dropdown')) {
-            document.querySelectorAll('.dropdown-list').forEach(dl => dl.style.display = 'none');
-        }
-    });
-
-    // ---------- Social media entry factory ----------
     function createSocial(platform = '', url = '') {
-        const list = document.getElementById('social-media-list');
-        const panel = document.createElement('div');
-        panel.className = 'dashboard-panel';
+      const row = document.createElement('div');
+      row.className = 'social-media-row';
 
-        const wrap = document.createElement('div');
-        wrap.className = 'social-media-container';
+      const select = document.createElement('select');
+      select.className = 'org-form-control';
+      select.name = 'social_media_platform[]';
+      select.setAttribute('aria-label', '{{ _("Sosiaalisen median alusta") }}');
+      platforms.forEach(([value, label]) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label;
+        option.selected = value === platform;
+        select.appendChild(option);
+      });
 
-        wrap.innerHTML = `
-  <div class="custom-dropdown">
-    <div class="dropdown-selected" onclick="toggleDropdown(this)">{{ _('Valitse alusta') }} <i class="fas fa-caret-down"></i></div>
-    <div class="dropdown-list">
-      <div data-value="facebook"><i class="fab fa-facebook"></i> Facebook</div>
-      <div data-value="twitter"><i class="fab fa-twitter"></i> Twitter</div>
-        <div data-value="mastodon"><i class="fab fa-mastodon"></i> Mastodon</div>
+      const input = document.createElement('input');
+      input.className = 'org-form-control';
+      input.type = 'url';
+      input.name = 'social_media_url[]';
+      input.placeholder = 'https://...';
+      input.value = url;
+      input.required = true;
+      input.setAttribute('aria-label', '{{ _("Sosiaalisen median URL") }}');
 
-      <div data-value="instagram"><i class="fab fa-instagram"></i> Instagram</div>
-      <div data-value="linkedin"><i class="fab fa-linkedin"></i> LinkedIn</div>
-      <div data-value="tiktok"><i class="fab fa-tiktok"></i> TikTok</div>
-      <div data-value="youtube"><i class="fab fa-youtube"></i> YouTube</div>
-      <div data-value="snapchat"><i class="fab fa-snapchat"></i> Snapchat</div>
-    </div>
-    <input type="hidden" name="social_media_platform[]">
-  </div>
-  <input type="url" name="social_media_url[]" placeholder="{{ _('Syötä URL') }}" class="form-control flex-grow" />
-`;
+      const remove = document.createElement('button');
+      remove.className = 'org-form-button danger social-remove';
+      remove.type = 'button';
+      remove.title = '{{ _("Poista") }}';
+      remove.setAttribute('aria-label', '{{ _("Poista some-linkki") }}');
+      remove.innerHTML = '<i class="fas fa-trash" aria-hidden="true"></i>';
+      remove.addEventListener('click', () => {
+        row.remove();
+        updateEmptyState();
+      });
 
-        const removeBtn = document.createElement('span');
-        removeBtn.className = 'remove-btn';
-        removeBtn.innerHTML = '<i class="fas fa-times"></i>';
-        removeBtn.title = "{{ _('Poista') }}";
-        removeBtn.onclick = () => panel.remove();
-
-        panel.appendChild(removeBtn);
-        panel.appendChild(wrap);
-        list.appendChild(panel);
-
-        // Set initial values if given
-        if (platform) {
-            wrap.querySelector('input[type="hidden"]').value = platform;
-            wrap.querySelector('.dropdown-selected').innerHTML = `<i class="fab fa-${platform}"></i> ${platform.charAt(0).toUpperCase() + platform.slice(1)} <i class="fas fa-caret-down"></i>`;
-        }
-        if (url) {
-            wrap.querySelector('input[type="url"]').value = url;
-        }
-
+      row.append(select, input, remove);
+      list.appendChild(row);
+      updateEmptyState();
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-        document.getElementById('add-social-media').addEventListener('click', () => createSocial());
-        {% if organization %}
-        {% for p, u in organization.get('social_media_links', {}).items() %} createSocial('{{p}}', '{{u}}'); {% endfor %}
-        {% endif %}
-    });
+    document.getElementById('add-social-media').addEventListener('click', () => createSocial());
+    {% if organization %}
+    {% for platform, url in organization.get('social_media_links', {}).items() %}
+    createSocial({{ platform|tojson }}, {{ url|tojson }});
+    {% endfor %}
+    {% endif %}
+    updateEmptyState();
+  });
 </script>
 {% endblock %}
-
-{% block main_content %}
-<div class="dashboard-container" id="org-form">
-    <!-- Intro card -->
-    <div class="introduction">
-        <h1 id="tabletitle">{{ _('Muokkaa organisaatiota') if organization else _('Uusi organisaatio') }}</h1>
-        <p class="muted">
-            {{ _('Tällä lomakkeella voit luoda tai muokata organisaatioita, joihin sinulla on käyttöoikeus.') }}<br>
-            {% if organization %}
-            {{ _('Lisätietoja hallinnoimisesta löydät hallinnoijan käsikirjasta, kappaleesta 2.3: Organisaation
-            muokkaaminen.') }}
-            {% else %}
-            {{ _('Lisätietoja hallinnoimisesta löydät hallinnoijan käsikirjasta, kappaleesta 2.2: Uuden organisaation
-            luominen.') }}
-            {% endif %}
-        </p>
-    </div>
-
-
-    <form method="POST" enctype="multipart/form-data"
-        action="{{ url_for('admin_org.create_organization' if not organization else 'admin_org.edit_organization', org_id=organization._id if organization else None) }}">
-
-        <div class="form-group">
-            <label for="name">{{ _('Nimi') }} <span class="required">*</span></label>
-            <input id="name" name="name" class="form-control" required
-                value="{{ organization.name if organization else '' }}">
-        </div>
-
-        <div class="form-group">
-            <label for="description">{{ _('Kuvaus') }} <span class="required">*</span></label>
-            <textarea id="description" name="description" class="form-control"
-                required>{{ organization.description if organization else '' }}</textarea>
-        </div>
-
-        <div class="form-group">
-            <label for="email">{{ _('Sähköpostiosoite') }} <span class="required">*</span></label>
-            <input type="email" id="email" name="email" class="form-control" required
-                value="{{ organization.email if organization else '' }}">
-        </div>
-
-        <div class="form-group">
-            <label for="website">{{ _('Verkkosivu') }}</label>
-            <input type="url" id="website" name="website" class="form-control"
-                value="{{ organization.website if organization else '' }}">
-        </div>
-
-        <div class="form-group">
-            <label for="logo_url">{{ _('Logon URL') }}</label>
-            <input type="url" id="logo_url" name="logo_url" class="form-control"
-                placeholder="https://example.com/logo.png"
-                value="{{ organization.logo if organization and organization.logo else '' }}">
-            <small class="muted">{{ _('Voit käyttää olemassa olevaa kuvalinkkiä, jos logo on jo verkossa.') }}</small>
-        </div>
-
-        <div class="form-group">
-            <label for="logo_file">{{ _('Lataa logo tiedostona') }}</label>
-            <input type="file" id="logo_file" name="logo_file" class="form-control" accept="image/*">
-            <small class="muted">{{ _('Ladattu tiedosto tallennetaan ja korvaa yllä olevan URL-osoitteen arvon.') }}</small>
-
-            {% if organization and organization.logo %}
-            <div class="logo-preview">
-                <img src="{{ organization.logo }}" alt="{{ _('Nykyinen logo: %(name)s', name=organization.name) }}"
-                    loading="lazy">
-                <div class="logo-actions">
-                    <a href="{{ organization.logo }}" target="_blank" rel="noopener">
-                        {{ _('Avaa nykyinen logo') }}
-                    </a>
-                    <label class="remove-logo-toggle">
-                        <input type="checkbox" name="remove_logo">
-                        {{ _('Poista logo tallennettaessa') }}
-                    </label>
-                </div>
-            </div>
-            {% endif %}
-        </div>
-
-        {% if organization %}
-        <div class="form-group">
-            <label for="verified">{{ _('Onko organisaatio vahvistettu?') }}</label>
-            <input type="checkbox" id="verified" name="verified" {% if organization.verified %}checked{% endif %}>
-        </div>
-        {% endif %}
-
-        <div class="form-group">
-            <label>{{ _('Sosiaalinen media') }}</label>
-            <div id="social-media-list"></div>
-            <button type="button" id="add-social-media" class="button">{{ _('Lisää sosiaalisen median alusta')
-                }}</button>
-        </div>
-
-        <div class="form-buttons">
-            <button type="submit" class="button save-button">{% if organization %}{{ _('Tallenna muutokset') }}{% else %}{{
-                _('Luo') }}{% endif %}</button>
-            <a href="{{ url_for('admin_org.organization_control') }}" class="button cancel-button">{{ _('Peruuta') }}</a>
-        </div>
-    </form>
-
-    {% if organization %}
-    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#inviteModal">
-        {{ _('Kutsu käyttäjiä') }}
-    </button>
-    <div class="modal fade" id="inviteModal" tabindex="-1" aria-labelledby="inviteModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-sm"> {# You can use modal-md or modal-lg if needed #}
-            <div class="modal-content shadow rounded-4 border-0"
-                style="background-color: var(--container-bg); color: var(--text);">
-
-                <form method="POST"
-                    action="{{ url_for('admin_org.invite', org_id=organization._id if organization else None) }}">
-                    <div class="modal-header border-0 pb-0">
-                        <h5 class="modal-title" id="inviteModalLabel">{{ _('Kutsu käyttäjiä') }}</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal"
-                            aria-label="{{ _('Sulje') }}"></button>
-                    </div>
-
-                    <div class="modal-body">
-                        <div class="form-group mb-3">
-                            <label for="invitee_email" class="form-label">
-                                {{ _('Kutsuttavan sähköpostiosoite') }} <span class="required">*</span>
-                            </label>
-                            <input type="email" id="invitee_email" name="invitee_email" class="form-control" required
-                                placeholder="sähköposti@domain.fi">
-                        </div>
-                        <input type="hidden" id="organization_id" name="organization_id" value="{{ organization._id }}">
-                    </div>
-
-                    <div class="modal-footer border-0 pt-0">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Peruuta')
-                            }}</button>
-                        <button type="submit" class="btn btn-primary">{{ _('Lähetä kutsu') }}</button>
-                    </div>
-                </form>
-
-            </div>
-        </div>
-    </div>
-    {% endif %}
-</div>
-{% endblock %}
-    .logo-preview {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        margin-top: 0.75rem;
-        flex-wrap: wrap;
-    }
-
-    .logo-preview img {
-        width: 96px;
-        height: 96px;
-        object-fit: contain;
-        border-radius: 18px;
-        border: 1px solid var(--input-border);
-        background-color: var(--input-bg);
-        padding: 0.5rem;
-        box-shadow: 0 8px 20px rgba(0, 0, 0, .08);
-    }
-
-    .logo-actions {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-    }
-
-    .remove-logo-toggle {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        font-weight: 500;
-    }

--- a/mielenosoitukset_fi/templates/admin_V2/organizations/view.html
+++ b/mielenosoitukset_fi/templates/admin_V2/organizations/view.html
@@ -1,490 +1,526 @@
 {% extends 'admin_base.html' %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/admin/recu_dash.css') }}">
-
 <style>
-    :root {
-        --input-bg: light-dark(#fff, #1a1a1a);
-        --input-border: light-dark(#ccc, #444);
-        --input-text: light-dark(#111, #eee);
-    }
+  .org-detail {
+    --org-blue: light-dark(#0033a0, #8bb1ff);
+    --org-blue-dark: light-dark(#00267a, #c5d6ff);
+    --org-blue-soft: light-dark(#edf4ff, #17233b);
+    --org-orange: #ff6600;
+    --org-orange-soft: light-dark(#fff2e8, #3a2418);
+    --org-surface: light-dark(#ffffff, #20252d);
+    --org-surface-muted: light-dark(#f6f8fb, #292f39);
+    --org-border: light-dark(#dce3ec, #424b59);
+    --org-text: light-dark(#172033, #f2f5fa);
+    --org-muted: light-dark(#647083, #b7c0ce);
+    --org-danger: light-dark(#b42318, #ff9b91);
+    --org-danger-soft: light-dark(#fff0ee, #3b2021);
+    --org-success: light-dark(#087f5b, #65d6ac);
+    --org-success-soft: light-dark(#eaf8f2, #17382e);
+    --org-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .08), rgba(0, 0, 0, .18));
+    display: grid;
+    gap: 1rem;
+    max-width: 1450px;
+    margin: 0 auto;
+    color: var(--org-text);
+  }
 
-    .container {
-        background-color: var(--container-bg);
-        color: var(--text);
-        border-radius: 16px;
-        padding: 2rem 2.5rem;
-        max-width: 1000px;
-        margin: 2rem auto;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-    }
+  .org-detail-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .42), transparent 18rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
 
-    .form-title {
-        font-size: 2rem;
-        font-weight: 700;
-        color: var(--primary);
-        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-        margin-bottom: 1.5rem;
-    }
+  .org-detail-kicker {
+    margin: 0;
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
 
-    .form-group {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-    }
+  .org-detail-hero h1 {
+    margin: .25rem 0 .5rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    letter-spacing: -.035em;
+  }
 
-    .form-group label {
-        font-weight: 600;
-        color: var(--text);
-    }
+  .org-detail-hero-copy {
+    max-width: 720px;
+    margin: 0;
+    color: rgba(255, 255, 255, .8);
+    line-height: 1.65;
+  }
 
-    .form-control {
-        background-color: var(--input-bg);
-        color: var(--input-text);
-        border: 1px solid var(--input-border);
-        border-radius: 8px;
-        padding: 0.6rem 1rem;
-        width: 100%;
-        font-size: 0.95rem;
-    }
+  .org-detail-actions { display: flex; gap: .6rem; flex-wrap: wrap; justify-content: flex-end; }
+  .org-detail-action {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.65rem;
+    padding: .62rem .85rem;
+    border: 1px solid rgba(255, 255, 255, .22);
+    border-radius: .75rem;
+    color: #fff !important;
+    background: rgba(255, 255, 255, .1);
+    font-size: .84rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+  .org-detail-action:hover { background: rgba(255, 255, 255, .18); }
+  .org-detail-action.primary { border-color: #fff; background: #fff; color: #0033a0 !important; }
 
-    input.form-control::placeholder {
-        color: light-dark(#1a1a1a, #ccc);
-    }
+  .org-detail-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .8rem; }
+  .org-detail-summary-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .8rem;
+    align-items: center;
+    padding: 1rem;
+    border: 1px solid var(--org-border);
+    border-radius: 1rem;
+    background: var(--org-surface);
+    box-shadow: var(--org-shadow);
+  }
+  .org-detail-summary-icon {
+    display: grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--org-blue);
+    background: var(--org-blue-soft);
+  }
+  .org-detail-summary-card:last-child .org-detail-summary-icon { color: var(--org-orange); background: var(--org-orange-soft); }
+  .org-detail-summary-card div > span, .org-detail-summary-card div > strong { display: block; }
+  .org-detail-summary-card div > span { color: var(--org-muted); font-size: .72rem; font-weight: 800; }
+  .org-detail-summary-card div > strong { overflow: hidden; color: var(--org-text); font-size: 1.05rem; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+  .org-detail-summary-card strong.metric { font-size: 1.55rem; line-height: 1.1; }
 
-    select.form-control {
-        appearance: none;
-        background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg width='14' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-        background-repeat: no-repeat;
-        background-position: right 0.75rem center;
-        background-size: 1rem;
-    }
+  .org-detail-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(280px, .55fr); gap: 1rem; align-items: start; }
+  .org-detail-stack { display: grid; gap: 1rem; }
+  .org-detail-card {
+    overflow: hidden;
+    border: 1px solid var(--org-border);
+    border-radius: 1.1rem;
+    background: var(--org-surface);
+    box-shadow: var(--org-shadow);
+  }
+  .org-detail-card-header {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.1rem;
+    border-bottom: 1px solid var(--org-border);
+    background: var(--org-surface-muted);
+  }
+  .org-detail-card-title { display: flex; gap: .7rem; align-items: center; }
+  .org-detail-card-title i { color: var(--org-blue); }
+  .org-detail-card h2 { margin: 0; color: var(--org-text); font-size: 1rem; font-weight: 850; }
+  .org-detail-card-count { padding: .25rem .55rem; border-radius: 999px; color: var(--org-blue-dark); background: var(--org-blue-soft); font-size: .7rem; font-weight: 850; }
+  .org-detail-card-body { padding: 1.1rem; }
 
-    .table {
-        width: 100%;
-        border-spacing: 0 0.5rem;
-        color: var(--text);
-    }
+  .org-profile { display: grid; gap: 1rem; }
+  .org-profile-description { margin: 0; color: var(--org-text); line-height: 1.7; white-space: pre-line; }
+  .org-profile-description.muted { color: var(--org-muted); font-style: italic; }
+  .org-facts { display: grid; gap: .65rem; }
+  .org-fact { display: grid; grid-template-columns: 2.25rem minmax(0, 1fr); gap: .7rem; align-items: center; padding: .75rem; border-radius: .8rem; background: var(--org-surface-muted); }
+  .org-fact-icon { display: grid; width: 2.25rem; height: 2.25rem; place-items: center; border-radius: .65rem; color: var(--org-blue); background: var(--org-blue-soft); }
+  .org-fact > div > span, .org-fact > div > strong, .org-fact > div > a { display: block; overflow-wrap: anywhere; }
+  .org-fact > div > span { color: var(--org-muted); font-size: .68rem; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; }
+  .org-fact > div > strong, .org-fact > div > a { color: var(--org-text); font-size: .82rem; font-weight: 750; text-decoration: none; }
+  .org-fact a:hover { color: var(--org-blue-dark); text-decoration: underline; }
+  .org-status { display: inline-flex; gap: .35rem; align-items: center; width: fit-content; padding: .3rem .55rem; border-radius: 999px; color: var(--org-muted); background: var(--org-surface-muted); font-size: .7rem; font-weight: 850; }
+  .org-status.verified { color: var(--org-success); background: var(--org-success-soft); }
+  .org-status.pending { color: var(--org-orange); background: var(--org-orange-soft); }
 
-    thead th {
-        text-align: left;
-        padding: 0.75rem 1rem;
-        font-weight: 600;
-        border-bottom: 2px solid var(--border-color);
-    }
+  .org-social-list { display: grid; gap: .55rem; }
+  .org-social-link { display: grid; grid-template-columns: 2.2rem minmax(0, 1fr) auto; gap: .65rem; align-items: center; padding: .7rem; border: 1px solid var(--org-border); border-radius: .8rem; color: var(--org-text); background: var(--org-surface-muted); text-decoration: none; }
+  .org-social-link:hover { border-color: var(--org-blue); color: var(--org-blue-dark); }
+  .org-social-link > i:first-child { display: grid; width: 2.2rem; height: 2.2rem; place-items: center; border-radius: .65rem; color: var(--org-blue); background: var(--org-blue-soft); }
+  .org-social-link span { overflow: hidden; font-size: .78rem; font-weight: 750; text-overflow: ellipsis; white-space: nowrap; }
 
-    tbody td {
-        padding: 0.75rem 1rem;
-        border-bottom: 1px solid var(--border-color);
-    }
+  .org-table-scroll { overflow-x: auto; }
+  .org-detail-table { width: 100%; min-width: 760px; border-collapse: collapse; }
+  .org-detail-table th, .org-detail-table td { padding: .85rem 1rem; border-bottom: 1px solid var(--org-border); color: var(--org-text); vertical-align: middle; }
+  .org-detail-table th { color: var(--org-muted); background: var(--org-surface); font-size: .7rem; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+  .org-detail-table tbody tr:hover { background: var(--org-blue-soft); }
+  .org-detail-table tbody tr:last-child td { border-bottom: 0; }
+  .org-member { display: flex; gap: .7rem; align-items: center; min-width: 190px; }
+  .org-member-avatar { display: grid; flex: 0 0 auto; width: 2.45rem; height: 2.45rem; place-items: center; border-radius: .75rem; color: var(--org-blue); background: var(--org-blue-soft); font-weight: 900; text-transform: uppercase; }
+  .org-member > div > strong, .org-member > div > span { display: block; }
+  .org-member > div > strong { font-size: .86rem; }
+  .org-member > div > span { margin-top: .12rem; color: var(--org-muted); font-size: .7rem; }
+  .org-role-select {
+    min-width: 8.5rem;
+    padding: .5rem 2rem .5rem .65rem;
+    border: 1px solid var(--org-border);
+    border-radius: .65rem;
+    color: var(--org-text);
+    background-color: var(--org-surface-muted);
+  }
+  .org-row-actions { display: flex; gap: .4rem; flex-wrap: wrap; }
+  .org-button {
+    display: inline-flex;
+    gap: .4rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.35rem;
+    padding: .5rem .7rem;
+    border: 1px solid var(--org-border);
+    border-radius: .65rem;
+    color: var(--org-text) !important;
+    background: var(--org-surface-muted);
+    font-size: .76rem;
+    font-weight: 850;
+    text-decoration: none;
+  }
+  .org-button:hover { border-color: var(--org-blue); color: var(--org-blue-dark) !important; }
+  .org-button.primary { border-color: var(--org-blue); color: #fff !important; background: light-dark(#0033a0, #315ea8); }
+  .org-button.danger { color: var(--org-danger) !important; background: var(--org-danger-soft); }
+  .org-button.orange { color: light-dark(#a74400, #ffad75) !important; background: var(--org-orange-soft); }
+  .org-button[disabled] { cursor: wait; opacity: .55; }
 
-    tbody tr {
-        background-color: light-dark(#fff, #1e1e1e);
-        transition: background 0.2s;
-    }
+  .org-empty { padding: 2.5rem 1.25rem; color: var(--org-muted); text-align: center; }
+  .org-empty i { display: block; margin-bottom: .65rem; color: var(--org-blue); font-size: 1.8rem; }
+  .org-empty strong { display: block; margin-bottom: .25rem; color: var(--org-text); }
 
-    tbody tr:hover {
-        background-color: var(--row-hover);
-    }
+  .org-detail .modal-content { border: 1px solid var(--org-border) !important; border-radius: 1.1rem !important; color: var(--org-text); background: var(--org-surface); box-shadow: 0 24px 70px rgba(0, 0, 0, .25); }
+  .org-detail .modal-header, .org-detail .modal-footer { border-color: var(--org-border); }
+  .org-detail .modal-title { color: var(--org-text); font-weight: 850; }
+  .org-detail .form-label { color: var(--org-text); font-size: .8rem; font-weight: 800; }
+  .org-detail .form-control { border-color: var(--org-border); color: var(--org-text); background: var(--org-surface-muted); }
+  .org-detail .form-control:focus { border-color: var(--org-blue); box-shadow: 0 0 0 3px light-dark(rgba(0, 51, 160, .1), rgba(139, 177, 255, .12)); }
+  .org-detail .btn-close { filter: light-dark(none, invert(1)); }
+  .org-confirm-copy { margin: 0; color: var(--org-muted); line-height: 1.6; }
 
-    .button,
-    .btn-primary {
-        background-color: var(--primary);
-        color: white;
-        padding: 0.5rem 1.25rem;
-        border-radius: 8px;
-        border: none;
-        cursor: pointer;
-        transition: background-color 0.2s ease-in-out;
-        font-weight: 500;
-        margin: 0.2rem;
-    }
+  .org-toast {
+    position: fixed;
+    z-index: 1100;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: .7rem;
+    align-items: center;
+    width: min(390px, calc(100vw - 2rem));
+    padding: .85rem;
+    border: 1px solid var(--org-border);
+    border-radius: .9rem;
+    color: var(--org-text);
+    background: var(--org-surface);
+    box-shadow: 0 18px 50px rgba(0, 0, 0, .2);
+    transform: translateY(130%);
+    transition: transform .2s ease;
+  }
+  .org-toast.show { transform: translateY(0); }
+  .org-toast-icon { display: grid; width: 2rem; height: 2rem; place-items: center; border-radius: .6rem; color: var(--org-success); background: var(--org-success-soft); }
+  .org-toast.error .org-toast-icon { color: var(--org-danger); background: var(--org-danger-soft); }
+  .org-toast-message { font-size: .78rem; font-weight: 750; }
+  .org-toast-close { border: 0; color: var(--org-muted); background: transparent; }
 
-    .button:hover,
-    .btn-primary:hover {
-        background-color: var(--primary-hover);
-    }
-
-    .no-users {
-        margin-top: 1rem;
-        background-color: var(--alert-warning-bg);
-        color: var(--alert-warning-text);
-        padding: 0.75rem 1.25rem;
-        border-radius: 8px;
-        text-align: center;
-        font-weight: 500;
-    }
-
-    /* Social dropdown styling */
-    .social-media-container {
-        display: flex;
-        align-items: center;
-        margin-bottom: 0.75rem;
-    }
-
-    .dropdown-selected {
-        background: var(--input-bg);
-        color: var(--input-text);
-        border: 1px solid var(--input-border);
-        border-radius: 8px 0 0 8px;
-        padding: 0.6rem 1rem;
-        font-weight: 500;
-        width: 160px;
-    }
-
-    #social-media-list .form-control {
-        border-radius: 0 8px 8px 0;
-        border-left: none;
-    }
-
-    .social-media-container p.form-control {
-        margin-bottom: 0;
-        height: 45.2px;
-    }
+  @media (max-width: 1100px) {
+    .org-detail-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .org-detail-grid { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 760px) {
+    .org-detail-hero { grid-template-columns: 1fr; }
+    .org-detail-actions { justify-content: flex-start; }
+    .org-detail-card-header { align-items: flex-start; flex-direction: column; }
+  }
+  @media (max-width: 520px) {
+    .org-detail-summary { grid-template-columns: 1fr; }
+    .org-detail-action, .org-button.primary.invite { width: 100%; }
+  }
 </style>
-
-{% endblock %}
-
-{% block scripts %}
-<!--<script src="{{ url_for('static', filename='js/modal.js') }}"></script>-->
-<script>
-    // TODO: Add functionality to handle dropdown selection
-    // TODO: Add form validation for invitee email
-
-</script>
-<script>
-    document.addEventListener("DOMContentLoaded", () => {
-        const saveButtons = document.querySelectorAll(".save-role-btn");
-
-        saveButtons.forEach(btn => {
-            btn.addEventListener("click", async () => {
-                const userId = btn.dataset.userId;
-                const orgId = btn.dataset.orgId;
-                const select = btn.closest("tr").querySelector(".role-select");
-                const newRole = select.value;
-
-                const payload = {
-                    user_id: userId,
-                    organization_id: orgId,
-                    role: newRole
-                };
-
-                try {
-                    const res = await fetch("/admin/organization/api/change_access_level/", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json"
-                        },
-                        body: JSON.stringify(payload)
-                    });
-
-                    const result = await res.json();
-                    if (res.ok) {
-                        alert("Käyttäjän rooli päivitetty onnistuneesti!");
-                    } else {
-                        alert(result.error || "Päivitys epäonnistui.");
-                    }
-                } catch (err) {
-                    console.error(err);
-                    alert("Virhe palvelinyhteydessä.");
-                }
-            });
-        });
-        const deleteButtons = document.querySelectorAll(".delete-role-btn");
-
-        deleteButtons.forEach(btn => {
-            btn.addEventListener("click", async () => {
-                const shipId = btn.dataset.shipId;
-                if (!confirm("Haluatko varmasti poistaa tämän käyttäjän?")) return;
-
-                try {
-                    const res = await fetch("/admin/organization/api/delete_membership/", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/json"
-                        },
-                        body: JSON.stringify({ membership_id: shipId })
-                    });
-
-                    const result = await res.json();
-                    if (res.ok) {
-                        alert(result.message || "Käyttäjä poistettu");
-                        btn.closest("tr").remove(); // remove row from table
-                    } else {
-                        alert(result.error || "Poisto epäonnistui.");
-                    }
-                } catch (err) {
-                    console.error(err);
-                    alert("Virhe palvelinyhteydessä.");
-                }
-            });
-        });
-
-    });
-</script>
-
 {% endblock %}
 
 {% block main_content %}
-<div class="dashboard-container mt-4" id="view">
-    <div class="dashboard-actions">
-        <a class="button-edit" href="{{ url_for('admin_org.edit_organization', org_id=organization._id) }}">
-            <i class="fa fa-pen"></i> {{ _('Muokkaa') }}
-        </a>
-        
+<div class="org-detail">
+  <header class="org-detail-hero">
+    <div>
+      <p class="org-detail-kicker">{{ _('Organisaation yhteenveto') }}</p>
+      <h1>{{ organization.name }}</h1>
+      <p class="org-detail-hero-copy">{{ _('Tarkista profiilin tiedot, pidä jäsenroolit ajan tasalla ja hoida avoimet kutsut yhdessä paikassa.') }}</p>
     </div>
-    
-    <!-- Intro card -->
-    <div class="introduction">
-        <h1 id="tabletitle">{{ _('Organisaation tiedot') }}</h1>
-        <p class="muted">
-            Tällä sivulla näet valitsemasi organisaation keskeiset tiedot ja käyttäjähallinnan. <br>
-            Voit tarkastella organisaation nimeä, kuvausta, yhteystietoja ja sosiaalisen median linkkejä. <br>
-            Lisäksi voit hallita organisaation jäsenten rooleja, poistaa käyttäjiä ja tarkastella tai peruuttaa
-            lähetettyjä kutsuja. <br>
-            Lisätietoa löydät hallinnoijan käsikirjan kohdasta 2.2: <strong>Organisaation yhteenveto</strong>.
-        </p>
+    <div class="org-detail-actions">
+      <a class="org-detail-action" href="{{ url_for('admin_org.organization_control') }}"><i class="fas fa-arrow-left" aria-hidden="true"></i>{{ _('Organisaatiot') }}</a>
+      <a class="org-detail-action" href="{{ url_for('org', org_id=organization._id) }}"><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i>{{ _('Julkinen sivu') }}</a>
+      {% if current_user.has_permission("EDIT_ORGANIZATION", organization._id) %}
+      <a class="org-detail-action primary" href="{{ url_for('admin_org.edit_organization', org_id=organization._id) }}"><i class="fas fa-pen" aria-hidden="true"></i>{{ _('Muokkaa') }}</a>
+      {% endif %}
     </div>
+  </header>
 
-    <div class="form-group">
-        <label>{{ _('Nimi') }}</label>
-        <p class="form-control">{{ organization.name }}</p>
-    </div>
+  <section class="org-detail-summary" aria-label="{{ _('Organisaation yhteenveto') }}">
+    <article class="org-detail-summary-card"><span class="org-detail-summary-icon"><i class="fas fa-user-group" aria-hidden="true"></i></span><div><span>{{ _('Jäseniä') }}</span><strong class="metric" id="member-count">{{ memberships|length }}</strong></div></article>
+    <article class="org-detail-summary-card"><span class="org-detail-summary-icon"><i class="fas fa-envelope-open-text" aria-hidden="true"></i></span><div><span>{{ _('Avoimia kutsuja') }}</span><strong class="metric" id="invite-count">{{ invited_users|length }}</strong></div></article>
+    <article class="org-detail-summary-card"><span class="org-detail-summary-icon"><i class="fas fa-circle-check" aria-hidden="true"></i></span><div><span>{{ _('Profiilin tila') }}</span><strong>{{ _('Vahvistettu') if organization.verified else _('Vahvistamaton') }}</strong></div></article>
+    <article class="org-detail-summary-card"><span class="org-detail-summary-icon"><i class="fas fa-globe" aria-hidden="true"></i></span><div><span>{{ _('Verkkosivu') }}</span><strong>{{ _('Lisätty') if organization.website else _('Puuttuu') }}</strong></div></article>
+  </section>
 
-    <div class="form-group">
-        <label>{{ _('Kuvaus') }}</label>
-        <p class="form-control">{{ organization.description }}</p>
-    </div>
-
-    <div class="form-group">
-        <label>{{ _('Sähköpostiosoite') }}</label>
-        <p class="form-control">{{ organization.email }}</p>
-    </div>
-
-    <div class="form-group">
-        <label>{{ _('Verkkosivu') }}</label>
-        <p class="form-control">{{ organization.website }}</p>
-    </div>
-
-    {% if organization %}
-    <div class="form-group">
-        <label>{{ _('Onko organisaatio vahvistettu?') }}</label>
-        <p class="form-control">{% if organization.verified %} <i class="fa fa-check"></i> {{ _('Kyllä') }} {% else %}
-            <i class="fa fa-ban"></i> {{ _('Ei') }}{% endif %}
-        </p>
-    </div>
-    {% endif %}
-
-    <div class="form-group">
-        <label>{{ _('Sosiaalinen media') }}</label>
-
-        <div id="social-media-list">
-            {% for platform, url in organization.social_media_links.items() %}
-            <div class="social-media-container">
-                <div class="custom-dropdown">
-                    <div class="dropdown-selected"><i class="fab fa-{{ platform }}"></i> {{ platform.capitalize() }}:
-                    </div>
-                </div>
-                <p class="form-control">{{ url }}</p>
-            </div>
-            {% endfor %}
+  <div class="org-detail-grid">
+    <div class="org-detail-stack">
+      <section class="org-detail-card">
+        <div class="org-detail-card-header">
+          <div class="org-detail-card-title"><i class="fas fa-users" aria-hidden="true"></i><h2>{{ _('Jäsenet') }}</h2><span class="org-detail-card-count" id="member-card-count">{{ memberships|length }}</span></div>
+          <button class="org-button primary invite" type="button" data-bs-toggle="modal" data-bs-target="#inviteModal"><i class="fas fa-user-plus" aria-hidden="true"></i>{{ _('Kutsu käyttäjä') }}</button>
         </div>
-    </div>
-
-    <div class="form-group">
-        <label>{{ _('Käyttäjät') }}</label>
-        <table class="table">
-            {% if organization.members %}
-            <thead>
-                <tr>
-                    <th>{{ _('Nimi') }}</th>
-                    <th>{{ _('Sähköpostiosoite') }}</th>
-                    <th>{{ _('Pääsytaso') }}</th>
-                    <th>{{ _('Toiminnot') }}</th>
-                </tr>
-            </thead>
-            {% endif %}
-            <tbody>
-                {% for user in memberships %}
-                <tr>
-                    <td>{{ user.displayname or user.username }}</td>
-                    <td>{{ user.email }}</td>
-                    <td>
-                        <select class="form-control role-select">
-                            <option value="owner" {% if user.role=='owner' %}selected{% endif %}>{{ _('Omistaja') }}
-                            </option>
-                            <option value="admin" {% if user.role=='admin' %}selected{% endif %}>{{ _('Admin') }}
-                            </option>
-                            <option value="member" {% if user.role=='member' %}selected{% endif %}>{{ _('Jäsen') }}
-                            </option>
-                        </select>
-                    </td>
-                    <td>
-                        <button class="btn-primary save-role-btn" data-user-id="{{ user._id }}"
-                            data-org-id="{{ organization._id }}">
-                            {{ _('Tallenna') }}
-                        </button>
-                        <button data-ship-id="{{ user._ship_id }}" class="button delete-role-btn">{{ _('Poista')
-                            }}</button>
-                    </td>
-                </tr>
-                {% else %}
-                <div class="no-users">
-                    <p>{{ _('Ei käyttäjiä') }}</p>
-                </div>
-                {% endfor %}
+        {% if memberships %}
+        <div class="org-table-scroll">
+          <table class="org-detail-table">
+            <thead><tr><th>{{ _('Käyttäjä') }}</th><th>{{ _('Sähköpostiosoite') }}</th><th>{{ _('Pääsytaso') }}</th><th>{{ _('Toiminnot') }}</th></tr></thead>
+            <tbody id="member-table-body">
+              {% for user in memberships %}
+              <tr>
+                <td><div class="org-member"><span class="org-member-avatar">{{ (user.displayname or user.username or '?')[:1] }}</span><div><strong>{{ user.displayname or user.username }}</strong><span>@{{ user.username }}</span></div></div></td>
+                <td>{{ user.email }}</td>
+                <td>
+                  <select class="org-role-select role-select" aria-label="{{ _('Pääsytaso') }}">
+                    <option value="owner" {% if user.role == 'owner' %}selected{% endif %}>{{ _('Omistaja') }}</option>
+                    <option value="admin" {% if user.role == 'admin' %}selected{% endif %}>{{ _('Admin') }}</option>
+                    <option value="member" {% if user.role == 'member' %}selected{% endif %}>{{ _('Jäsen') }}</option>
+                  </select>
+                </td>
+                <td><div class="org-row-actions">
+                  <button class="org-button save-role-btn" type="button" data-user-id="{{ user._id }}" data-org-id="{{ organization._id }}"><i class="fas fa-check" aria-hidden="true"></i>{{ _('Tallenna') }}</button>
+                  <button class="org-button danger confirm-action-btn" type="button" data-action="delete-member" data-ship-id="{{ user._ship_id }}" data-label="{{ user.displayname or user.username }}"><i class="fas fa-user-minus" aria-hidden="true"></i>{{ _('Poista') }}</button>
+                </div></td>
+              </tr>
+              {% endfor %}
             </tbody>
-        </table>
-
-        <div class="form-group">
-            <label>{{ _('Kutsutut käyttäjät') }}</label>
-            <table class="table">
-                {% if invited_users and invited_users|length > 0 %}
-                <thead>
-                    <tr>
-                        <th>{{ _('Sähköpostiosoite') }}</th>
-                        <th>{{ _('Kutsun tila') }}</th>
-                        <th>{{ _('Rooli') }}</th>
-                        <th>{{ _('Toiminnot') }}</th>
-                    </tr>
-                </thead>
-                {% endif %}
-                <tbody>
-                    {% for invite in invited_users %}
-                    <tr>
-                        <td>{{ invite.email }}</td>
-                        <td>{{ _('Odottaa hyväksyntää') }}</td>
-                        <td>
-                            <select class="form-control invited-role-select" data-invite-email="{{ invite.email }}">
-                                <option value="owner" {% if invite.role=='owner' %}selected{% endif %}>{{ _('Omistaja') }}</option>
-                                <option value="admin" {% if invite.role=='admin' %}selected{% endif %}>{{ _('Admin') }}</option>
-                                <option value="member" {% if invite.role=='member' or not invite.role %}selected{% endif %}>{{ _('Jäsen') }}</option>
-                            </select>
-                        </td>
-                        <td>
-                            <button class="button cancel-invite-btn" data-invite-email="{{ invite.email }}">{{ _('Peruuta kutsu') }}</button>
-                            {% if current_user.global_admin %}
-                            <button class="button force-accept-invite-btn" data-invite-email="{{ invite.email }}">{{ _('Hyväksy puolesta') }}</button>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% else %}
-                    <div class="no-users">
-                        <p>{{ _('Ei kutsuttuja käyttäjiä') }}</p>
-                    </div>
-                    {% endfor %}
-                </tbody>
-            </table>
+          </table>
         </div>
-        <script>
-        document.addEventListener("DOMContentLoaded", function() {
-            document.querySelectorAll('.invited-role-select').forEach(function(select) {
-                select.addEventListener('change', function() {
-                    const email = this.getAttribute('data-invite-email');
-                    const role = this.value;
-                    const orgId = '{{ organization._id }}';
-                    fetch('/admin/organization/api/set_invite_role/', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ email: email, organization_id: orgId, role: role })
-                    })
-                    .then(res => res.json())
-                    .then(data => {
-                        if (data.status !== 'OK') {
-                            alert(data.error || 'Roolin tallennus epäonnistui.');
-                        }
-                    })
-                    .catch(() => alert('Virhe palvelinyhteydessä.'));
-                });
-            });
+        {% else %}
+        <div class="org-empty" id="members-empty"><i class="fas fa-user-group" aria-hidden="true"></i><strong>{{ _('Ei vielä jäseniä') }}</strong><span>{{ _('Kutsu ensimmäinen käyttäjä mukaan organisaatioon.') }}</span></div>
+        {% endif %}
+      </section>
 
-            document.querySelectorAll('.cancel-invite-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    if (!confirm('Haluatko varmasti peruuttaa kutsun?')) return;
-                    const email = this.getAttribute('data-invite-email');
-                    const orgId = '{{ organization._id }}';
-                    fetch('/admin/organization/api/cancel_invite/', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ email: email, organization_id: orgId })
-                    })
-                    .then(res => res.json())
-                    .then(data => {
-                        if (data.status === 'OK') {
-                            // Remove the row from the table
-                            this.closest('tr').remove();
-                        } else {
-                            alert(data.error || 'Kutsun peruutus epäonnistui.');
-                        }
-                    })
-                    .catch(() => alert('Virhe palvelinyhteydessä.'));
-                });
-            });
-            document.querySelectorAll('.force-accept-invite-btn').forEach(function(btn) {
-                btn.addEventListener('click', function() {
-                    if (!confirm('Hyväksytäänkö kutsu tämän käyttäjän puolesta?')) return;
-                    const email = this.getAttribute('data-invite-email');
-                    const orgId = '{{ organization._id }}';
-                    fetch('/admin/organization/api/force_accept_invite/', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ email: email, organization_id: orgId })
-                    })
-                    .then(res => res.json())
-                    .then(data => {
-                        if (data.status === 'OK') {
-                            // Remove the row from the table
-                            this.closest('tr').remove();
-                        } else {
-                            alert(data.error || 'Kutsun hyväksyntä epäonnistui.');
-                        }
-                    })
-                    .catch(() => alert('Virhe palvelinyhteydessä.'));
-                });
-            });
-        });
-        </script>
-        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#inviteModal">
-            {{ _('Kutsu käyttäjiä') }}
-        </button>
-    </div>
-    <div class="modal fade" id="inviteModal" tabindex="-1" aria-labelledby="inviteModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-sm"> {# You can use modal-md or modal-lg if needed #}
-            <div class="modal-content shadow rounded-4 border-0"
-                style="background-color: var(--container-bg); color: var(--text);">
-
-                <form method="POST"
-                    action="{{ url_for('admin_org.invite', org_id=organization._id if organization else None) }}">
-                    <div class="modal-header border-0 pb-0">
-                        <h5 class="modal-title" id="inviteModalLabel">{{ _('Kutsu käyttäjiä') }}</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal"
-                            aria-label="{{ _('Sulje') }}"></button>
-                    </div>
-
-                    <div class="modal-body">
-                        <div class="form-group mb-3">
-                            <label for="invitee_email" class="form-label">
-                                {{ _('Kutsuttavan sähköpostiosoite') }} <span class="required">*</span>
-                            </label>
-                            <input type="email" id="invitee_email" name="invitee_email" class="form-control" required
-                                placeholder="sähköposti@domain.fi">
-                        </div>
-                        <input type="hidden" id="organization_id" name="organization_id" value="{{ organization._id }}">
-                    </div>
-
-                    <div class="modal-footer border-0 pt-0">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Peruuta')
-                            }}</button>
-                        <button type="submit" class="btn btn-primary">{{ _('Lähetä kutsu') }}</button>
-                    </div>
-                </form>
-
-            </div>
+      <section class="org-detail-card">
+        <div class="org-detail-card-header">
+          <div class="org-detail-card-title"><i class="fas fa-paper-plane" aria-hidden="true"></i><h2>{{ _('Avoimet kutsut') }}</h2><span class="org-detail-card-count" id="invite-card-count">{{ invited_users|length }}</span></div>
         </div>
+        {% if invited_users %}
+        <div class="org-table-scroll" id="invites-table-wrap">
+          <table class="org-detail-table">
+            <thead><tr><th>{{ _('Sähköpostiosoite') }}</th><th>{{ _('Tila') }}</th><th>{{ _('Rooli') }}</th><th>{{ _('Toiminnot') }}</th></tr></thead>
+            <tbody id="invite-table-body">
+              {% for invite in invited_users %}
+              <tr>
+                <td><div class="org-member"><span class="org-member-avatar"><i class="fas fa-envelope" aria-hidden="true"></i></span><div><strong>{{ invite.email }}</strong><span>{{ _('Kutsu lähetetty') }}</span></div></div></td>
+                <td><span class="org-status pending"><i class="fas fa-clock" aria-hidden="true"></i>{{ _('Odottaa hyväksyntää') }}</span></td>
+                <td>
+                  <select class="org-role-select invited-role-select" data-invite-email="{{ invite.email }}" aria-label="{{ _('Kutsutun rooli') }}">
+                    <option value="owner" {% if invite.role == 'owner' %}selected{% endif %}>{{ _('Omistaja') }}</option>
+                    <option value="admin" {% if invite.role == 'admin' %}selected{% endif %}>{{ _('Admin') }}</option>
+                    <option value="member" {% if invite.role == 'member' or not invite.role %}selected{% endif %}>{{ _('Jäsen') }}</option>
+                  </select>
+                </td>
+                <td><div class="org-row-actions">
+                  {% if current_user.global_admin %}<button class="org-button orange confirm-action-btn" type="button" data-action="accept-invite" data-invite-email="{{ invite.email }}" data-label="{{ invite.email }}"><i class="fas fa-user-check" aria-hidden="true"></i>{{ _('Hyväksy puolesta') }}</button>{% endif %}
+                  <button class="org-button danger confirm-action-btn" type="button" data-action="cancel-invite" data-invite-email="{{ invite.email }}" data-label="{{ invite.email }}"><i class="fas fa-xmark" aria-hidden="true"></i>{{ _('Peruuta') }}</button>
+                </div></td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <div class="org-empty" id="invites-empty"><i class="fas fa-inbox" aria-hidden="true"></i><strong>{{ _('Ei avoimia kutsuja') }}</strong><span>{{ _('Kaikki lähetetyt kutsut on käsitelty.') }}</span></div>
+        {% endif %}
+      </section>
     </div>
+
+    <aside class="org-detail-stack">
+      <section class="org-detail-card">
+        <div class="org-detail-card-header"><div class="org-detail-card-title"><i class="fas fa-address-card" aria-hidden="true"></i><h2>{{ _('Profiilin tiedot') }}</h2></div></div>
+        <div class="org-detail-card-body org-profile">
+          <p class="org-profile-description {% if not organization.description %}muted{% endif %}">{{ organization.description or _('Organisaatiolla ei ole vielä kuvausta.') }}</p>
+          <div class="org-facts">
+            <div class="org-fact"><span class="org-fact-icon"><i class="fas fa-circle-check" aria-hidden="true"></i></span><div><span>{{ _('Tila') }}</span>{% if organization.verified %}<strong class="org-status verified"><i class="fas fa-check" aria-hidden="true"></i>{{ _('Vahvistettu') }}</strong>{% else %}<strong class="org-status"><i class="fas fa-clock" aria-hidden="true"></i>{{ _('Vahvistamaton') }}</strong>{% endif %}</div></div>
+            <div class="org-fact"><span class="org-fact-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span><div><span>{{ _('Sähköposti') }}</span>{% if organization.email %}<a href="mailto:{{ organization.email }}">{{ organization.email }}</a>{% else %}<strong>{{ _('Ei sähköpostia') }}</strong>{% endif %}</div></div>
+            <div class="org-fact"><span class="org-fact-icon"><i class="fas fa-globe" aria-hidden="true"></i></span><div><span>{{ _('Verkkosivu') }}</span>{% if organization.website %}<a href="{{ organization.website }}" target="_blank" rel="noopener noreferrer">{{ organization.website }}</a>{% else %}<strong>{{ _('Ei verkkosivua') }}</strong>{% endif %}</div></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="org-detail-card">
+        <div class="org-detail-card-header"><div class="org-detail-card-title"><i class="fas fa-hashtag" aria-hidden="true"></i><h2>{{ _('Sosiaalinen media') }}</h2></div></div>
+        <div class="org-detail-card-body">
+          {% if organization.social_media_links %}
+          <div class="org-social-list">
+            {% for platform, url in organization.social_media_links.items() %}
+            <a class="org-social-link" href="{{ url }}" target="_blank" rel="noopener noreferrer"><i class="fab fa-{{ platform }}" aria-hidden="true"></i><span>{{ platform|capitalize }}</span><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i></a>
+            {% endfor %}
+          </div>
+          {% else %}
+          <div class="org-empty"><i class="fas fa-link-slash" aria-hidden="true"></i><strong>{{ _('Ei some-linkkejä') }}</strong><span>{{ _('Linkkejä voi lisätä muokkausnäkymässä.') }}</span></div>
+          {% endif %}
+        </div>
+      </section>
+    </aside>
+  </div>
+
+  <div class="modal fade" id="inviteModal" tabindex="-1" aria-labelledby="inviteModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <form method="POST" action="{{ url_for('admin_org.invite') }}">
+          <div class="modal-header"><div><p class="org-detail-kicker mb-1">{{ _('Uusi jäsen') }}</p><h2 class="modal-title" id="inviteModalLabel">{{ _('Kutsu käyttäjä') }}</h2></div><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button></div>
+          <div class="modal-body">
+            <p class="org-confirm-copy mb-3">{{ _('Lähetämme käyttäjälle sähköpostitse linkin, jolla hän voi liittyä organisaatioon.') }}</p>
+            <label for="invitee_email" class="form-label">{{ _('Kutsuttavan sähköpostiosoite') }}</label>
+            <input type="email" id="invitee_email" name="invitee_email" class="form-control" required autocomplete="email" placeholder="nimi@example.fi">
+            <input type="hidden" name="organization_id" value="{{ organization._id }}">
+          </div>
+          <div class="modal-footer"><button type="button" class="org-button" data-bs-dismiss="modal">{{ _('Peruuta') }}</button><button type="submit" class="org-button primary"><i class="fas fa-paper-plane" aria-hidden="true"></i>{{ _('Lähetä kutsu') }}</button></div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="confirmActionModal" tabindex="-1" aria-labelledby="confirmActionTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+      <div class="modal-content">
+        <div class="modal-header"><h2 class="modal-title" id="confirmActionTitle">{{ _('Vahvista toiminto') }}</h2><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button></div>
+        <div class="modal-body"><p class="org-confirm-copy" id="confirmActionCopy"></p></div>
+        <div class="modal-footer"><button type="button" class="org-button" data-bs-dismiss="modal">{{ _('Peruuta') }}</button><button type="button" class="org-button danger" id="confirmActionButton">{{ _('Vahvista') }}</button></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="org-toast" id="orgToast" role="status" aria-live="polite"><span class="org-toast-icon"><i class="fas fa-check" aria-hidden="true"></i></span><span class="org-toast-message"></span><button class="org-toast-close" type="button" aria-label="{{ _('Sulje') }}"><i class="fas fa-xmark" aria-hidden="true"></i></button></div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const orgId = '{{ organization._id }}';
+    const toast = document.getElementById('orgToast');
+    const toastMessage = toast.querySelector('.org-toast-message');
+    const toastIcon = toast.querySelector('.org-toast-icon i');
+    let toastTimer;
+    let pendingAction = null;
+    const confirmModal = new bootstrap.Modal(document.getElementById('confirmActionModal'));
+    const confirmCopy = document.getElementById('confirmActionCopy');
+    const confirmButton = document.getElementById('confirmActionButton');
+
+    function showNotice(message, isError = false) {
+      clearTimeout(toastTimer);
+      toast.classList.toggle('error', isError);
+      toastIcon.className = isError ? 'fas fa-triangle-exclamation' : 'fas fa-check';
+      toastMessage.textContent = message;
+      toast.classList.add('show');
+      toastTimer = setTimeout(() => toast.classList.remove('show'), 4200);
+    }
+
+    async function postJson(url, payload) {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json();
+      if (!response.ok || data.status && data.status !== 'OK') throw new Error(data.error || data.message || '{{ _("Toiminto epäonnistui.") }}');
+      return data;
+    }
+
+    function reduceCount(id) {
+      const element = document.getElementById(id);
+      if (element) element.textContent = Math.max(0, Number(element.textContent) - 1);
+    }
+
+    document.querySelector('.org-toast-close').addEventListener('click', () => toast.classList.remove('show'));
+
+    document.querySelectorAll('.save-role-btn').forEach((button) => {
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        try {
+          const role = button.closest('tr').querySelector('.role-select').value;
+          await postJson('/admin/organization/api/change_access_level/', { user_id: button.dataset.userId, organization_id: orgId, role });
+          showNotice('{{ _("Käyttäjän rooli päivitettiin.") }}');
+        } catch (error) {
+          showNotice(error.message, true);
+        } finally {
+          button.disabled = false;
+        }
+      });
+    });
+
+    document.querySelectorAll('.invited-role-select').forEach((select) => {
+      select.addEventListener('change', async () => {
+        select.disabled = true;
+        try {
+          await postJson('/admin/organization/api/set_invite_role/', { email: select.dataset.inviteEmail, organization_id: orgId, role: select.value });
+          showNotice('{{ _("Kutsun rooli päivitettiin.") }}');
+        } catch (error) {
+          showNotice(error.message, true);
+        } finally {
+          select.disabled = false;
+        }
+      });
+    });
+
+    document.querySelectorAll('.confirm-action-btn').forEach((button) => {
+      button.addEventListener('click', () => {
+        pendingAction = button;
+        const label = button.dataset.label;
+        const messages = {
+          'delete-member': `{{ _("Poistetaanko käyttäjä organisaatiosta?") }} ${label}`,
+          'cancel-invite': `{{ _("Peruutetaanko käyttäjälle lähetetty kutsu?") }} ${label}`,
+          'accept-invite': `{{ _("Hyväksytäänkö kutsu käyttäjän puolesta?") }} ${label}`
+        };
+        confirmCopy.textContent = messages[button.dataset.action];
+        confirmButton.classList.toggle('danger', button.dataset.action !== 'accept-invite');
+        confirmButton.classList.toggle('orange', button.dataset.action === 'accept-invite');
+        confirmModal.show();
+      });
+    });
+
+    confirmButton.addEventListener('click', async () => {
+      if (!pendingAction) return;
+      confirmButton.disabled = true;
+      try {
+        const action = pendingAction.dataset.action;
+        if (action === 'delete-member') {
+          await postJson('/admin/organization/api/delete_membership/', { membership_id: pendingAction.dataset.shipId });
+          reduceCount('member-count');
+          reduceCount('member-card-count');
+          showNotice('{{ _("Käyttäjä poistettiin organisaatiosta.") }}');
+        } else if (action === 'cancel-invite') {
+          await postJson('/admin/organization/api/cancel_invite/', { email: pendingAction.dataset.inviteEmail, organization_id: orgId });
+          reduceCount('invite-count');
+          reduceCount('invite-card-count');
+          showNotice('{{ _("Kutsu peruutettiin.") }}');
+        } else {
+          await postJson('/admin/organization/api/force_accept_invite/', { email: pendingAction.dataset.inviteEmail, organization_id: orgId });
+          reduceCount('invite-count');
+          reduceCount('invite-card-count');
+          showNotice('{{ _("Kutsu hyväksyttiin käyttäjän puolesta.") }}');
+        }
+        pendingAction.closest('tr').remove();
+        confirmModal.hide();
+      } catch (error) {
+        showNotice(error.message, true);
+      } finally {
+        confirmButton.disabled = false;
+        pendingAction = null;
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/admin_V2/stats.html
+++ b/mielenosoitukset_fi/templates/admin_V2/stats.html
@@ -10,89 +10,72 @@
     position: relative;
   }
   th.sortable::after {
-    content: "⬍";
-    font-size: 0.75em;
-    color: var(--text_muted, #888);
+    content: "\f0dc";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 0.7em;
+    color: var(--stats-muted);
     position: absolute;
     right: 0.75rem;
   }
-  th.sortable.asc::after { content: "⬆"; }
-  th.sortable.desc::after { content: "⬇"; }
+  th.sortable.asc::after { content: "\f0de"; }
+  th.sortable.desc::after { content: "\f0dd"; }
 </style>
 {% endblock %}
 
 {% block main_content %}
 <div class="stats-shell">
-  <section class="holo-hero">
-    <div class="holo-grid">
-      <div class="beam"></div><div class="beam"></div><div class="beam"></div>
-    </div>
-    <div class="hero-copy">
-      <p class="eyebrow">{{ _('Reaaliaikainen tilannekuva') }}</p>
-      <h1>{{ _('Tilastot & telemetria') }}</h1>
-      <p class="lede">
-        {{ _('Näe, miten yhteisö sykkii juuri nyt. Kaikki luvut päivittyvät live-datasta, Matomo-telemetriasta ja taustajobeista.') }}
+  <section class="stats-hero">
+    <div class="stats-hero-copy">
+      <p class="stats-kicker">{{ _('Tilastot') }}</p>
+      <h1>{{ _('Miten palvelulla menee?') }}</h1>
+      <p class="stats-lede">
+        {{ _('Täältä näet palvelun tärkeimmät luvut ja mielenosoitusten katselukerrat yhdessä paikassa.') }}
       </p>
-      <div class="hero-badges">
-        <span class="badge badge-pill badge-signal"><i class="fas fa-wave-square"></i> {{ _('Matomo live') }}</span>
-        <span class="badge badge-pill badge-fresh" id="last-updated">{{ _('Päivitetään...') }}</span>
-      </div>
     </div>
-    <div class="hero-panels">
-      <div class="pulse-card">
-        <span class="label">{{ _('Katselut / demo (ka.)') }}</span>
-        <span class="value" id="avg-views">–</span>
-        <div class="pulse-bar"><span style="width: 64%"></span></div>
-      </div>
-      <div class="pulse-card">
-        <span class="label">{{ _('Vahvistetut käyttäjät') }}</span>
-        <span class="value" id="active-users">–</span>
-        <div class="pulse-bar alt"><span style="width: 78%"></span></div>
-      </div>
+    <div class="stats-hero-note">
+      <span>{{ _('Viimeisin päivitys') }}</span>
+      <strong id="last-updated">{{ _('Päivitetään...') }}</strong>
     </div>
   </section>
 
   <section class="stat-grid">
     <div class="stat-card">
-      <p class="stat-label">{{ _('Käyttäjiä') }}</p>
-      <p class="stat-value" id="total-users">–</p>
-      <p class="stat-sub">{{ _('Kaikki tilit') }}</p>
+      <span class="stat-icon"><i class="fas fa-user-group" aria-hidden="true"></i></span>
+      <div><p class="stat-label">{{ _('Käyttäjiä') }}</p><p class="stat-value" id="total-users">–</p><p class="stat-sub">{{ _('Kaikki tilit') }}</p></div>
     </div>
     <div class="stat-card">
-      <p class="stat-label">{{ _('Organisaatioita') }}</p>
-      <p class="stat-value" id="total-orgs">–</p>
-      <p class="stat-sub">{{ _('Yhteisöä ja ryhmää') }}</p>
+      <span class="stat-icon"><i class="fas fa-building" aria-hidden="true"></i></span>
+      <div><p class="stat-label">{{ _('Organisaatioita') }}</p><p class="stat-value" id="total-orgs">–</p><p class="stat-sub">{{ _('Yhteisöä ja ryhmää') }}</p></div>
     </div>
     <div class="stat-card">
-      <p class="stat-label">{{ _('Mielenosoituksia') }}</p>
-      <p class="stat-value" id="total-demos">–</p>
-      <p class="stat-sub">{{ _('Julkaistut tapahtumat') }}</p>
+      <span class="stat-icon"><i class="fas fa-bullhorn" aria-hidden="true"></i></span>
+      <div><p class="stat-label">{{ _('Mielenosoituksia') }}</p><p class="stat-value" id="total-demos">–</p><p class="stat-sub">{{ _('Julkaistut tapahtumat') }}</p></div>
     </div>
     <div class="stat-card highlight">
-      <p class="stat-label">{{ _('Katselukerrat') }}</p>
-      <p class="stat-value" id="total-views">–</p>
-      <p class="stat-sub">{{ _('Kaikki demot yhteensä') }}</p>
+      <span class="stat-icon"><i class="fas fa-eye" aria-hidden="true"></i></span>
+      <div><p class="stat-label">{{ _('Katselukerrat') }}</p><p class="stat-value" id="total-views">–</p><p class="stat-sub">{{ _('Keskimäärin') }} <span id="avg-views">–</span> / {{ _('mielenosoitus') }}</p></div>
     </div>
   </section>
 
   <section class="analytics-panel">
     <header class="panel-header">
       <div>
-        <p class="eyebrow">{{ _('Analytiikka') }}</p>
+        <p class="stats-kicker">{{ _('Analytiikka') }}</p>
         <h2>{{ _('Mielenosoitusnäkymät') }}</h2>
-        <p class="lede small">
-          {{ _('Järjestä ja poraa alas – sorttaus on client-pohjaista, tarkemmat luvut aukeavat demo-analytics-sivulle.') }}
+        <p class="stats-description">
+          {{ _('Järjestä lista otsikoista ja avaa mielenosoitus nähdäksesi tarkemmat luvut.') }}
         </p>
       </div>
       <div class="cta-group">
-        <label class="ghost-link" style="gap:0.5rem; cursor:pointer;">
-          <input type="checkbox" id="toggle-past" style="accent-color: var(--holo-highlight);"> {{ _('Näytä menneet') }}
+        <label class="stats-control">
+          <input type="checkbox" id="toggle-past"> {{ _('Näytä menneet') }}
         </label>
-        <a href="{{ url_for('admin.analytics_overall_24h') }}" class="btn btn-light futuristic">
+        <a href="{{ url_for('admin.analytics_overall_24h') }}" class="stats-action stats-action-primary">
           <i class="fas fa-clock"></i> {{ _('Viimeiset 24 h') }}
         </a>
-        <a href="{{ url_for('admin.analytics_overall_24h') }}" class="ghost-link" id="matomo-link">
-          <i class="fas fa-bolt"></i> {{ _('Matomo live pulse') }}
+        <a href="{{ url_for('admin.analytics_overall_24h') }}" class="stats-action" id="matomo-link">
+          <i class="fas fa-chart-line"></i> {{ _('Matomo') }}
         </a>
       </div>
     </header>
@@ -209,7 +192,7 @@
       return `
         <tr>
           <td><a class="demo-link" href="${href}">${row.title || row.id}</a></td>
-          <td class="views-cell"><span class="chip neon">${row.views}</span></td>
+          <td class="views-cell"><span class="view-count">${row.views}</span></td>
         </tr>
       `;
     }).join("");
@@ -230,7 +213,7 @@
       setText("total-demos", includePast ? summary.total_demos : summary.total_demos_future);
       setText("total-views", summary.total_views);
       setText("avg-views", summary.avg_views);
-      setText("last-updated", `${"{{ _('Päivitetty') }}"}: ${summary.last_updated}`);
+      setText("last-updated", summary.last_updated);
 
       renderRows(analytics.rows);
       buildPagination(analytics);
@@ -249,7 +232,7 @@
         link.innerHTML = `<i class="fas fa-bolt-slash"></i> {{ _('Matomo ei saatavilla') }}`;
         return;
       }
-      link.innerHTML = `<i class="fas fa-bolt"></i> {{ _('Matomo live') }} · ${payload.visits.length} {{ _('kävijää') }}`;
+      link.innerHTML = `<i class="fas fa-chart-line"></i> {{ _('Matomo') }} · ${payload.visits.length} {{ _('kävijää') }}`;
     } catch (e) {
       link.innerHTML = `<i class="fas fa-bolt-slash"></i> {{ _('Matomo ei saatavilla') }}`;
     }

--- a/mielenosoitukset_fi/templates/admin_V2/user/list.html
+++ b/mielenosoitukset_fi/templates/admin_V2/user/list.html
@@ -1,9 +1,219 @@
 {% extends 'admin_base.html' %}
 
 {% block styles %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/admin/users.css') }}">
 <style>
-  /* Toasts */
+  .users-page {
+    --users-blue: light-dark(#0033a0, #8bb1ff);
+    --users-blue-dark: light-dark(#00267a, #b9ceff);
+    --users-blue-soft: light-dark(#edf4ff, #17233b);
+    --users-orange: #ff6600;
+    --users-orange-soft: light-dark(#fff2e8, #3a2418);
+    --users-surface: light-dark(#ffffff, #20252d);
+    --users-surface-muted: light-dark(#f6f8fb, #292f39);
+    --users-border: light-dark(#dce3ec, #424b59);
+    --users-text: light-dark(#172033, #f2f5fa);
+    --users-muted: light-dark(#647083, #b7c0ce);
+    --users-shadow: 0 14px 38px light-dark(rgba(28, 48, 82, .08), rgba(0, 0, 0, .18));
+    display: grid;
+    gap: 1rem;
+    max-width: 1450px;
+    margin: 0 auto;
+    color: var(--users-text);
+  }
+
+  .users-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.75rem, 4vw, 3rem);
+    border-radius: 1.5rem;
+    color: #fff;
+    background:
+      radial-gradient(circle at 94% 8%, rgba(255, 102, 0, .42), transparent 18rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
+    box-shadow: 0 20px 50px rgba(0, 43, 137, .18);
+  }
+
+  .users-kicker {
+    margin: 0;
+    color: #ffd6bc;
+    font-size: .76rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+
+  .users-hero h1 {
+    margin: .25rem 0 .5rem;
+    color: #fff;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    letter-spacing: -.035em;
+  }
+
+  .users-hero p:last-child {
+    max-width: 680px;
+    margin: 0;
+    color: rgba(255,255,255,.8);
+    line-height: 1.65;
+  }
+
+  .users-hero-actions {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: .6rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .users-hero-action {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    min-height: 2.65rem;
+    padding: .62rem .85rem;
+    border: 1px solid rgba(255,255,255,.22);
+    border-radius: .75rem;
+    color: #fff;
+    background: rgba(255,255,255,.1);
+    font-size: .84rem;
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .users-hero-action:hover {
+    color: #fff;
+    background: rgba(255,255,255,.18);
+  }
+
+  .users-request-count {
+    display: inline-grid;
+    min-width: 1.45rem;
+    height: 1.45rem;
+    place-items: center;
+    border-radius: 999px;
+    color: #9a3412;
+    background: #ffdbc2;
+    font-size: .72rem;
+  }
+
+  .users-summary {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: .8rem;
+  }
+
+  .users-summary-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: .8rem;
+    align-items: center;
+    min-width: 0;
+    padding: 1rem;
+    border: 1px solid var(--users-border);
+    border-radius: 1rem;
+    background: var(--users-surface);
+    box-shadow: var(--users-shadow);
+  }
+
+  .users-summary-icon {
+    display: inline-grid;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--users-blue);
+    background: var(--users-blue-soft);
+  }
+
+  .users-summary-card:last-child .users-summary-icon {
+    color: var(--users-orange);
+    background: var(--users-orange-soft);
+  }
+
+  .users-summary-card div span,
+  .users-summary-card strong {
+    display: block;
+  }
+
+  .users-summary-card div span {
+    color: var(--users-muted);
+    font-size: .72rem;
+    font-weight: 800;
+  }
+
+  .users-summary-card strong {
+    color: var(--users-text);
+    font-size: 1.55rem;
+    line-height: 1.1;
+  }
+
+  .users-toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    padding: .9rem;
+    border: 1px solid var(--users-border);
+    border-radius: 1rem;
+    background: var(--users-surface);
+  }
+
+  .users-search {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .65rem;
+    align-items: center;
+    flex: 1;
+    max-width: 680px;
+  }
+
+  .users-search-icon {
+    color: var(--users-blue);
+  }
+
+  .users-search input {
+    width: 100%;
+    min-width: 0;
+    padding: .7rem .8rem;
+    border: 1px solid var(--users-border);
+    border-radius: .7rem;
+    color: var(--users-text);
+    background: var(--users-surface-muted);
+    outline: none;
+  }
+
+  .users-search input:focus {
+    border-color: var(--users-blue);
+    box-shadow: 0 0 0 3px light-dark(rgba(0,51,160,.1), rgba(139,177,255,.12));
+  }
+
+  .users-create {
+    display: inline-flex;
+    gap: .5rem;
+    align-items: center;
+    min-height: 2.65rem;
+    padding: .62rem .9rem;
+    border: 1px solid var(--users-blue);
+    border-radius: .75rem;
+    color: #fff;
+    background: var(--users-blue);
+    font-size: .84rem;
+    font-weight: 800;
+  }
+
+  .users-table-shell {
+    overflow: visible;
+    border: 1px solid var(--users-border);
+    border-radius: 1.1rem;
+    background: var(--users-surface);
+    box-shadow: var(--users-shadow);
+  }
+
   #toast-container {
     position: fixed;
     top: 1rem;
@@ -11,107 +221,446 @@
     z-index: 1055;
   }
 
-  .toast {
-    min-width: 250px;
+  .toast { min-width: 250px; }
+
+  #createUserModal {
+    --create-surface: light-dark(#ffffff, #20252d);
+    --create-surface-muted: light-dark(#f6f8fb, #292f39);
+    --create-border: light-dark(#dce3ec, #424b59);
+    --create-text: light-dark(#172033, #f2f5fa);
+    --create-muted: light-dark(#647083, #b7c0ce);
   }
 
-  /* Table enhancements */
-  .table-hover tbody tr:hover {
-    background-color: #f1f3f5;
-    cursor: pointer;
+  #createUserModal .modal-content {
+    overflow: hidden;
+    border: 1px solid var(--create-border);
+    border-radius: 1.2rem;
+    color: var(--create-text);
+    background: var(--create-surface);
+    box-shadow: 0 24px 70px rgba(0, 0, 0, .28);
   }
 
-  .badge-role {
-    text-transform: capitalize;
+  #createUserModal .modal-header {
+    align-items: flex-start;
+    padding: 1.25rem 1.35rem;
+    border-bottom: 1px solid rgba(255,255,255,.14);
+    color: #fff;
+    background:
+      radial-gradient(circle at 92% 5%, rgba(255, 102, 0, .4), transparent 12rem),
+      linear-gradient(135deg, #00236e, #0033a0 72%, #164fc2);
   }
 
-  /* Sortable column indicators */
-  th.sortable {
-    cursor: pointer;
-    position: relative;
+  #createUserModal .modal-title { color: #fff; font-size: 1.35rem; }
+  #createUserModal .modal-header p { margin: .3rem 0 0; color: rgba(255,255,255,.76); font-size: .84rem; }
+  #createUserModal .btn-close { filter: invert(1) grayscale(1) brightness(2); }
+  #createUserModal .modal-body { padding: 1.25rem 1.35rem; color: var(--create-text); }
+
+  .create-user-note {
+    display: flex;
+    gap: .8rem;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+    padding: .9rem 1rem;
+    border: 1px solid light-dark(#f4d6bd, #68452e);
+    border-radius: .85rem;
+    color: var(--create-text);
+    background: var(--users-orange-soft);
+    font-size: .82rem;
+    line-height: 1.55;
   }
 
-  th.sortable::after {
-    content: '⬍';
-    font-size: 0.7em;
-    position: absolute;
-    right: 8px;
-    color: #888;
+  .create-user-note i { margin-top: .15rem; color: var(--users-orange); }
+  .create-user-note a { color: var(--users-blue-dark); font-weight: 800; }
+
+  .create-user-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: .9rem;
   }
 
-  th.sortable.asc::after {
-    content: '⬆';
+  .create-user-field { min-width: 0; }
+  .create-user-field-wide { grid-column: 1 / -1; }
+
+  .create-user-field label {
+    display: block;
+    margin-bottom: .35rem;
+    color: var(--create-text);
+    font-size: .78rem;
+    font-weight: 800;
   }
 
-  th.sortable.desc::after {
-    content: '⬇';
+  .create-user-field small {
+    display: block;
+    margin-top: .3rem;
+    color: var(--create-muted);
+    font-size: .72rem;
+  }
+
+  #createUserModal .form-control,
+  #createUserModal .form-select {
+    border-color: var(--create-border);
+    border-radius: .7rem;
+    color: var(--create-text);
+    background-color: var(--create-surface-muted);
+  }
+
+  #createUserModal .form-control:focus,
+  #createUserModal .form-select:focus {
+    border-color: var(--users-blue);
+    box-shadow: 0 0 0 3px light-dark(rgba(0,51,160,.1), rgba(139,177,255,.12));
+  }
+
+  #createUserModal .is-invalid {
+    border-color: light-dark(#c92a2a, #ff8787);
+  }
+
+  .create-user-status {
+    min-height: 1.25rem;
+    margin-top: .8rem;
+    color: var(--create-muted);
+    font-size: .78rem;
+  }
+
+  .create-user-status.error { color: light-dark(#c92a2a, #ff8787); }
+
+  #createUserModal .modal-footer {
+    gap: .6rem;
+    margin-top: 1rem;
+    padding: 1rem 0 0;
+    border-top: 1px solid var(--create-border);
+  }
+
+  .create-user-cancel,
+  .create-user-submit {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.6rem;
+    padding: .6rem .85rem;
+    border-radius: .7rem;
+    font-size: .82rem;
+    font-weight: 800;
+  }
+
+  .create-user-cancel {
+    border: 1px solid var(--create-border);
+    color: var(--create-text);
+    background: var(--create-surface-muted);
+  }
+
+  .create-user-submit {
+    border: 1px solid var(--users-blue);
+    color: #fff !important;
+    background: light-dark(#0033a0, #315ea8);
+  }
+
+  .create-user-submit:hover,
+  .create-user-submit:focus {
+    border-color: light-dark(#00267a, #8bb1ff);
+    color: #fff !important;
+    background: light-dark(#00267a, #416fbd);
+  }
+
+  .create-user-submit i { color: inherit; }
+  .create-user-submit:disabled { opacity: .65; cursor: wait; }
+
+  .user-workflow-modal {
+    --workflow-surface: light-dark(#ffffff, #20252d);
+    --workflow-surface-muted: light-dark(#f6f8fb, #292f39);
+    --workflow-border: light-dark(#dce3ec, #424b59);
+    --workflow-text: light-dark(#172033, #f2f5fa);
+    --workflow-muted: light-dark(#647083, #b7c0ce);
+    --workflow-danger: light-dark(#b42318, #ff9b93);
+    --workflow-danger-soft: light-dark(#fff1f0, #3c2022);
+    --workflow-warning: light-dark(#9a4d00, #ffd098);
+    --workflow-warning-soft: light-dark(#fff4e6, #3d2b1c);
+  }
+
+  .user-workflow-modal .modal-content {
+    overflow: hidden;
+    border: 1px solid var(--workflow-border);
+    border-radius: 1.15rem;
+    color: var(--workflow-text);
+    background: var(--workflow-surface);
+    box-shadow: 0 24px 70px rgba(0, 0, 0, .28);
+  }
+
+  .user-workflow-modal .modal-header,
+  .user-workflow-modal .modal-body,
+  .user-workflow-modal .modal-footer {
+    color: var(--workflow-text);
+    background: var(--workflow-surface);
+    border-color: var(--workflow-border);
+  }
+
+  .user-workflow-modal .modal-header {
+    align-items: flex-start;
+    padding: 1.15rem 1.25rem;
+  }
+
+  .workflow-heading {
+    display: flex;
+    gap: .75rem;
+    align-items: flex-start;
+  }
+
+  .workflow-heading-icon {
+    display: inline-grid;
+    flex: 0 0 auto;
+    width: 2.5rem;
+    height: 2.5rem;
+    place-items: center;
+    border-radius: .75rem;
+    color: var(--users-blue);
+    background: var(--users-blue-soft);
+  }
+
+  .workflow-heading-icon.warning {
+    color: var(--workflow-warning);
+    background: var(--workflow-warning-soft);
+  }
+
+  .workflow-heading-icon.danger {
+    color: var(--workflow-danger);
+    background: var(--workflow-danger-soft);
+  }
+
+  .workflow-heading h5 { margin: 0; color: var(--workflow-text); font-size: 1.08rem; }
+  .workflow-heading p { margin: .25rem 0 0; color: var(--workflow-muted); font-size: .78rem; line-height: 1.5; }
+  .user-workflow-modal .btn-close { filter: light-dark(none, invert(1) grayscale(1) brightness(2)); }
+  .user-workflow-modal .modal-body { padding: 1.2rem 1.25rem; }
+  .user-workflow-modal .modal-footer { gap: .55rem; padding: .9rem 1.25rem; }
+
+  .workflow-note {
+    padding: .85rem .95rem;
+    border: 1px solid var(--workflow-border);
+    border-radius: .8rem;
+    color: var(--workflow-text);
+    background: var(--workflow-surface-muted);
+    font-size: .84rem;
+    line-height: 1.6;
+  }
+
+  .workflow-note.warning {
+    border-color: light-dark(#f4d6bd, #68452e);
+    background: var(--workflow-warning-soft);
+  }
+
+  .workflow-confirm-label {
+    display: block;
+    margin: 1rem 0 .35rem;
+    color: var(--workflow-text);
+    font-size: .78rem;
+    font-weight: 800;
+  }
+
+  .user-workflow-modal .form-control {
+    border-color: var(--workflow-border);
+    border-radius: .7rem;
+    color: var(--workflow-text);
+    background: var(--workflow-surface-muted);
+  }
+
+  .user-workflow-modal .form-control:focus {
+    border-color: var(--users-blue);
+    box-shadow: 0 0 0 3px light-dark(rgba(0,51,160,.1), rgba(139,177,255,.12));
+  }
+
+  .workflow-status {
+    min-height: 1.25rem;
+    margin-top: .7rem;
+    color: var(--workflow-muted);
+    font-size: .78rem;
+  }
+
+  .workflow-status.warning { color: var(--workflow-warning); }
+  .workflow-status.danger { color: var(--workflow-danger); }
+
+  .workflow-button {
+    display: inline-flex;
+    gap: .45rem;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.5rem;
+    padding: .58rem .82rem;
+    border: 1px solid var(--workflow-border);
+    border-radius: .68rem;
+    color: var(--workflow-text);
+    background: var(--workflow-surface-muted);
+    font-size: .8rem;
+    font-weight: 800;
+  }
+
+  .workflow-button-primary {
+    border-color: var(--users-blue);
+    color: #fff !important;
+    background: light-dark(#0033a0, #315ea8);
+  }
+
+  .workflow-button-warning {
+    border-color: var(--workflow-warning);
+    color: light-dark(#fff, #201306);
+    background: light-dark(#b85c00, #ffd098);
+  }
+
+  .workflow-button-danger {
+    border-color: var(--workflow-danger);
+    color: #fff;
+    background: light-dark(#b42318, #9f342d);
+  }
+
+  .workflow-button:disabled { opacity: .55; cursor: not-allowed; }
+
+  .login-history-status {
+    padding: 2rem 1rem;
+    color: var(--workflow-muted);
+    text-align: center;
+  }
+
+  .login-history-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .login-history-table th,
+  .login-history-table td {
+    padding: .75rem;
+    border-bottom: 1px solid var(--workflow-border);
+    color: var(--workflow-text);
+    font-size: .8rem;
+    vertical-align: top;
+  }
+
+  .login-history-table th {
+    color: var(--workflow-muted);
+    background: var(--workflow-surface-muted);
+    font-size: .68rem;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
+
+  .login-history-result {
+    display: inline-flex;
+    gap: .35rem;
+    align-items: center;
+    padding: .22rem .48rem;
+    border-radius: 999px;
+    font-size: .68rem;
+    font-weight: 800;
+  }
+
+  .login-history-result.success {
+    color: light-dark(#087f5b, #65d6ac);
+    background: light-dark(#eaf8f2, #17382e);
+  }
+
+  .login-history-result.failed {
+    color: var(--workflow-danger);
+    background: var(--workflow-danger-soft);
+  }
+
+  .login-history-agent {
+    margin-top: .25rem;
+    color: var(--workflow-muted);
+    font-size: .68rem;
+  }
+
+  @media (max-width: 1050px) {
+    .users-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+
+  @media (max-width: 760px) {
+    .users-hero { grid-template-columns: 1fr; }
+    .users-hero-actions { justify-content: flex-start; }
+    .users-toolbar { align-items: stretch; flex-direction: column; }
+    .users-search { grid-template-columns: auto 1fr; }
+    .users-search { max-width: none; }
+    .users-create { justify-content: center; width: 100%; }
+  }
+
+  @media (max-width: 520px) {
+    .users-summary { grid-template-columns: 1fr; }
+    .users-hero-action { width: 100%; justify-content: center; }
+    .create-user-grid { grid-template-columns: 1fr; }
+    .create-user-field-wide { grid-column: auto; }
+    .user-workflow-modal .modal-footer { align-items: stretch; flex-direction: column-reverse; }
+    .workflow-button { width: 100%; }
   }
 </style>
 {% endblock %}
 
 {% block main_content %}
-<div class="container-fluid">
-  <h2 class="mb-4">{{ _('Käyttäjät') }}</h2>
+<div class="users-page">
+  <header class="users-hero">
+    <div>
+      <p class="users-kicker">{{ _('Käyttäjähallinta') }}</p>
+      <h1>{{ _('Käyttäjät') }}</h1>
+      <p>{{ _('Etsi käyttäjiä, tarkista käyttöoikeudet ja hoida käyttäjätilien tärkeimmät ylläpitotoimet.') }}</p>
+    </div>
+    <div class="users-hero-actions">
+      <a href="{{ url_for('admin.manual_page', page='users') }}" target="_blank" class="users-hero-action">
+        <i class="fa-solid fa-book-open" aria-hidden="true"></i>{{ _('Käyttöohje') }}
+      </a>
+      <a href="{{ url_for('admin_dev.list_requests') }}" class="users-hero-action">
+        <i class="fa-solid fa-key" aria-hidden="true"></i>{{ _('API-avainpyynnöt') }}
+        {% if pending_token_requests %}<span class="users-request-count">{{ pending_token_requests }}</span>{% endif %}
+      </a>
+    </div>
+  </header>
 
-  <!-- User Manual Link -->
-  <div class="mb-3">
-    <a href="{{ url_for('admin.manual_page', page='users') }}" target="_blank" class="btn btn-info">
-      <i class="fa-solid fa-book me-1"></i> Käyttöohje
-    </a>
-    <a href="{{ url_for('admin_dev.list_requests') }}" class="btn btn-outline-primary ms-2">
-      <i class="fa-solid fa-key me-1"></i> API-avainten pyynnöt
-      {% if pending_token_requests %}
-      <span class="badge bg-danger">{{ pending_token_requests }}</span>
-      {% endif %}
-    </a>
-  </div>
+  <section class="users-summary" aria-label="{{ _('Käyttäjätilien yhteenveto') }}">
+    <article class="users-summary-card">
+      <span class="users-summary-icon"><i class="fas fa-users" aria-hidden="true"></i></span>
+      <div><span>{{ _('Kaikki käyttäjät') }}</span><strong>{{ user_summary.all }}</strong></div>
+    </article>
+    <article class="users-summary-card">
+      <span class="users-summary-icon"><i class="fas fa-circle-check" aria-hidden="true"></i></span>
+      <div><span>{{ _('Vahvistetut tilit') }}</span><strong>{{ user_summary.confirmed }}</strong></div>
+    </article>
+    <article class="users-summary-card">
+      <span class="users-summary-icon"><i class="fas fa-shield-halved" aria-hidden="true"></i></span>
+      <div><span>{{ _('Ylläpitäjät') }}</span><strong>{{ user_summary.admins }}</strong></div>
+    </article>
+    <article class="users-summary-card">
+      <span class="users-summary-icon"><i class="fas fa-door-open" aria-hidden="true"></i></span>
+      <div><span>{{ _('Ei vielä kirjautunut') }}</span><strong>{{ user_summary.never_logged_in }}</strong></div>
+    </article>
+  </section>
 
-
-  <!-- Search + Create -->
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <input type="text" id="userSearch" class="form-control me-2" placeholder="{{ _('Hae käyttäjiä...') }}"
-      value="{{ search_query }}">
-
+  <section class="users-toolbar">
+    <label class="users-search" for="userSearch">
+      <i class="fas fa-search users-search-icon" aria-hidden="true"></i>
+      <input type="search" id="userSearch" placeholder="{{ _('Hae nimellä, käyttäjänimellä tai sähköpostilla...') }}" value="{{ search_query }}">
+    </label>
     {% if current_user.has_permission("CREATE_USER") %}
-    <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#createUserModal">
-      <i class="fas fa-user-plus me-1"></i>{{ _('Luo uusi käyttäjä') }}
-    </button>
+      <button type="button" class="users-create" data-bs-toggle="modal" data-bs-target="#createUserModal">
+        <i class="fas fa-user-plus" aria-hidden="true"></i>{{ _('Luo uusi käyttäjä') }}
+      </button>
     {% endif %}
-  </div>
+  </section>
 
-  <div id="usersTableContainer">
+  <div id="usersTableContainer" class="users-table-shell">
     {% include 'admin_V2/_users_table.html' %}
   </div>
 </div>
 
-<!-- Toasts -->
 <div id="toast-container"></div>
-
-<!-- Include Modals -->
 {% include 'admin_V2/_modals_users.html' %}
 {% endblock %}
 
 {% block scripts %}
 <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
-
 <script>
-  // ======== Toast Helper ========
   function showToast(message, type = 'success') {
     const toastContainer = $('#toast-container');
-    const toastEl = $(`
-      <div class="toast align-items-center text-bg-${type} border-0" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="d-flex">
-          <div class="toast-body">${message}</div>
-          <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
-        </div>
-      </div>`);
+    const toastEl = $(`<div class="toast align-items-center text-bg-${type} border-0" role="alert" aria-live="assertive" aria-atomic="true"><div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div></div>`);
     toastContainer.append(toastEl);
     const toast = new bootstrap.Toast(toastEl[0], { delay: 4000 });
     toast.show();
     toastEl.on('hidden.bs.toast', () => toastEl.remove());
   }
 
-  // ======== Live Search ========
   function loadUserTable(url) {
     $.get(url, function (html) {
       const newTable = $(html).find('#usersTableContainer').html();
@@ -142,31 +691,82 @@
 
   initUserTableEnhancements();
 
-  // ======== Sortable Table Columns ========
   $(document).on('click', 'th.sortable', function () {
     const table = $(this).closest('table');
     const tbody = table.find('tbody');
     const index = $(this).index();
     const asc = !$(this).hasClass('asc');
-
-    // Reset classes
     table.find('th.sortable').removeClass('asc desc');
     $(this).addClass(asc ? 'asc' : 'desc');
-
     const rows = tbody.find('tr').get();
     rows.sort((a, b) => {
-      const A = $(a).children('td').eq(index).text().toUpperCase();
-      const B = $(b).children('td').eq(index).text().toUpperCase();
-      if ($.isNumeric(A) && $.isNumeric(B)) {
-        return asc ? A - B : B - A;
-      } else {
-        return asc ? A.localeCompare(B) : B.localeCompare(A);
-      }
+      const A = $(a).children('td').eq(index).text().trim().toUpperCase();
+      const B = $(b).children('td').eq(index).text().trim().toUpperCase();
+      return asc ? A.localeCompare(B) : B.localeCompare(A);
     });
     $.each(rows, (_, row) => tbody.append(row));
   });
+
+  const createUserForm = document.getElementById('createUserForm');
+  const createUserModal = document.getElementById('createUserModal');
+  const createUserEmail = document.getElementById('create-user-email');
+  const createUserUsername = document.getElementById('create-user-username');
+  const createUserDisplayname = document.getElementById('create-user-displayname');
+  const createUserRole = document.getElementById('create-user-role');
+  const createUserRoleHelp = document.getElementById('create-user-role-help');
+  const createUserStatus = document.getElementById('create-user-status');
+  const createUserSubmit = document.getElementById('create-user-submit');
+  let usernameWasEdited = false;
+  let displaynameWasEdited = false;
+
+  function suggestUsername(email) {
+    return (email.split('@')[0] || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-zA-Z0-9._-]/g, '')
+      .toLowerCase();
+  }
+
+  createUserUsername?.addEventListener('input', () => { usernameWasEdited = true; });
+  createUserDisplayname?.addEventListener('input', () => { displaynameWasEdited = true; });
+
+  createUserEmail?.addEventListener('input', () => {
+    const suggested = suggestUsername(createUserEmail.value);
+    if (!usernameWasEdited) createUserUsername.value = suggested;
+    if (!displaynameWasEdited) createUserDisplayname.value = suggested;
+  });
+
+  createUserRole?.addEventListener('change', () => {
+    createUserRoleHelp.textContent = createUserRole.value === 'admin'
+      ? "{{ _('Admin voi käyttää ylläpitotoimintoja myönnettyjen oikeuksien mukaan.') }}"
+      : "{{ _('Tavallinen käyttäjä saa perustilin ilman ylläpito-oikeuksia.') }}";
+  });
+
+  createUserForm?.addEventListener('submit', (event) => {
+    const requiredFields = [createUserEmail, createUserUsername, createUserRole];
+    requiredFields.forEach((field) => field?.classList.toggle('is-invalid', !field.value.trim()));
+    if (!createUserForm.checkValidity()) {
+      event.preventDefault();
+      createUserStatus.textContent = "{{ _('Tarkista puuttuvat tai virheelliset tiedot.') }}";
+      createUserStatus.classList.add('error');
+      createUserForm.reportValidity();
+      return;
+    }
+    createUserStatus.textContent = "{{ _('Luodaan käyttäjää ja valmistellaan tunnusviestiä...') }}";
+    createUserStatus.classList.remove('error');
+    createUserSubmit.disabled = true;
+    createUserSubmit.innerHTML = '<i class="fas fa-circle-notch fa-spin" aria-hidden="true"></i>{{ _("Luodaan...") }}';
+  });
+
+  createUserModal?.addEventListener('hidden.bs.modal', () => {
+    createUserForm.reset();
+    createUserForm.querySelectorAll('.is-invalid').forEach((field) => field.classList.remove('is-invalid'));
+    createUserStatus.textContent = '';
+    createUserStatus.classList.remove('error');
+    createUserSubmit.disabled = false;
+    createUserSubmit.innerHTML = '<i class="fas fa-user-plus" aria-hidden="true"></i>{{ _("Luo käyttäjä") }}';
+    usernameWasEdited = false;
+    displaynameWasEdited = false;
+  });
 </script>
-
-
-<script src="{{ url_for('static', filename='js/admin/users_modals.js') }}"></script>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -1706,7 +1706,7 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
         <div class="organizer-card-header">
           <div class="organizer-logo {% if not org.logo %}placeholder{% endif %}">
             {% if org.logo %}
-            <img src="{{ org.logo }}" alt="{{ _('Logo: %(name)s', name=org.name) }}" loading="lazy" decoding="async">
+            <img src="{{ org.logo }}" alt="{{ _('Logo: %(name)s', name=org.name) }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
             {% else %}
             <i class="fa-solid fa-building"></i>
             {% endif %}

--- a/mielenosoitukset_fi/templates/organizations/details.html
+++ b/mielenosoitukset_fi/templates/organizations/details.html
@@ -746,7 +746,7 @@
     <div class="org-hero-header">
       <div class="org-logo-wrapper">
         {% if org.logo %}
-        <img src="{{ org.logo }}" alt="{{ _('Logo: %(name)s', name=org.name) }}" loading="lazy" decoding="async">
+        <img src="{{ org.logo }}" alt="{{ _('Logo: %(name)s', name=org.name) }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
         {% else %}
         <div class="org-logo-placeholder">
           <i class="fa-solid fa-building"></i>

--- a/mielenosoitukset_fi/templates/users/profile/profile copy.html
+++ b/mielenosoitukset_fi/templates/users/profile/profile copy.html
@@ -750,7 +750,7 @@ Voimme myös lisätä toisemme ystäviksi!</textarea>
           <div class="org-header">
             <div class="org-avatar">
               {% if org.logo %}
-                <img src="{{ org.logo }}" alt="{{ org.name }}" loading="lazy">
+                <img src="{{ org.logo }}" alt="{{ org.name }}" loading="lazy" referrerpolicy="no-referrer">
               {% else %}
                 <i class="fa-solid fa-building"></i>
               {% endif %}

--- a/mielenosoitukset_fi/templates/users/profile/profile.html
+++ b/mielenosoitukset_fi/templates/users/profile/profile.html
@@ -736,7 +736,7 @@ Voimme myös lisätä toisemme ystäviksi!</textarea>
           <div class="org-header">
             <div class="org-avatar">
               {% if org.logo %}
-                <img src="{{ org.logo }}" alt="{{ org.name }}" loading="lazy">
+                <img src="{{ org.logo }}" alt="{{ org.name }}" loading="lazy" referrerpolicy="no-referrer">
               {% else %}
                 <i class="fa-solid fa-building"></i>
               {% endif %}

--- a/mielenosoitukset_fi/users/BPs/auth.py
+++ b/mielenosoitukset_fi/users/BPs/auth.py
@@ -24,6 +24,7 @@ from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.utils.helpers import is_strong_password
 from mielenosoitukset_fi.utils.validators import normalize_username, validate_username
 from mielenosoitukset_fi.utils.s3 import upload_image_fileobj
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 from mielenosoitukset_fi.database_manager import DatabaseManager
 from bson.objectid import ObjectId
 from werkzeug.utils import secure_filename
@@ -310,7 +311,7 @@ def generate_api_token():
             "action": "attempted privileged scope request",
             "requested_scopes": data.get("scopes", []),
             "denied_scopes": sorted(requested_privileged_scopes),
-            "ip_address": request.remote_addr,
+            "ip_address": get_client_ip(),
             "timestamp": datetime.now()
         })
         return jsonify({
@@ -640,7 +641,7 @@ def login():
 
         user_doc = _find_user_by_username(username)
         
-        user_ip = request.remote_addr
+        user_ip = get_client_ip()
         user_agent = request.headers.get("User-Agent", "")
 
         if not user_doc:
@@ -701,7 +702,7 @@ from datetime import datetime
 @auth_bp.route("/forced_pwd_reset/", methods=["GET", "POST"])
 @login_required
 def forced_pwd_reset():
-    ip = request.remote_addr
+    ip = get_client_ip()
     user_agent = request.headers.get("User-Agent", "")
 
     log_entry = {
@@ -1255,7 +1256,7 @@ def password_reset(token):
     """
     Handle password reset using a token, with full logging and single-use token enforcement.
     """
-    ip = request.remote_addr
+    ip = get_client_ip()
     user_agent = request.headers.get("User-Agent", "")
     
     # Check if token has already been used
@@ -1458,7 +1459,7 @@ def api_change_password():
     mongo.password_changes.insert_one({
         "user_id": current_user._id,
         "datetime": utcnow(),
-        "ip": request.remote_addr,
+        "ip": get_client_ip(),
         "user_agent": request.headers.get("User-Agent", ""),
         "method": "settings_page",
         "changed": True

--- a/mielenosoitukset_fi/users/BPs/profile.py
+++ b/mielenosoitukset_fi/users/BPs/profile.py
@@ -10,6 +10,7 @@ from mielenosoitukset_fi.utils.database import stringify_object_ids
 from mielenosoitukset_fi.utils.flashing import flash_message
 from mielenosoitukset_fi.users.models import User
 from mielenosoitukset_fi.utils.logger import logger
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
 
 def _get_mongo():
     """Return the current database handle."""
@@ -263,7 +264,7 @@ def send_friend_request():
     other.friend_requests.append({
         "sent_by": current_user._id,
         "sent_at": utcnow(),
-        "sent_ip": request.remote_addr
+        "sent_ip": get_client_ip()
     })
     other.save()
     return {"success": True, "status": "request_sent"}, 200

--- a/mielenosoitukset_fi/utils/request_ip.py
+++ b/mielenosoitukset_fi/utils/request_ip.py
@@ -1,0 +1,56 @@
+"""Trusted real-client IP extraction for proxied requests."""
+
+from functools import lru_cache
+from ipaddress import ip_address, ip_network
+
+from flask import has_request_context, request
+
+
+# Published by Cloudflare at https://www.cloudflare.com/ips/
+CLOUDFLARE_NETWORKS = (
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22",
+    "103.31.4.0/22", "141.101.64.0/18", "108.162.192.0/18",
+    "190.93.240.0/20", "188.114.96.0/20", "197.234.240.0/22",
+    "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+    "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+    "2400:cb00::/32", "2606:4700::/32", "2803:f800::/32",
+    "2405:b500::/32", "2405:8100::/32", "2a06:98c0::/29",
+    "2c0f:f248::/32",
+)
+
+
+@lru_cache(maxsize=1)
+def _cloudflare_networks():
+    return tuple(ip_network(network) for network in CLOUDFLARE_NETWORKS)
+
+
+def _valid_ip(value):
+    if not value:
+        return None
+    try:
+        return str(ip_address(value.strip()))
+    except ValueError:
+        return None
+
+
+def _is_cloudflare_ip(value):
+    parsed = _valid_ip(value)
+    if not parsed:
+        return False
+    address = ip_address(parsed)
+    return any(address in network for network in _cloudflare_networks())
+
+
+def get_client_ip(default="0.0.0.0"):
+    """Return the visitor IP, trusting Cloudflare's header only from Cloudflare."""
+    if not has_request_context():
+        return default
+
+    proxy_ip = _valid_ip(request.remote_addr)
+    cloudflare_ip = (
+        _valid_ip(request.headers.get("CF-Connecting-IPv6"))
+        or _valid_ip(request.headers.get("CF-Connecting-IP"))
+    )
+    if cloudflare_ip and _is_cloudflare_ip(proxy_ip):
+        return cloudflare_ip
+    return proxy_ip or default

--- a/tests/test_org_logo_referrer_policy.py
+++ b/tests/test_org_logo_referrer_policy.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+TEMPLATE_ROOT = Path("mielenosoitukset_fi/templates")
+ORGANIZATION_LOGO_TEMPLATES = (
+    "admin_V2/organizations/form.html",
+    "detail.html",
+    "organizations/details.html",
+    "users/profile/profile.html",
+    "users/profile/profile copy.html",
+)
+
+
+def test_organization_logo_images_do_not_send_preview_referrers():
+    for relative_path in ORGANIZATION_LOGO_TEMPLATES:
+        template = (TEMPLATE_ROOT / relative_path).read_text()
+        logo_lines = [
+            line
+            for line in template.splitlines()
+            if "<img" in line and ("org.logo" in line or "organization.logo" in line)
+        ]
+
+        assert logo_lines, f"No organization logo image found in {relative_path}"
+        assert all('referrerpolicy="no-referrer"' in line for line in logo_lines)

--- a/tests/test_request_ip.py
+++ b/tests/test_request_ip.py
@@ -1,0 +1,52 @@
+from flask import Flask
+
+from mielenosoitukset_fi.utils.request_ip import get_client_ip
+
+
+def test_client_ip_uses_socket_address_without_proxy_header():
+    app = Flask(__name__)
+    with app.test_request_context("/", environ_base={"REMOTE_ADDR": "203.0.113.10"}):
+        assert get_client_ip() == "203.0.113.10"
+
+
+def test_client_ip_accepts_cloudflare_header_from_cloudflare_proxy():
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/",
+        headers={"CF-Connecting-IP": "203.0.113.10"},
+        environ_base={"REMOTE_ADDR": "172.64.10.20"},
+    ):
+        assert get_client_ip() == "203.0.113.10"
+
+
+def test_client_ip_rejects_spoofed_cloudflare_header_from_direct_request():
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/",
+        headers={"CF-Connecting-IP": "198.51.100.99"},
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    ):
+        assert get_client_ip() == "203.0.113.10"
+
+
+def test_client_ip_rejects_invalid_cloudflare_header():
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/",
+        headers={"CF-Connecting-IP": "not-an-ip"},
+        environ_base={"REMOTE_ADDR": "172.64.10.20"},
+    ):
+        assert get_client_ip() == "172.64.10.20"
+
+
+def test_client_ip_prefers_real_ipv6_when_cloudflare_pseudo_ipv4_is_enabled():
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/",
+        headers={
+            "CF-Connecting-IP": "240.0.0.10",
+            "CF-Connecting-IPv6": "2001:db8::10",
+        },
+        environ_base={"REMOTE_ADDR": "2606:4700::100"},
+    ):
+        assert get_client_ip() == "2001:db8::10"


### PR DESCRIPTION
## What changed

- Refreshes admin suggestions, analytics, user management, and organization management with a calmer blue-and-orange visual system inspired by `/ohjeet`.
- Redesigns organization dashboard, detail, create, and edit workflows with responsive cards, clearer actions, themed modals, inline feedback, and fixed pagination/dropdown behavior.
- Documents the refreshed admin visual system in `docs/admin_ui_style.md`.
- Adds a trusted client-IP resolver used consistently by request logging, audit trails, security checks, APIs, and rate limiting.
- Fixes organization logos hosted on lc-main/CDN being denied by Cloudflare Hotlink Protection in localhost and preview environments.

## Why

Several admin pages had inconsistent, dense, template-like styling and broken dark-mode/modal behavior. Request logs and rate limiting also recorded Cloudflare edge addresses instead of visitors, while local/preview organization-logo embeds sent referrers that Cloudflare Hotlink Protection rejected.

The real-IP resolver only trusts Cloudflare connecting-IP headers when the immediate proxy belongs to Cloudflare's published address ranges, preventing spoofed-header trust. Organization-logo requests omit only their referrer, preserving Hotlink Protection for unrelated assets.

## Validation

- `.venv/bin/python -m pytest -q tests/test_request_ip.py tests/test_org_logo_referrer_policy.py tests/test_security_regressions.py tests/test_admin_user_bp.py tests/test_admin_demo_views.py tests/test_route_smoke.py tests/test_flashing.py tests/test_api_contract.py -x` (22 passed)
- Additional focused organization and browser smoke runs completed; browser E2E tests skip when Chromium is unavailable.
- `git diff --check`
- Verified the production CDN asset returns `403` with a localhost referrer and `200` with the new no-referrer behavior.