### PR TITLE
Avoid None in organization suggestion fields

### DIFF
--- a/mielenosoitukset_fi/templates/organizations/fill_info.html
+++ b/mielenosoitukset_fi/templates/organizations/fill_info.html
@@ -581,28 +581,28 @@
           <div class="form-grid">
             <div class="form-group">
               <label for="name"><i class="fa-solid fa-building"></i> {{ _('Järjestön nimi') }}</label>
-              <input type="text" id="name" name="name" value="{{ organization.name }}" required>
+              <input type="text" id="name" name="name" value="{{ organization.name or '' }}" required>
             </div>
 
             <div class="form-group">
               <label for="website"><i class="fa-solid fa-globe"></i> {{ _('Verkkosivusto') }}</label>
-              <input type="url" id="website" name="website" placeholder="https://esimerkki.fi" value="{{ organization.website }}">
+              <input type="url" id="website" name="website" placeholder="https://esimerkki.fi" value="{{ organization.website or '' }}">
             </div>
 
             <div class="form-group">
               <label for="logo"><i class="fa-solid fa-image"></i> {{ _('Logo URL') }}</label>
-              <input type="url" id="logo" name="logo" placeholder="https://esimerkki.fi/logo.png" value="{{ organization.logo }}">
+              <input type="url" id="logo" name="logo" placeholder="https://esimerkki.fi/logo.png" value="{{ organization.logo or '' }}">
             </div>
 
             <div class="form-group full-width">
               <label for="description"><i class="fa-solid fa-align-left"></i> {{ _('Kuvaus') }}</label>
               <textarea id="description" name="description" rows="5"
-                placeholder="{{ _('Kuvaile järjestön toimintaa, tavoitteita ja arvoja...') }}">{{ organization.description }}</textarea>
+                placeholder="{{ _('Kuvaile järjestön toimintaa, tavoitteita ja arvoja...') }}">{{ organization.description or '' }}</textarea>
             </div>
 
             <div class="form-group full-width">
               <label for="email"><i class="fa-solid fa-envelope"></i> {{ _('Sähköposti') }}</label>
-              <input type="email" id="email" name="email" placeholder="info@esimerkki.fi" value="{{ organization.email }}">
+              <input type="email" id="email" name="email" placeholder="info@esimerkki.fi" value="{{ organization.email or '' }}">
             </div>
           </div>
         </div>

--- a/tests/test_organization_fill_page.py
+++ b/tests/test_organization_fill_page.py
@@ -8,6 +8,7 @@ def test_organization_fill_page_uses_public_org_visual_shell(client, seeded_data
     assert "Nykyiset tiedot" in html
     assert "Täydennä järjestön tietoja" in html
     assert 'name="logo"' in html
+    assert 'value="None"' not in html
     assert "Test Organization" in html
 
 


### PR DESCRIPTION
## Summary
- render missing organization suggestion form values as empty strings instead of None
- cover the logo field regression in the fill page test

## Validation
- git diff --check
- .venv/bin/python -m pytest tests/test_organization_fill_page.py tests/test_org_logo_referrer_policy.py -q
- .venv/bin/python - <<'PY'
from pathlib import Path
from jinja2 import Environment
Environment().parse(Path('mielenosoitukset_fi/templates/organizations/fill_info.html').read_text())
print('fill_info.html parses')
PY