### PR TITLE
Add profile follower lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Streamlined `_path_value` logic in test route smoke tests and enhanced payload generation for better test coverage and maintainability.
 
 ### Added
+* Profile follower and following counts now open user lists so visitors can view and navigate to those profiles.
 * Recurring demonstration editors can now recalculate parent coordinates from the saved address/city and bulk-copy latitude/longitude to generated child demonstrations with the location fields.
 * Recurring demonstration admins can now add break dates and bulk-cancel generated child demonstrations from the parent editor; existing child demos on break dates are marked cancelled instead of silently recreated.
 * Expanded the public privacy notice to disclose the service's actual personal-data categories, processing purposes and legal bases, cookies and analytics, recipients, current retention limitations, and data-subject rights.

--- a/mielenosoitukset_fi/templates/users/profile/profile.html
+++ b/mielenosoitukset_fi/templates/users/profile/profile.html
@@ -144,6 +144,25 @@ body {
   transform: translateY(-2px);
 }
 
+.stat-button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+
+.stat-button:focus-visible {
+  border-radius: var(--border_radius);
+  outline: 3px solid var(--box_shadow_color);
+  outline-offset: 0.35rem;
+}
+
 .stat-value {
   display: block;
   font-size: 2rem;
@@ -531,6 +550,58 @@ body {
   display: block;
 }
 
+.follow-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.follow-list-item {
+  align-items: center;
+  background: var(--background_light);
+  border: 1px solid var(--border_color);
+  border-radius: var(--border_radius);
+  color: var(--primary_text_color);
+  display: flex;
+  gap: 0.85rem;
+  padding: 0.85rem;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.follow-list-item:hover,
+.follow-list-item:focus {
+  background: var(--hover_bg_color);
+  border-color: var(--primary_color);
+  color: var(--primary_text_color);
+  transform: translateY(-2px);
+}
+
+.follow-list-avatar {
+  border-radius: 50%;
+  flex: 0 0 44px;
+  height: 44px;
+  object-fit: cover;
+  width: 44px;
+}
+
+.follow-list-name {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.follow-list-display {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.follow-list-username {
+  color: var(--secondary_text_color);
+  font-size: 0.9rem;
+}
+
 /* Toast Notification */
 .custom-toast {
   position: fixed;
@@ -646,6 +717,50 @@ Voimme myös lisätä toisemme ystäviksi!</textarea>
   </div>
 </div>
 
+{% macro follow_list_modal(modal_id, title, people, empty_text) %}
+<div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-labelledby="{{ modal_id }}Label" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="{{ modal_id }}Label">
+          <i class="fa-solid fa-user-group"></i> {{ title }}
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Sulje') }}"></button>
+      </div>
+      <div class="modal-body">
+        {% if people %}
+          <div class="follow-list">
+            {% for person in people %}
+              <a class="follow-list-item" href="{{ person.url }}">
+                <img class="follow-list-avatar"
+                  src="{{ person.profile_picture or 'https://cdn2.mielenosoitukset.fi/default-pfp.jpg' }}"
+                  alt="{{ person.displayname }}n profiilikuva"
+                  loading="lazy"
+                  onerror="this.src='https://cdn2.mielenosoitukset.fi/default-pfp.jpg'">
+                <span class="follow-list-name">
+                  <span class="follow-list-display">{{ person.displayname }}</span>
+                  <span class="follow-list-username">@{{ person.username }}</span>
+                </span>
+              </a>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="empty-state">
+            <div class="empty-icon">
+              <i class="fa-solid fa-user-group"></i>
+            </div>
+            <div class="empty-text">{{ empty_text }}</div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endmacro %}
+
+{{ follow_list_modal("followersModal", _("Seuraajat"), followers, _("Tällä käyttäjällä ei ole vielä seuraajia.")) }}
+{{ follow_list_modal("followingModal", _("Seuratut"), following, _("Tämä käyttäjä ei seuraa vielä ketään.")) }}
+
 <div class="profile-wrapper">
   <!-- Profile Header -->
   <div class="profile-header-card">
@@ -674,12 +789,16 @@ Voimme myös lisätä toisemme ystäviksi!</textarea>
             <span class="stat-label">{{ _('Postaukset') }}</span>
           </div>
           <div class="stat-item">
-            <span class="stat-value">{{ user.followers_count or 0 }}</span>
-            <span class="stat-label">{{ _('Seuraajat') }}</span>
+            <button type="button" class="stat-button" data-bs-toggle="modal" data-bs-target="#followersModal">
+              <span class="stat-value">{{ user.followers_count or 0 }}</span>
+              <span class="stat-label">{{ _('Seuraajat') }}</span>
+            </button>
           </div>
           <div class="stat-item">
-            <span class="stat-value">{{ user.following_count or 0 }}</span>
-            <span class="stat-label">{{ _('Seuratut') }}</span>
+            <button type="button" class="stat-button" data-bs-toggle="modal" data-bs-target="#followingModal">
+              <span class="stat-value">{{ user.following_count or 0 }}</span>
+              <span class="stat-label">{{ _('Seuratut') }}</span>
+            </button>
           </div>
         </div>
 

--- a/mielenosoitukset_fi/users/BPs/profile.py
+++ b/mielenosoitukset_fi/users/BPs/profile.py
@@ -16,6 +16,42 @@ def _get_mongo():
     """Return the current database handle."""
     return DatabaseManager().get_instance().get_db()
 
+
+def _profile_user_summaries(mongo, user_ids):
+    """Return public profile details for a list of followed/follower IDs."""
+    object_ids = []
+    for user_id in user_ids or []:
+        try:
+            object_ids.append(ObjectId(user_id))
+        except Exception:
+            continue
+
+    if not object_ids:
+        return []
+
+    users_by_id = {
+        doc["_id"]: doc
+        for doc in mongo.users.find(
+            {"_id": {"$in": object_ids}},
+            {"username": 1, "displayname": 1, "profile_picture": 1},
+        )
+    }
+
+    summaries = []
+    for object_id in object_ids:
+        doc = users_by_id.get(object_id)
+        if not doc or not doc.get("username"):
+            continue
+        summaries.append(
+            {
+                "username": doc["username"],
+                "displayname": doc.get("displayname") or doc["username"],
+                "profile_picture": doc.get("profile_picture"),
+                "url": url_for("users.profile.profile", username=doc["username"]),
+            }
+        )
+    return summaries
+
 profile_bp = Blueprint(
     "profile", __name__, template_folder="/users/profile/", url_prefix="/profile"
 )
@@ -49,6 +85,8 @@ def profile(username=None):
         user_obj = User.from_db(user_data)
         user_obj.followers_count = len(user_obj.followers)
         user_obj.following_count = len(user_obj.following)
+        followers = _profile_user_summaries(mongo, user_obj.followers)
+        following = _profile_user_summaries(mongo, user_obj.following)
 
         followed_orgs = []
         followed_recurring = []
@@ -79,6 +117,8 @@ def profile(username=None):
         return render_template(
             "users/profile/profile.html",
             user=user_obj,
+            followers=followers,
+            following=following,
             followed_orgs=followed_orgs,
             followed_recurring=followed_recurring,
         )

--- a/tests/test_profile_follow_lists.py
+++ b/tests/test_profile_follow_lists.py
@@ -1,0 +1,20 @@
+def test_profile_follow_counts_open_public_user_lists(user_client, db, seeded_data):
+    db.users.update_one(
+        {"_id": seeded_data["user_id"]},
+        {"$set": {"followers": [seeded_data["friend_id"]], "following": [seeded_data["friend_id"]]}},
+    )
+    db.users.update_one(
+        {"_id": seeded_data["friend_id"]},
+        {"$set": {"followers": [seeded_data["user_id"]], "following": [seeded_data["user_id"]]}},
+    )
+
+    response = user_client.get("/users/profile/")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'data-bs-target="#followersModal"' in html
+    assert 'data-bs-target="#followingModal"' in html
+    assert "Bob Friend" in html
+    assert "@bob" in html
+    assert "/users/profile/bob" in html
+    assert "bob@example.test" not in html


### PR DESCRIPTION
## Summary
- make the profile follower and followed counts clickable without changing their visual stat layout
- add Bootstrap modals listing followers and followed users with profile links
- keep list data public-safe: display name, username, profile picture, and profile URL only
- update the changelog

## Validation
- git diff --check
- .venv/bin/python -m pytest tests/test_profile_follow_lists.py tests/test_route_smoke.py::test_reset_client_session_restores_authentication_after_logout -q
- .venv/bin/python - <<'PY'
from pathlib import Path
from jinja2 import Environment
source = Path('mielenosoitukset_fi/templates/users/profile/profile.html').read_text()
Environment().parse(source)
print('profile.html parses')
PY