### PR TITLE
[codex] Combine Mastodon and X share actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 ### Changed
+* Demonstration detail pages now combine Mastodon and X sharing into one Mastodon-led dropdown, keeping X available without a separate standalone button.
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.
 
 ### Fixed

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -542,6 +542,27 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     color: white;
   }
 
+  .btn-social.mastodon {
+    background: #6364ff;
+    color: white;
+  }
+
+  .share-dropdown .dropdown-menu {
+    border: 1px solid var(--color-border);
+    background: var(--color-card-bg);
+    box-shadow: var(--color-shadow);
+  }
+
+  .share-dropdown .dropdown-item {
+    color: var(--color-text);
+  }
+
+  .share-dropdown .dropdown-item:hover,
+  .share-dropdown .dropdown-item:focus {
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    color: var(--color-text);
+  }
+
   .btn-social.linkedin {
     background: #0077b5;
     color: white;
@@ -1513,16 +1534,36 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
 
   <!-- Social Share -->
   <div class="action-buttons animate-fade-in-up">
+    {% set demo_url = url_for('demonstration_detail', demo_id=demo['_id'], _external=True) %}
+    {% set share_text = demo['title'] ~ ' ' ~ demo_url %}
     <a href="https://www.facebook.com/sharer/sharer.php?u={{ url_for('demonstration_detail', demo_id=demo['_id'], _external=True) }}"
       target="_blank" class="btn btn-social facebook">
       <i class="fa-brands fa-facebook-f"></i>
       {{ _('Jaa Facebookissa') }}
     </a>
-    <a href="https://twitter.com/intent/tweet?url={{ url_for('demonstration_detail', demo_id=demo['_id'], _external=True) }}&text={{ demo['title'] }}"
-      target="_blank" class="btn btn-social twitter">
-      <i class="fa-brands fa-x-twitter"></i>
-      {{ _('Jaa X:ssä') }}
-    </a>
+    <div class="btn-group share-dropdown">
+      <button type="button" class="btn btn-social mastodon dropdown-toggle" data-bs-toggle="dropdown"
+        aria-expanded="false">
+        <i class="fa-brands fa-mastodon"></i>
+        {{ _('Jaa Mastodonissa') }}
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <a class="dropdown-item" href="https://mastodon.social/share?text={{ share_text|urlencode }}"
+            target="_blank" rel="noopener">
+            <i class="fa-brands fa-mastodon"></i>
+            {{ _('Jaa Mastodonissa') }}
+          </a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="https://twitter.com/intent/tweet?url={{ demo_url|urlencode }}&text={{ demo['title']|urlencode }}"
+            target="_blank" rel="noopener">
+            <i class="fa-brands fa-x-twitter"></i>
+            {{ _('Jaa X:ssä') }}
+          </a>
+        </li>
+      </ul>
+    </div>
     <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_for('demonstration_detail', demo_id=demo['_id'], _external=True) }}&title={{ demo['title'] }}"
       target="_blank" class="btn btn-social linkedin">
       <i class="fa-brands fa-linkedin-in"></i>


### PR DESCRIPTION
## Summary
- replace the standalone X share button on demonstration detail pages with a Mastodon-led share dropdown
- keep both Mastodon and X share targets available from the same control
- document the user-facing share UI change in the changelog

## Validation
- `git diff --check HEAD~1..HEAD`
- parsed `detail.html` with Jinja using local app-compatible dummy filters for template-only syntax checking
