### PR TITLE
[codex] Add recurring demo cancellation breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * Organization information suggestion pages now accept logo URL suggestions, and admin suggestion review shows logo previews before applying selected fields.
 * Profile follower and following counts now open user lists so visitors can view and navigate to those profiles.
 * Recurring demonstration editors can now recalculate parent coordinates from the saved address/city and bulk-copy latitude/longitude to generated child demonstrations with the location fields.
-* Recurring demonstration admins can now add break dates and bulk-cancel generated child demonstrations from the parent editor; existing child demos on break dates are marked cancelled instead of silently recreated.
+* Recurring demonstration admins can now add break ranges and bulk-cancel generated child demonstrations from the parent editor; existing child demos during breaks are marked cancelled instead of silently recreated.
 * Expanded the public privacy notice to disclose the service's actual personal-data categories, processing purposes and legal bases, cookies and analytics, recipients, current retention limitations, and data-subject rights.
 * Recurring demonstration editors can now bulk-copy selected series fields to selected generated children, with future/all selection shortcuts, per-child audit history, and optional freezing after updates.
 * Regular and recurring admin demonstration editors now use clearer section navigation, improved panel hierarchy, and a responsive sticky save bar.

--- a/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_recu_demo_bp.py
@@ -76,9 +76,10 @@ def _render_recu_demo_form(*, form_action, title, submit_button_text, demo=None)
             .limit(200)
         )
         child_counts["shown"] = len(child_demos)
+        break_dates = _break_dates_from_ranges(demo.break_ranges)
         for child in child_demos:
             child["is_frozen"] = str(child["_id"]) in frozen_child_ids
-            child["is_break"] = child.get("date") in (demo.break_dates or [])
+            child["is_break"] = child.get("date") in break_dates
 
     return render_template(
         f"{_ADMIN_TEMPLATE_FOLDER}recu_demonstrations/_form_v2.html",
@@ -144,22 +145,72 @@ def _get_route_points(form):
     return [point.strip() for point in legacy_route.split(",") if point.strip()]
 
 
-def _collect_break_dates(form):
-    """Collect unique recurring-series break dates from repeated date inputs."""
-    dates = []
+def _normalize_break_range(start_value, end_value=None):
+    """Return a normalized inclusive break range, or None for invalid input."""
+    start_value = (start_value or "").strip()
+    end_value = (end_value or start_value or "").strip()
+    if not start_value:
+        return None
+    try:
+        start_date = datetime.strptime(start_value, "%Y-%m-%d").date()
+        end_date = datetime.strptime(end_value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+    if end_date < start_date:
+        start_date, end_date = end_date, start_date
+    return {
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+    }
+
+
+def _collect_break_ranges(form):
+    """Collect unique recurring-series break ranges from paired date inputs."""
+    ranges = []
     seen = set()
+    starts = form.getlist("break_start_dates")
+    ends = form.getlist("break_end_dates")
+    for index, start in enumerate(starts):
+        break_range = _normalize_break_range(
+            start,
+            ends[index] if index < len(ends) else start,
+        )
+        if not break_range:
+            continue
+        key = (break_range["start_date"], break_range["end_date"])
+        if key not in seen:
+            ranges.append(break_range)
+            seen.add(key)
+
     for raw_date in form.getlist("break_dates"):
-        value = (raw_date or "").strip()
-        if not value:
+        break_range = _normalize_break_range(raw_date)
+        if not break_range:
             continue
-        try:
-            normalized = datetime.strptime(value, "%Y-%m-%d").date().isoformat()
-        except ValueError:
+        key = (break_range["start_date"], break_range["end_date"])
+        if key not in seen:
+            ranges.append(break_range)
+            seen.add(key)
+
+    return sorted(ranges, key=lambda item: (item["start_date"], item["end_date"]))
+
+
+def _break_dates_from_ranges(break_ranges):
+    """Expand inclusive break ranges into ISO date strings."""
+    dates = set()
+    for break_range in break_ranges or []:
+        normalized = _normalize_break_range(
+            break_range.get("start_date"),
+            break_range.get("end_date"),
+        )
+        if not normalized:
             continue
-        if normalized not in seen:
-            dates.append(normalized)
-            seen.add(normalized)
-    return sorted(dates)
+        start_date = datetime.strptime(normalized["start_date"], "%Y-%m-%d").date()
+        end_date = datetime.strptime(normalized["end_date"], "%Y-%m-%d").date()
+        current = start_date
+        while current <= end_date:
+            dates.add(current.isoformat())
+            current = date.fromordinal(current.toordinal() + 1)
+    return dates
 
 
 def _is_valid_latitude(value):
@@ -221,7 +272,7 @@ def _cancel_children_for_break_dates(parent_id, break_dates):
         return 0, 0
     return _cancel_recurring_children(
         parent_id,
-        {"parent": parent_id, "date": {"$in": break_dates}},
+        {"parent": parent_id, "date": {"$in": sorted(break_dates)}},
         "Toistuvan mielenosoituksen taukopäivä",
         "cancel_recurring_child_break",
         "Lapsimielenosoitus peruttiin sarjan taukopäivän vuoksi",
@@ -463,7 +514,8 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
         weekday_of_month=weekday_of_month,
         end_date=end_date,
     ).to_dict()
-    break_dates = _collect_break_dates(request.form)
+    break_ranges = _collect_break_ranges(request.form)
+    break_dates = _break_dates_from_ranges(break_ranges)
 
     if existing_demo:
         for field_name, submitted_value in (
@@ -525,7 +577,8 @@ def handle_recu_demo_form(request, is_edit=False, demo_id=None):
         "cover_picture": cover_picture,
         "gallery_images": gallery_images,
         "repeat_schedule": repeat_schedule,
-        "break_dates": break_dates,
+        "break_ranges": break_ranges,
+        "break_dates": [],
         "recurs": freq != "none",
         "organizers": organizers,
     }

--- a/mielenosoitukset_fi/scripts/repeat_v2.py
+++ b/mielenosoitukset_fi/scripts/repeat_v2.py
@@ -125,8 +125,24 @@ def _frozen_child_ids(parent_demo: dict) -> set[str]:
 
 
 def _break_date_strings(parent_demo: dict) -> set[str]:
-    """Return recurring break dates in ISO date-string form."""
+    """Return recurring break dates in ISO date-string form, expanding ranges."""
     dates = set()
+    for break_range in parent_demo.get("break_ranges", []) or []:
+        if not isinstance(break_range, dict):
+            continue
+        try:
+            start_date = datetime.strptime(str(break_range.get("start_date")), "%Y-%m-%d").date()
+            end_date = datetime.strptime(str(break_range.get("end_date") or break_range.get("start_date")), "%Y-%m-%d").date()
+        except Exception:
+            logger.warning("Skipping invalid recurring break range %r", break_range)
+            continue
+        if end_date < start_date:
+            start_date, end_date = end_date, start_date
+        current = start_date
+        while current <= end_date:
+            dates.add(current.isoformat())
+            current = date.fromordinal(current.toordinal() + 1)
+
     for raw_date in parent_demo.get("break_dates", []) or []:
         if isinstance(raw_date, datetime):
             dates.add(raw_date.date().isoformat())

--- a/mielenosoitukset_fi/templates/admin_V2/recu_demonstrations/_form_v2.html
+++ b/mielenosoitukset_fi/templates/admin_V2/recu_demonstrations/_form_v2.html
@@ -349,20 +349,22 @@
             </div>
 
             <div class="form-group mt-4" id="recurring-break-dates">
-                <label class="block font-medium mb-1">{{ _('Taukopäivät') }}</label>
-                <p class="text-muted">{{ _('Taukopäivälle osuvat jo luodut lapsimielenosoitukset merkitään perutuiksi, eikä uusia luoda kyseiselle päivälle.') }}</p>
+                <label class="block font-medium mb-1">{{ _('Taukojaksot') }}</label>
+                <p class="text-muted">{{ _('Taukojaksolle osuvat jo luodut lapsimielenosoitukset merkitään perutuiksi, eikä uusia luoda kyseisille päiville.') }}</p>
                 <div id="break-date-list" class="child-demo-list">
-                    {% if demo and demo.break_dates %}
-                    {% for break_date in demo.break_dates %}
+                    {% if demo and demo.break_ranges %}
+                    {% for break_range in demo.break_ranges %}
                     <label class="child-demo-row">
-                        <input type="date" name="break_dates" value="{{ break_date }}" class="form-control">
-                        <span><strong>{{ break_date }}</strong><small>{{ _('Sarjan taukopäivä') }}</small></span>
+                        <input type="date" name="break_start_dates" value="{{ break_range.start_date }}" class="form-control">
+                        <span><strong>-</strong><small>{{ _('Alku - loppu') }}</small></span>
+                        <input type="date" name="break_end_dates" value="{{ break_range.end_date }}" class="form-control">
+                        <span><strong>{{ break_range.start_date }} - {{ break_range.end_date }}</strong><small>{{ _('Sarjan taukojakso') }}</small></span>
                         <button type="button" class="btn btn-secondary btn-sm" data-remove-break-date>{{ _('Poista') }}</button>
                     </label>
                     {% endfor %}
                     {% endif %}
                 </div>
-                <button type="button" class="btn btn-secondary btn-sm mt-2" id="add-break-date">{{ _('Lisää taukopäivä') }}</button>
+                <button type="button" class="btn btn-secondary btn-sm mt-2" id="add-break-date">{{ _('Lisää taukojakso') }}</button>
             </div>
 
             <script>
@@ -389,8 +391,10 @@
                     const row = document.createElement('label');
                     row.className = 'child-demo-row';
                     row.innerHTML = `
-                        <input type="date" name="break_dates" class="form-control">
-                        <span><strong>{{ _('Uusi taukopäivä') }}</strong><small>{{ _('Sarjan taukopäivä') }}</small></span>
+                        <input type="date" name="break_start_dates" class="form-control">
+                        <span><strong>-</strong><small>{{ _('Alku - loppu') }}</small></span>
+                        <input type="date" name="break_end_dates" class="form-control">
+                        <span><strong>{{ _('Uusi taukojakso') }}</strong><small>{{ _('Sarjan taukojakso') }}</small></span>
                         <button type="button" class="btn btn-secondary btn-sm" data-remove-break-date>{{ _('Poista') }}</button>
                     `;
                     breakDateList.appendChild(row);
@@ -901,7 +905,7 @@
                         <small>{{ child.date or '–' }} · {{ child.start_time or '–' }} · {{ child.city or '–' }}</small>
                     </span>
                     {% if child.is_frozen %}<span class="status-chip frozen">{{ _('Jäädytetty') }}</span>{% endif %}
-                    {% if child.is_break %}<span class="status-chip frozen">{{ _('Taukopäivä') }}</span>{% endif %}
+                    {% if child.is_break %}<span class="status-chip frozen">{{ _('Taukojakso') }}</span>{% endif %}
                     {% if child.approved %}<span class="status-chip approved">{{ _('Hyväksytty') }}</span>{% endif %}
                     {% if child.cancelled %}<span class="status-chip cancelled">{{ _('Peruttu') }}</span>{% endif %}
                     <a href="{{ url_for('admin_demo.edit_demo', demo_id=child._id) }}" class="btn btn-secondary btn-sm" target="_blank">{{ _('Avaa') }}</a>

--- a/mielenosoitukset_fi/utils/classes/RecurringDemonstration.py
+++ b/mielenosoitukset_fi/utils/classes/RecurringDemonstration.py
@@ -12,6 +12,43 @@ from .Organizer import Organizer
 
 from mielenosoitukset_fi.utils.logger import logger
 
+
+def _normalize_break_ranges(break_ranges=None, break_dates=None):
+    """Normalize range records, accepting legacy single-day break dates."""
+    normalized = []
+    seen = set()
+
+    def add_range(start_value, end_value=None):
+        start_value = str(start_value or "").strip()
+        end_value = str(end_value or start_value or "").strip()
+        if not start_value:
+            return
+        try:
+            start_date = datetime.strptime(start_value, "%Y-%m-%d").date()
+            end_date = datetime.strptime(end_value, "%Y-%m-%d").date()
+        except ValueError:
+            logger.warning("Skipping invalid recurring break range: %r - %r", start_value, end_value)
+            return
+        if end_date < start_date:
+            start_date, end_date = end_date, start_date
+        key = (start_date.isoformat(), end_date.isoformat())
+        if key in seen:
+            return
+        normalized.append({"start_date": key[0], "end_date": key[1]})
+        seen.add(key)
+
+    for break_range in break_ranges or []:
+        if isinstance(break_range, dict):
+            add_range(break_range.get("start_date"), break_range.get("end_date"))
+        else:
+            add_range(break_range)
+
+    for break_date in break_dates or []:
+        add_range(break_date)
+
+    return sorted(normalized, key=lambda item: (item["start_date"], item["end_date"]))
+
+
 class RecurringDemonstration(Demonstration):
     """
     A demonstration event that repeats over time.
@@ -49,6 +86,7 @@ class RecurringDemonstration(Demonstration):
         created_until: Optional[datetime] = None,
         freezed_children: Optional[list] = None,
         break_dates: Optional[list] = None,
+        break_ranges: Optional[list] = None,
         **kwargs,
     ):
         kwargs["recurs"] = True  # force recurring=True
@@ -63,6 +101,7 @@ class RecurringDemonstration(Demonstration):
         )
         self.created_until = created_until or datetime.now()
         self.freezed_children = freezed_children or []
+        self.break_ranges = _normalize_break_ranges(break_ranges, break_dates)
         self.break_dates = break_dates or []
 
         super().__init__(*args, **kwargs)
@@ -169,7 +208,8 @@ class RecurringDemonstration(Demonstration):
             
         else:
             data["freezed_children"] = self.freezed_children
-        data["break_dates"] = self.break_dates
+        data["break_ranges"] = self.break_ranges
+        data["break_dates"] = []
 
         return data
 
@@ -270,6 +310,7 @@ class RecurringDemonstration(Demonstration):
                     
         data.pop("freezed_children", None)
         break_dates = data.pop("break_dates", []) or []
+        break_ranges = data.pop("break_ranges", []) or []
         data.pop("created_until", None)
         data.pop("city_key", None)
 
@@ -279,6 +320,7 @@ class RecurringDemonstration(Demonstration):
             created_until=created_until,
             freezed_children=_freezed_children,
             break_dates=break_dates,
+            break_ranges=break_ranges,
         )
 
     def __repr__(self) -> str:

--- a/tests/test_admin_recu_demo.py
+++ b/tests/test_admin_recu_demo.py
@@ -223,7 +223,7 @@ def test_admin_can_bulk_cancel_selected_recurring_children(admin_client, db, see
     assert db.demo_edit_history.count_documents({"demo_id": str(selected_id)}) == 1
 
 
-def test_admin_recurring_break_date_cancels_existing_child(admin_client, db, seeded_data):
+def test_admin_recurring_break_range_cancels_existing_child(admin_client, db, seeded_data):
     parent_id = seeded_data["recu_demo_id"]
     child_id = ObjectId()
     db.demonstrations.insert_one(
@@ -255,7 +255,8 @@ def test_admin_recurring_break_date_cancels_existing_child(admin_client, db, see
             "approved": "on",
             "frequency_type": "weekly",
             "frequency_interval": "1",
-            "break_dates": ["2026-07-01"],
+            "break_start_dates": ["2026-07-01"],
+            "break_end_dates": ["2026-07-07"],
             "organizer_name_1": "Test Organization",
             "organizer_email_1": "bob@example.test",
             "organizer_id_1": str(ObjectId()),
@@ -266,12 +267,15 @@ def test_admin_recurring_break_date_cancels_existing_child(admin_client, db, see
     assert response.status_code == 302
     parent = db.recu_demos.find_one({"_id": parent_id})
     child = db.demonstrations.find_one({"_id": child_id})
-    assert parent["break_dates"] == ["2026-07-01"]
+    assert parent["break_ranges"] == [
+        {"start_date": "2026-07-01", "end_date": "2026-07-07"}
+    ]
+    assert parent["break_dates"] == []
     assert child["cancelled"] is True
     assert child["cancellation_reason"] == "Toistuvan mielenosoituksen taukopäivä"
 
 
-def test_recurring_runner_skips_break_dates_and_cancels_existing_children(
+def test_recurring_runner_skips_break_ranges_and_cancels_existing_children(
     monkeypatch, db
 ):
     from mielenosoitukset_fi.scripts import repeat_v2
@@ -282,7 +286,7 @@ def test_recurring_runner_skips_break_dates_and_cancels_existing_children(
         "_id": parent_id,
         "title": "Runner break series",
         "description": "Created by recurring runner test.",
-        "date": "2026-06-24",
+        "date": "2027-06-02",
         "start_time": "12:00",
         "end_time": "13:00",
         "city": "Helsinki",
@@ -296,11 +300,11 @@ def test_recurring_runner_skips_break_dates_and_cancels_existing_children(
             "frequency": "weekly",
             "interval": 1,
             "weekday": "wednesday",
-            "end_date": "2026-07-15",
+            "end_date": "2027-06-23",
         },
-        "created_until": "2026-06-30T00:00:00",
+        "created_until": "2027-06-08T00:00:00",
         "freezed_children": [],
-        "break_dates": ["2026-07-01"],
+        "break_ranges": [{"start_date": "2027-06-09", "end_date": "2027-06-15"}],
         "organizers": [],
     }
     db.recu_demos.insert_one(parent)
@@ -309,7 +313,7 @@ def test_recurring_runner_skips_break_dates_and_cancels_existing_children(
             "_id": break_child_id,
             "parent": parent_id,
             "title": "Existing break child",
-            "date": "2026-07-01",
+            "date": "2027-06-09",
             "start_time": "12:00",
             "end_time": "13:00",
             "city": "Helsinki",
@@ -334,10 +338,10 @@ def test_recurring_runner_skips_break_dates_and_cancels_existing_children(
     }
     saved_parent = db.recu_demos.find_one({"_id": parent_id})
     assert break_child["cancelled"] is True
-    assert "2026-07-01" in created_dates
-    assert "2026-07-08" in created_dates
-    assert "2026-07-15" in created_dates
-    assert saved_parent["created_until"].startswith("2026-07-15")
+    assert "2027-06-09" in created_dates
+    assert "2027-06-16" in created_dates
+    assert "2027-06-23" in created_dates
+    assert saved_parent["created_until"].startswith("2027-06-23")
 
 
 def test_recurring_demo_no_change_save_preserves_schedule_and_nullable_values(


### PR DESCRIPTION
## What changed

- Added parent-scoped bulk cancellation for generated recurring demonstration children.
- Added recurring break ranges in the parent editor using `start - end` date pairs.
- Existing generated children inside a break range are marked cancelled, and the recurring runner skips creating new children during break ranges.
- Kept legacy single-day `break_dates` readable as one-day ranges and added focused regression coverage.

## Why

Admins need a quick way to cancel many demonstrations from the same recurring parent, and recurring breaks should cover date spans rather than isolated dates.

## Validation

- `./.venv/bin/python -m pytest -q tests/test_admin_recu_demo.py tests/test_admin_recu_demo_views.py tests/test_surface_manifest.py`
