### PR TITLE
Remove social share dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 ### Changed
+* Demonstration detail share controls now show Mastodon and X as separate buttons instead of a dropdown menu.
 * Demonstration detail share controls now present the Mastodon/X split button with a more polished dropdown treatment.
 * Demonstration detail pages now combine Mastodon and X sharing into one Mastodon-led dropdown, keeping X available without a separate standalone button.
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.

--- a/mielenosoitukset_fi/templates/detail.html
+++ b/mielenosoitukset_fi/templates/detail.html
@@ -547,93 +547,6 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
     color: white;
   }
 
-  .share-dropdown {
-    position: relative;
-    display: inline-flex;
-    isolation: isolate;
-    filter: drop-shadow(0 10px 20px rgba(99, 100, 255, 0.18));
-  }
-
-  .share-dropdown .share-primary {
-    border-radius: 50px 0 0 50px;
-    border-right: 0;
-    padding-right: 1.1rem;
-  }
-
-  .share-dropdown .share-menu-toggle {
-    align-items: center;
-    border-radius: 0 50px 50px 0;
-    border-left: 1px solid rgba(255, 255, 255, 0.28);
-    cursor: pointer;
-    display: inline-flex;
-    justify-content: center;
-    list-style: none;
-    min-width: 3rem;
-    padding-left: 0.85rem;
-    padding-right: 0.95rem;
-    user-select: none;
-  }
-
-  .share-dropdown .dropdown-toggle::after {
-    display: none;
-  }
-
-  .share-dropdown .share-menu-toggle i {
-    font-size: 0.85rem;
-    transition: transform 0.18s ease;
-  }
-
-  .share-dropdown .share-menu-toggle[aria-expanded="true"] i,
-  .share-dropdown:focus-within .share-menu-toggle i,
-  .share-dropdown:hover .share-menu-toggle i {
-    transform: rotate(180deg);
-  }
-
-  .share-dropdown .dropdown-menu {
-    border: 1px solid var(--color-border);
-    background: var(--color-card-bg);
-    border-radius: 1rem;
-    box-shadow: var(--color-shadow-lg);
-    display: none;
-    left: auto;
-    margin-top: 0.55rem;
-    min-width: 14rem;
-    padding: 0.45rem;
-    position: absolute;
-    right: 0;
-    top: 100%;
-    z-index: 1050;
-  }
-
-  .share-dropdown .dropdown-menu.show,
-  .share-dropdown:focus-within .dropdown-menu,
-  .share-dropdown:hover .dropdown-menu {
-    display: block;
-  }
-
-  .share-dropdown .dropdown-header {
-    color: var(--color-muted);
-    font-size: 0.78rem;
-    font-weight: 700;
-    letter-spacing: 0;
-    padding: 0.45rem 0.75rem 0.25rem;
-  }
-
-  .share-dropdown .dropdown-item {
-    align-items: center;
-    border-radius: 0.75rem;
-    color: var(--color-text);
-    display: flex;
-    gap: 0.65rem;
-    padding: 0.7rem 0.8rem;
-  }
-
-  .share-dropdown .dropdown-item:hover,
-  .share-dropdown .dropdown-item:focus {
-    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-    color: var(--color-text);
-  }
-
   .btn-social.linkedin {
     background: #0077b5;
     color: white;
@@ -1612,27 +1525,16 @@ Template accepts either demo['mastodon'] or a global mastodon_profile variable. 
       <i class="fa-brands fa-facebook-f"></i>
       {{ _('Jaa Facebookissa') }}
     </a>
-    <div class="btn-group share-dropdown" data-share-dropdown>
-      <a class="btn btn-social mastodon share-primary" href="https://mastodon.social/share?text={{ share_text|urlencode }}"
-        target="_blank" rel="noopener">
-        <i class="fa-brands fa-mastodon"></i>
-        {{ _('Jaa Mastodonissa') }}
-      </a>
-      <button type="button" class="btn btn-social mastodon dropdown-toggle share-menu-toggle"
-        data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ _('Valitse jakopalvelu') }}">
-        <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-end">
-        <li class="dropdown-header">{{ _('Jaa myös') }}</li>
-        <li>
-          <a class="dropdown-item" href="https://twitter.com/intent/tweet?url={{ demo_url|urlencode }}&text={{ demo['title']|urlencode }}"
-            target="_blank" rel="noopener">
-            <i class="fa-brands fa-x-twitter"></i>
-            {{ _('Jaa X:ssä') }}
-          </a>
-        </li>
-      </ul>
-    </div>
+    <a class="btn btn-social mastodon" href="https://mastodon.social/share?text={{ share_text|urlencode }}"
+      target="_blank" rel="noopener">
+      <i class="fa-brands fa-mastodon"></i>
+      {{ _('Jaa Mastodonissa') }}
+    </a>
+    <a href="https://twitter.com/intent/tweet?url={{ demo_url|urlencode }}&text={{ demo['title']|urlencode }}"
+      target="_blank" rel="noopener" class="btn btn-social twitter">
+      <i class="fa-brands fa-x-twitter"></i>
+      {{ _('Jaa X:ssä') }}
+    </a>
     <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ url_for('demonstration_detail', demo_id=demo['_id'], _external=True) }}&title={{ demo['title'] }}"
       target="_blank" class="btn btn-social linkedin">
       <i class="fa-brands fa-linkedin-in"></i>


### PR DESCRIPTION
## Summary
- remove the Mastodon/X dropdown menu from demonstration detail pages
- show Mastodon and X as separate direct share buttons again
- update the changelog

## Validation
- git diff --check
- .venv/bin/python - <<'PY'
from pathlib import Path
from jinja2 import Environment
source = Path('mielenosoitukset_fi/templates/detail.html').read_text()
Environment().parse(source)
print('detail.html parses')
PY
- .venv/bin/python -m pytest tests/test_live_http_smoke.py -q