### PR TITLE
Add organization logo suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Streamlined `_path_value` logic in test route smoke tests and enhanced payload generation for better test coverage and maintainability.
 
 ### Added
+* Organization information suggestion pages now accept logo URL suggestions, and admin suggestion review shows logo previews before applying selected fields.
 * Profile follower and following counts now open user lists so visitors can view and navigate to those profiles.
 * Recurring demonstration editors can now recalculate parent coordinates from the saved address/city and bulk-copy latitude/longitude to generated child demonstrations with the location fields.
 * Recurring demonstration admins can now add break dates and bulk-cancel generated child demonstrations from the parent editor; existing child demos on break dates are marked cancelled instead of silently recreated.

--- a/mielenosoitukset_fi/admin/admin_org_bp.py
+++ b/mielenosoitukset_fi/admin/admin_org_bp.py
@@ -93,7 +93,7 @@ def _normalized_suggestion_fields(suggestion):
 
     # Legacy suggestion documents stored edited values at the top level.
     legacy_fields = {}
-    for key in ["name", "description", "website", "email", "social_media_links"]:
+    for key in ["name", "description", "website", "email", "logo", "social_media_links"]:
         value = suggestion.get(key)
         if value not in (None, "", []):
             legacy_fields[key] = value

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -2558,7 +2558,7 @@ def init_routes(app):
 
 
         # Normal fields
-        for field in ["name", "description", "website", "email"]:
+        for field in ["name", "description", "website", "email", "logo"]:
             val = request.form.get(field)
             if val and val.strip():
                 suggestion["fields"][field] = val.strip()

--- a/mielenosoitukset_fi/templates/admin_V2/organizations/review_suggestion.html
+++ b/mielenosoitukset_fi/templates/admin_V2/organizations/review_suggestion.html
@@ -156,6 +156,32 @@
     font-weight: 500;
   }
 
+  .suggested-logo-preview {
+    display: grid;
+    gap: 0.65rem;
+    max-width: 260px;
+  }
+
+  .suggested-logo-preview img {
+    background: var(--color-card-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    height: 96px;
+    object-fit: contain;
+    padding: 0.6rem;
+    width: 96px;
+  }
+
+  .suggested-logo-preview a,
+  .suggested-dict-value a {
+    overflow-wrap: anywhere;
+  }
+
+  .suggested-dict-value {
+    display: grid;
+    gap: 0.35rem;
+  }
+
   .value-badge {
     display: inline-block;
     padding: 0.25rem 0.75rem;
@@ -360,18 +386,47 @@
           </tr>
         </thead>
         <tbody>
+          {% set field_labels = {
+            "name": _("Nimi"),
+            "description": _("Kuvaus"),
+            "website": _("Verkkosivusto"),
+            "email": _("Sähköposti"),
+            "logo": _("Logo"),
+            "social_media_links": _("Sosiaalinen media")
+          } %}
+          {% set field_icons = {
+            "name": "fa-building",
+            "description": "fa-align-left",
+            "website": "fa-globe",
+            "email": "fa-envelope",
+            "logo": "fa-image",
+            "social_media_links": "fa-share-nodes"
+          } %}
           {% for key, new_value in suggestion.fields.items() %}
           <tr>
             <td>
               <div class="field-name">
-                <i class="fa-solid fa-tag"></i>
-                {{ key }}
+                <i class="fa-solid {{ field_icons.get(key, 'fa-tag') }}"></i>
+                {{ field_labels.get(key, key) }}
               </div>
             </td>
             <td>
               <div class="field-value {% if not org.to_dict().get(key) %}empty{% endif %}">
                 {% if org.to_dict().get(key) %}
-                  <span class="value-badge has-value">{{ org.to_dict().get(key) }}</span>
+                  {% if key == "logo" %}
+                    <div class="suggested-logo-preview">
+                      <img src="{{ org.to_dict().get(key) }}" alt="{{ _('Nykyinen logo') }}" loading="lazy" referrerpolicy="no-referrer">
+                      <a href="{{ org.to_dict().get(key) }}" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">{{ org.to_dict().get(key) }}</a>
+                    </div>
+                  {% elif key == "social_media_links" and org.to_dict().get(key) is mapping %}
+                    <div class="suggested-dict-value">
+                      {% for platform, url in org.to_dict().get(key).items() %}
+                        <span><strong>{{ platform }}:</strong> <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ url }}</a></span>
+                      {% endfor %}
+                    </div>
+                  {% else %}
+                    <span class="value-badge has-value">{{ org.to_dict().get(key) }}</span>
+                  {% endif %}
                 {% else %}
                   <span class="value-badge empty">{{ _('Ei asetettu') }}</span>
                 {% endif %}
@@ -379,7 +434,20 @@
             </td>
             <td>
               <div class="field-value new">
-                <span class="value-badge new-value">{{ new_value }}</span>
+                {% if key == "logo" %}
+                  <div class="suggested-logo-preview">
+                    <img src="{{ new_value }}" alt="{{ _('Ehdotettu logo') }}" loading="lazy" referrerpolicy="no-referrer">
+                    <a href="{{ new_value }}" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">{{ new_value }}</a>
+                  </div>
+                {% elif key == "social_media_links" and new_value is mapping %}
+                  <div class="suggested-dict-value">
+                    {% for platform, url in new_value.items() %}
+                      <span><strong>{{ platform }}:</strong> <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ url }}</a></span>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  <span class="value-badge new-value">{{ new_value }}</span>
+                {% endif %}
               </div>
             </td>
             <td class="checkbox-cell">

--- a/mielenosoitukset_fi/templates/organizations/fill_info.html
+++ b/mielenosoitukset_fi/templates/organizations/fill_info.html
@@ -214,6 +214,50 @@
     font-weight: 600;
   }
 
+  .org-logo-current {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+  }
+
+  .org-logo-current-preview {
+    align-items: center;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius);
+    display: grid;
+    gap: 0.85rem;
+    grid-template-columns: 76px minmax(0, 1fr);
+    padding: 0.85rem;
+  }
+
+  .org-logo-current-preview img {
+    background: var(--color-card-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.85rem;
+    height: 76px;
+    object-fit: contain;
+    padding: 0.5rem;
+    width: 76px;
+  }
+
+  .org-logo-current-preview strong,
+  .org-logo-current-preview span {
+    display: block;
+  }
+
+  .org-logo-current-preview strong {
+    color: var(--color-text);
+    font-size: 0.95rem;
+  }
+
+  .org-logo-current-preview span {
+    color: var(--color-text-secondary);
+    font-size: 0.88rem;
+    margin-top: 0.15rem;
+    overflow-wrap: anywhere;
+  }
+
   .edit-form {
     display: grid;
     gap: 1.5rem;
@@ -411,6 +455,15 @@
       width: 92px;
     }
 
+    .org-logo-current-preview {
+      grid-template-columns: 1fr;
+    }
+
+    .org-logo-current-preview img {
+      height: 120px;
+      width: 100%;
+    }
+
     .section-card {
       padding: 1.25rem;
     }
@@ -479,6 +532,10 @@
           <i class="fa-solid fa-envelope"></i>
           <span>{{ organization.email or _('Sähköposti puuttuu') }}</span>
         </div>
+        <div class="org-field-pill {% if not organization.logo %}is-missing{% endif %}">
+          <i class="fa-solid fa-image"></i>
+          <span>{{ _('Logo lisätty') if organization.logo else _('Logo puuttuu') }}</span>
+        </div>
         <div class="org-field-pill {% if not organization.social_media_links %}is-missing{% endif %}">
           <i class="fa-solid fa-share-nodes"></i>
           <span>
@@ -490,6 +547,18 @@
           </span>
         </div>
       </div>
+
+      {% if organization.logo %}
+      <div class="org-logo-current">
+        <div class="org-logo-current-preview">
+          <img src="{{ organization.logo }}" alt="{{ _('Nykyinen logo: %(name)s', name=organization.name) }}" loading="lazy" decoding="async" referrerpolicy="no-referrer">
+          <div>
+            <strong>{{ _('Nykyinen logo') }}</strong>
+            <span>{{ organization.logo }}</span>
+          </div>
+        </div>
+      </div>
+      {% endif %}
     </aside>
 
     <section class="section-card animate-fade-in-up">
@@ -518,6 +587,11 @@
             <div class="form-group">
               <label for="website"><i class="fa-solid fa-globe"></i> {{ _('Verkkosivusto') }}</label>
               <input type="url" id="website" name="website" placeholder="https://esimerkki.fi" value="{{ organization.website }}">
+            </div>
+
+            <div class="form-group">
+              <label for="logo"><i class="fa-solid fa-image"></i> {{ _('Logo URL') }}</label>
+              <input type="url" id="logo" name="logo" placeholder="https://esimerkki.fi/logo.png" value="{{ organization.logo }}">
             </div>
 
             <div class="form-group full-width">

--- a/tests/test_organization_fill_page.py
+++ b/tests/test_organization_fill_page.py
@@ -7,4 +7,47 @@ def test_organization_fill_page_uses_public_org_visual_shell(client, seeded_data
     assert "org-fill-layout" in html
     assert "Nykyiset tiedot" in html
     assert "Täydennä järjestön tietoja" in html
+    assert 'name="logo"' in html
     assert "Test Organization" in html
+
+
+def test_organization_fill_submission_stores_logo_suggestion(client, db, seeded_data):
+    logo_url = "https://example.test/logo.png"
+
+    response = client.post(
+        f"/organization/{seeded_data['org_id']}/save_suggestion",
+        data={
+            "name": "Test Organization",
+            "description": "Updated description",
+            "website": "https://example.test/org",
+            "email": "contact@test-org.example",
+            "logo": logo_url,
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    suggestion = db.org_edit_suggestions.find_one(
+        {"organization_id": seeded_data["org_id"], "fields.logo": logo_url}
+    )
+    assert suggestion is not None
+    assert suggestion["fields"]["logo"] == logo_url
+
+
+def test_admin_can_apply_logo_suggestion(admin_client, db, seeded_data):
+    logo_url = "https://example.test/new-logo.png"
+    suggestion = db.org_edit_suggestions.find_one({"_id": seeded_data["org_suggestion_id"]})
+    db.org_edit_suggestions.update_one(
+        {"_id": suggestion["_id"]},
+        {"$set": {"fields.logo": logo_url}},
+    )
+
+    response = admin_client.post(
+        f"/admin/organization/{seeded_data['org_id']}/suggestion/{suggestion['_id']}/apply",
+        data={"apply_fields": ["logo"]},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    organization = db.organizations.find_one({"_id": seeded_data["org_id"]})
+    assert organization["logo"] == logo_url


### PR DESCRIPTION
## Summary
- add logo URL suggestions to the public organization fill page
- store logo in the same suggestion fields flow as name, website, email, and social links
- show logo previews in admin suggestion review before applying selected fields
- include logo in legacy suggestion normalization

## Validation
- git diff --check
- .venv/bin/python - <<'PY'
from pathlib import Path
from jinja2 import Environment
for path in [
    'mielenosoitukset_fi/templates/organizations/fill_info.html',
    'mielenosoitukset_fi/templates/admin_V2/organizations/review_suggestion.html',
]:
    Environment().parse(Path(path).read_text())
    print(f'{path} parses')
PY
- .venv/bin/python -m pytest tests/test_organization_fill_page.py tests/test_org_logo_referrer_policy.py -q
- .venv/bin/python -m pytest tests/test_route_smoke.py::test_reset_client_session_restores_authentication_after_logout -q