### PR TITLE
Use Bootstrap share dropdown fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.
 
 ### Fixed
+* Demonstration detail Mastodon/X share menu now uses Bootstrap dropdown markup with hover and focus fallbacks so the X option can open across browsers.
 * Demonstration detail Mastodon/X share menu now uses a native dropdown control so the X option opens reliably without custom page JavaScript.
 * Demonstration detail Mastodon/X share dropdown now works as a split button: the Mastodon side opens Mastodon sharing and the arrow opens the X option.
 * Organization logos served through the production CDN now omit local and preview-page referrers when embedded or opened, preventing Cloudflare Hotlink Protection from rejecting valid lc-main assets during development and previews.

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -574,12 +574,7 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     user-select: none;
   }
 
-  .share-dropdown .share-options {
-    display: inline-flex;
-    position: relative;
-  }
-
-  .share-dropdown .share-menu-toggle::-webkit-details-marker {
+  .share-dropdown .dropdown-toggle::after {
     display: none;
   }
 
@@ -588,7 +583,9 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     transition: transform 0.18s ease;
   }
 
-  .share-dropdown .share-options[open] .share-menu-toggle i {
+  .share-dropdown .share-menu-toggle[aria-expanded="true"] i,
+  .share-dropdown:focus-within .share-menu-toggle i,
+  .share-dropdown:hover .share-menu-toggle i {
     transform: rotate(180deg);
   }
 
@@ -608,7 +605,9 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     z-index: 1050;
   }
 
-  .share-dropdown .share-options[open] .dropdown-menu {
+  .share-dropdown .dropdown-menu.show,
+  .share-dropdown:focus-within .dropdown-menu,
+  .share-dropdown:hover .dropdown-menu {
     display: block;
   }
 
@@ -1619,22 +1618,20 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
         <i class="fa-brands fa-mastodon"></i>
         {{ _('Jaa Mastodonissa') }}
       </a>
-      <details class="share-options">
-        <summary class="btn btn-social mastodon share-menu-toggle"
-          aria-label="{{ _('Valitse jakopalvelu') }}">
-          <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
-        </summary>
-        <ul class="dropdown-menu">
-          <li class="dropdown-header">{{ _('Jaa myös') }}</li>
-          <li>
-            <a class="dropdown-item" href="https://twitter.com/intent/tweet?url={{ demo_url|urlencode }}&text={{ demo['title']|urlencode }}"
-              target="_blank" rel="noopener">
-              <i class="fa-brands fa-x-twitter"></i>
-              {{ _('Jaa X:ssä') }}
-            </a>
-          </li>
-        </ul>
-      </details>
+      <button type="button" class="btn btn-social mastodon dropdown-toggle share-menu-toggle"
+        data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ _('Valitse jakopalvelu') }}">
+        <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li class="dropdown-header">{{ _('Jaa myös') }}</li>
+        <li>
+          <a class="dropdown-item" href="https://twitter.com/intent/tweet?url={{ demo_url|urlencode }}&text={{ demo['title']|urlencode }}"
+            target="_blank" rel="noopener">
+            <i class="fa-brands fa-x-twitter"></i>
+            {{ _('Jaa X:ssä') }}
+          </a>
+        </li>
+      </ul>
     </div>
     <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_for('demonstration_detail', demo_id=demo['_id'], _external=True) }}&title={{ demo['title'] }}"
       target="_blank" class="btn btn-social linkedin">


### PR DESCRIPTION
## Summary
- switch the Mastodon/X share split button back to Bootstrap dropdown markup
- add hover/focus CSS fallbacks so X can still be reached even if dropdown JS is flaky
- update the changelog

## Validation
- git diff --check
- .venv/bin/python - <<'PY'
from pathlib import Path
from jinja2 import Environment
source = Path('mielenosoitukset_fi/templates/detail.html').read_text()
Environment().parse(source)
print('detail.html parses')
PY
- .venv/bin/python -m pytest tests/test_live_http_smoke.py -q