### PR TITLE
Fix pending demo admin reminder emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support cases now use a cleaner admin list/detail presentation with stable status labels, real internal-note submission, clearer cancellation and error-report context, and less brittle per-case rendering.
 
 ### Fixed
+* Pending demonstration admin reminder emails now resume after the 24-hour reminder window instead of being blocked forever by an older completed notification job.
 * Demonstration detail Mastodon/X share menu now uses Bootstrap dropdown markup with hover and focus fallbacks so the X option can open across browsers.
 * Demonstration detail Mastodon/X share menu now uses a native dropdown control so the X option opens reliably without custom page JavaScript.
 * Demonstration detail Mastodon/X share dropdown now works as a split button: the Mastodon side opens Mastodon sharing and the arrow opens the X option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 * Pending demonstration admin reminder emails now resume after the 24-hour reminder window instead of being blocked forever by an older completed notification job.
+* Recurring demonstration generation now preserves cancelled break-date child demos instead of deleting them as invalid generated children.
 * Demonstration detail Mastodon/X share menu now uses Bootstrap dropdown markup with hover and focus fallbacks so the X option can open across browsers.
 * Demonstration detail Mastodon/X share menu now uses a native dropdown control so the X option opens reliably without custom page JavaScript.
 * Demonstration detail Mastodon/X share dropdown now works as a split button: the Mastodon side opens Mastodon sharing and the arrow opens the X option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Streamlined `_path_value` logic in test route smoke tests and enhanced payload generation for better test coverage and maintainability.
 
 ### Added
+* Admin demonstration listing can now filter by event year, required hashtag, and missing hashtag while general search also matches tags and descriptions.
 * Organization information suggestion pages now accept logo URL suggestions, and admin suggestion review shows logo previews before applying selected fields.
 * Profile follower and following counts now open user lists so visitors can view and navigate to those profiles.
 * Recurring demonstration editors can now recalculate parent coordinates from the saved address/city and bulk-copy latitude/longitude to generated child demonstrations with the location fields.

--- a/mielenosoitukset_fi/admin/admin_demo_bp.py
+++ b/mielenosoitukset_fi/admin/admin_demo_bp.py
@@ -345,6 +345,33 @@ def _deduplicate_demos(demo_list):
     return unique
 
 
+def _split_admin_filter_tokens(raw_value: str) -> list[str]:
+    tokens = []
+    for part in re.split(r"[,\s]+", raw_value or ""):
+        token = part.strip().lstrip("#")
+        if token:
+            tokens.append(token)
+    return tokens
+
+
+def _tag_exact_filter(tag: str):
+    return {"$regex": rf"^#?{re.escape(tag)}$", "$options": "i"}
+
+
+def _demo_text_search_clause(search_query: str):
+    escaped_query = re.escape(search_query)
+    regex_filter = {"$regex": escaped_query, "$options": "i"}
+    return {
+        "$or": [
+            {"title": regex_filter},
+            {"city": regex_filter},
+            {"address": regex_filter},
+            {"description": regex_filter},
+            {"tags": regex_filter},
+        ]
+    }
+
+
 def _json_safe(value):
     if isinstance(value, dict):
         return {k: _json_safe(v) for k, v in value.items()}
@@ -1380,6 +1407,9 @@ from bson.objectid import ObjectId as BsonObjectId
 def demo_control():
     # --- Query parameters ---
     search_query = (request.args.get("search") or "").strip()
+    year_filter = (request.args.get("year") or "").strip()
+    tag_filter = (request.args.get("tag") or "").strip()
+    missing_tag_filter = (request.args.get("missing_tag") or "").strip()
     approved_only = (request.args.get("approved") or "false").lower() == "true"
     show_hidden = (request.args.get("show_hidden") or "false").lower() == "true"
     show_past_param = (request.args.get("show_past") or "all").lower()
@@ -1411,7 +1441,22 @@ def demo_control():
         filter_clauses.append({"approved": True})
 
     if search_query:
-        filter_clauses.append({"title": {"$regex": search_query, "$options": "i"}})
+        filter_clauses.append(_demo_text_search_clause(search_query))
+
+    if year_filter:
+        if year_filter.isdigit() and len(year_filter) == 4:
+            filter_clauses.append({"date": {"$regex": f"^{re.escape(year_filter)}-"}})
+        else:
+            flash_message(_("Vuosisuodatin jätettiin huomiotta, koska sen pitää olla muodossa VVVV."), "warning")
+            year_filter = ""
+
+    for required_tag in _split_admin_filter_tokens(tag_filter):
+        filter_clauses.append({"tags": {"$elemMatch": _tag_exact_filter(required_tag)}})
+
+    for excluded_tag in _split_admin_filter_tokens(missing_tag_filter):
+        filter_clauses.append(
+            {"tags": {"$not": {"$elemMatch": _tag_exact_filter(excluded_tag)}}}
+        )
 
     # Permissions
     if not current_user.global_admin:
@@ -1512,6 +1557,9 @@ def demo_control():
         f"{_ADMIN_TEMPLATE_FOLDER}demonstrations/dashboard.html",
         demonstrations=demos,
         search_query=search_query,
+        year_filter=year_filter,
+        tag_filter=tag_filter,
+        missing_tag_filter=missing_tag_filter,
         approved_status=approved_only,
         show_hidden=show_hidden,
         show_cancelled=show_cancelled,

--- a/mielenosoitukset_fi/scripts/process_submission_notifications.py
+++ b/mielenosoitukset_fi/scripts/process_submission_notifications.py
@@ -48,13 +48,23 @@ def _send_messages(messages: List[Dict[str, Any]]) -> int:
     return sent
 
 
-def _pending_admin_job_exists(queue, demo_id: ObjectId) -> bool:
+def _pending_admin_job_exists(queue, demo_id: ObjectId, cutoff: datetime) -> bool:
     return bool(
         queue.find_one(
             {
                 "demo_id": demo_id,
                 "marks_admin_contact": True,
-                "status": {"$in": ["pending", "processing", "completed"]},
+                "$or": [
+                    {"status": {"$in": ["pending", "processing"]}},
+                    {
+                        "status": "completed",
+                        "$or": [
+                            {"processed_at": {"$gte": cutoff}},
+                            {"updated_at": {"$gte": cutoff}},
+                            {"created_at": {"$gte": cutoff}},
+                        ],
+                    },
+                ],
             }
         )
     )
@@ -96,7 +106,7 @@ def _enqueue_admin_reminders(db, max_to_enqueue: int = 50):
     created = 0
     for demo in candidates:
         demo_id = demo["_id"]
-        if _pending_admin_job_exists(queue, demo_id):
+        if _pending_admin_job_exists(queue, demo_id, cutoff):
             continue
 
         if demo.get("rejected"):

--- a/mielenosoitukset_fi/scripts/repeat_v2.py
+++ b/mielenosoitukset_fi/scripts/repeat_v2.py
@@ -330,6 +330,7 @@ def remove_invalid_child_demonstrations(parent_demo: dict, valid_dates: list[dat
     """
     # Ensure valid_dates are date objects (they may have been produced by calculate_next_dates)
     valid_date_strings = {d.strftime("%Y-%m-%d") for d in valid_dates}
+    break_date_strings = _break_date_strings(parent_demo)
     child_demos = demonstrations_collection.find({"parent": parent_demo["_id"]})
     freezed_children = _frozen_child_ids(parent_demo)
 
@@ -349,6 +350,16 @@ def remove_invalid_child_demonstrations(parent_demo: dict, valid_dates: list[dat
             demo_date_dt = datetime.strptime(demo["date"], "%Y-%m-%d").date()
         except Exception:
             logger.warning(f"Invalid date format for child demo {demo['_id']}: {demo['date']}")
+            continue
+
+        if demo["date"] in break_date_strings and demo.get("cancelled") is True:
+            runtime_actions.append({
+                "action": "break_skip",
+                "document": demo,
+                "reason": "recurring break date",
+                "timestamp": datetime.now(),
+                "executed_by": "system"
+            })
             continue
 
         # Normalize _created_until to date if datetime passed

--- a/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
+++ b/mielenosoitukset_fi/templates/admin_V2/demonstrations/dashboard.html
@@ -75,7 +75,8 @@
     box-shadow: 0 18px 28px rgba(37, 99, 235, 0.45);
   }
 
-  .filter-select {
+  .filter-select,
+  .filter-input {
     border-radius: 12px;
     border: 1px solid light-dark(#d2d8e5, rgba(255,255,255,0.12));
     background: light-dark(#ffffff, #1d2533);
@@ -86,7 +87,8 @@
     box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
   }
 
-  .filter-select:focus {
+  .filter-select:focus,
+  .filter-input:focus {
     outline: none;
     border-color: #2563eb;
     box-shadow: 0 12px 26px rgba(37, 99, 235, 0.18);
@@ -111,6 +113,17 @@
   .filter-field label {
     font-weight: 500;
     color: light-dark(#1f2937, #e5e7f4);
+  }
+
+  .filter-apply-button {
+    border: none;
+    border-radius: 12px;
+    padding: 0.58rem 1rem;
+    background: light-dark(#111827, #edf2ff);
+    color: light-dark(#ffffff, #111827);
+    font-weight: 600;
+    min-height: 42px;
+    align-self: end;
   }
 
   .actions-cell {
@@ -431,6 +444,22 @@
       <form method="GET" action="{{ url_for('admin_demo.demo_control') }}" class="filter-form" id="dashboard-filter-form">
         <input type="hidden" name="search" id="filter-search-hidden" value="{{ search_query }}">
         <div class="filter-field">
+          <label for="year">{{ _('Vuosi') }}</label>
+          <input type="text" inputmode="numeric" pattern="[0-9]{4}" name="year" id="year" class="filter-input"
+            placeholder="2026" value="{{ year_filter }}">
+        </div>
+
+        <div class="filter-field">
+          <label for="tag">{{ _('Sisältää tunnisteen') }}</label>
+          <input type="text" name="tag" id="tag" class="filter-input" placeholder="#pride" value="{{ tag_filter }}">
+        </div>
+
+        <div class="filter-field">
+          <label for="missing_tag">{{ _('Puuttuva tunniste') }}</label>
+          <input type="text" name="missing_tag" id="missing_tag" class="filter-input" placeholder="#pride" value="{{ missing_tag_filter }}">
+        </div>
+
+        <div class="filter-field">
           <label for="approved">{{ _('Näytä vain hyväksytyt mielenosoitukset:') }}</label>
           <select name="approved" id="approved" class="filter-select" onchange="this.form.submit()">
             <option value="true" {% if approved_status %}selected{% endif %}>{{ _('Kyllä') }}</option>
@@ -462,6 +491,8 @@
             <option value="true" {% if show_cancelled %}selected{% endif %}>{{ _('Kyllä') }}</option>
           </select>
         </div>
+
+        <button type="submit" class="filter-apply-button">{{ _('Suodata') }}</button>
       </form>
     </div>
     <script>
@@ -514,6 +545,7 @@
           } else {
             url.searchParams.delete('search');
           }
+          url.searchParams.delete('page');
           window.location.href = url.toString();
         };
 
@@ -596,7 +628,7 @@
 </tr>
 
 {% for demo in pending %}
-<tr id="demo-{{ demo._id }}" class="needs-attention" data-search-row="true" data-search-text="{{ (demo.title ~ ' ' ~ demo.city ~ ' ' ~ demo.date ~ ' ' ~ (demo.address or ''))|lower }}">
+<tr id="demo-{{ demo._id }}" class="needs-attention" data-search-row="true" data-search-text="{{ (demo.title ~ ' ' ~ demo.city ~ ' ' ~ demo.date ~ ' ' ~ (demo.address or '') ~ ' ' ~ ((demo.tags or [])|join(' ')))|lower }}">
 
     {% if current_user.has_permission("EDIT_DEMO") %}
     <td class="select-col">
@@ -756,7 +788,7 @@
 </tr>
 
 {% for demo in approved %}
-<tr id="demo-{{ demo._id }}" data-search-row="true" data-search-text="{{ (demo.title ~ ' ' ~ demo.city ~ ' ' ~ demo.date ~ ' ' ~ (demo.address or ''))|lower }}">
+<tr id="demo-{{ demo._id }}" data-search-row="true" data-search-text="{{ (demo.title ~ ' ' ~ demo.city ~ ' ' ~ demo.date ~ ' ' ~ (demo.address or '') ~ ' ' ~ ((demo.tags or [])|join(' ')))|lower }}">
 
     {% if current_user.has_permission("EDIT_DEMO") %}
     <td class="select-col">
@@ -901,7 +933,7 @@
         {# Previous button #}
         {% if prev_page %}
         <li class="page-item">
-          <a class="page-link" href="?page={{ prev_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}"
+          <a class="page-link" href="?page={{ prev_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}&year={{ year_filter|urlencode }}&tag={{ tag_filter|urlencode }}&missing_tag={{ missing_tag_filter|urlencode }}&approved={{ 'true' if approved_status else 'false' }}&show_past={{ show_past_filter }}&show_hidden={{ 'true' if show_hidden else 'false' }}&show_cancelled={{ 'true' if show_cancelled else 'false' }}"
             aria-label="Previous">
             <i class="fas fa-angle-left"></i> {{ _('Edellinen') }}
           </a>
@@ -920,7 +952,7 @@
         {# Next button #}
         {% if next_page %}
         <li class="page-item">
-          <a class="page-link" href="?page={{ next_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}"
+          <a class="page-link" href="?page={{ next_page }}&per_page={{ per_page }}&search={{ search_query|urlencode }}&year={{ year_filter|urlencode }}&tag={{ tag_filter|urlencode }}&missing_tag={{ missing_tag_filter|urlencode }}&approved={{ 'true' if approved_status else 'false' }}&show_past={{ show_past_filter }}&show_hidden={{ 'true' if show_hidden else 'false' }}&show_cancelled={{ 'true' if show_cancelled else 'false' }}"
             aria-label="Next">
             {{ _('Seuraava') }} <i class="fas fa-angle-right"></i>
           </a>

--- a/tests/test_admin_demo_views.py
+++ b/tests/test_admin_demo_views.py
@@ -1,3 +1,6 @@
+from bson import ObjectId
+
+
 def test_create_demo_hides_edit_only_controls(admin_client):
     response = admin_client.get("/admin/demo/create_demo")
 
@@ -17,3 +20,102 @@ def test_edit_demo_shows_edit_only_controls(admin_client, seeded_data):
     assert "Luo kopio mielenosoituksesta" in page
     assert 'class="editor-save-bar"' in page
     assert 'class="editor-section-nav"' in page
+
+
+def test_demo_dashboard_filters_year_text_and_missing_tag(admin_client, db, seeded_data):
+    db.demonstrations.insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "title": "Pride support march",
+                "description": "Pride visibility event.",
+                "date": "2026-06-28",
+                "city": "Helsinki",
+                "address": "Kaivokatu 1",
+                "approved": True,
+                "hide": False,
+                "rejected": False,
+                "cancelled": False,
+                "tags": ["equality"],
+                "editors": [seeded_data["user_id"]],
+            },
+            {
+                "_id": ObjectId(),
+                "title": "Pride tagged march",
+                "description": "Already categorized.",
+                "date": "2026-06-29",
+                "city": "Helsinki",
+                "address": "Mannerheimintie 1",
+                "approved": True,
+                "hide": False,
+                "rejected": False,
+                "cancelled": False,
+                "tags": ["#pride"],
+                "editors": [seeded_data["user_id"]],
+            },
+            {
+                "_id": ObjectId(),
+                "title": "Pride old march",
+                "description": "Wrong year.",
+                "date": "2025-06-29",
+                "city": "Helsinki",
+                "address": "Mannerheimintie 1",
+                "approved": True,
+                "hide": False,
+                "rejected": False,
+                "cancelled": False,
+                "tags": ["equality"],
+                "editors": [seeded_data["user_id"]],
+            },
+        ]
+    )
+
+    response = admin_client.get("/admin/demo/?search=pride&year=2026&missing_tag=pride")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Pride support march" in page
+    assert "Pride tagged march" not in page
+    assert "Pride old march" not in page
+
+
+def test_demo_dashboard_filters_by_required_tag(admin_client, db, seeded_data):
+    db.demonstrations.insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "title": "Tagged Pride demo",
+                "description": "Has the tag.",
+                "date": "2026-06-28",
+                "city": "Helsinki",
+                "address": "Kaivokatu 1",
+                "approved": True,
+                "hide": False,
+                "rejected": False,
+                "cancelled": False,
+                "tags": ["#pride"],
+                "editors": [seeded_data["user_id"]],
+            },
+            {
+                "_id": ObjectId(),
+                "title": "Untagged Pride demo",
+                "description": "Does not have the tag.",
+                "date": "2026-06-29",
+                "city": "Helsinki",
+                "address": "Mannerheimintie 1",
+                "approved": True,
+                "hide": False,
+                "rejected": False,
+                "cancelled": False,
+                "tags": ["equality"],
+                "editors": [seeded_data["user_id"]],
+            },
+        ]
+    )
+
+    response = admin_client.get("/admin/demo/?tag=pride")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Tagged Pride demo" in page
+    assert "Untagged Pride demo" not in page

--- a/tests/test_background_jobs.py
+++ b/tests/test_background_jobs.py
@@ -1,5 +1,5 @@
 from mielenosoitukset_fi.utils.time_utils import utcnow
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from bson import ObjectId
 from pymongo import DeleteMany, DeleteOne, InsertOne, ReplaceOne, UpdateMany, UpdateOne
@@ -516,3 +516,134 @@ def test_process_submit_notifications_marks_job_error_when_delivery_fails(db, mo
 
     demo = db.demonstrations.find_one({"_id": demo_id})
     assert demo.get("admin_notification_last_sent_at") is None
+
+
+@pytest.mark.integration
+@pytest.mark.jobs
+def test_admin_pending_reminder_ignores_old_completed_notifications(db, monkeypatch):
+    from mielenosoitukset_fi.scripts import process_submission_notifications as script
+
+    db.demonstrations.delete_many({})
+    db.submitters.delete_many({})
+    db.demo_notifications_queue.delete_many({})
+
+    demo_id = ObjectId()
+    old_time = utcnow() - timedelta(hours=25)
+    future_date = (utcnow().date() + timedelta(days=30)).strftime("%Y-%m-%d")
+    demo = _demo_doc(demo_id, "Still Waiting For Moderation")
+    demo.update(
+        {
+            "date": future_date,
+            "created_datetime": old_time,
+            "admin_notification_last_sent_at": old_time,
+        }
+    )
+    db.demonstrations.insert_one(demo)
+    db.submitters.insert_one(
+        {
+            "_id": ObjectId(),
+            "demonstration_id": demo_id,
+            "submitter_name": "Submitter Example",
+            "submitter_email": "submitter@example.test",
+            "submitter_role": "organizer",
+        }
+    )
+    db.demo_notifications_queue.insert_one(
+        {
+            "_id": ObjectId(),
+            "demo_id": demo_id,
+            "status": "completed",
+            "created_at": old_time,
+            "processed_at": old_time,
+            "marks_admin_contact": True,
+            "notification_type": "initial_submission",
+        }
+    )
+
+    monkeypatch.setattr(
+        script,
+        "generate_demo_approve_link",
+        lambda demo_id: f"https://example.test/{demo_id}/approve",
+    )
+    monkeypatch.setattr(
+        script,
+        "generate_demo_preview_link",
+        lambda demo_id: f"https://example.test/{demo_id}/preview",
+    )
+    monkeypatch.setattr(
+        script,
+        "generate_demo_reject_link",
+        lambda demo_id: f"https://example.test/{demo_id}/reject",
+    )
+
+    script._enqueue_admin_reminders(db)
+
+    reminder = db.demo_notifications_queue.find_one(
+        {"demo_id": demo_id, "notification_type": "admin_pending_reminder"}
+    )
+    assert reminder is not None
+    assert reminder["status"] == "pending"
+    assert (
+        reminder["messages"][0]["subject"]
+        == "Muistutus: Still Waiting For Moderation odottaa hyväksyntää"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.jobs
+def test_admin_pending_reminder_keeps_recent_completed_notifications_as_blockers(db, monkeypatch):
+    from mielenosoitukset_fi.scripts import process_submission_notifications as script
+
+    db.demonstrations.delete_many({})
+    db.submitters.delete_many({})
+    db.demo_notifications_queue.delete_many({})
+
+    demo_id = ObjectId()
+    recent_time = utcnow() - timedelta(hours=2)
+    old_time = utcnow() - timedelta(hours=25)
+    future_date = (utcnow().date() + timedelta(days=30)).strftime("%Y-%m-%d")
+    demo = _demo_doc(demo_id, "Recently Notified Moderation Demo")
+    demo.update(
+        {
+            "date": future_date,
+            "created_datetime": old_time,
+            "admin_notification_last_sent_at": old_time,
+        }
+    )
+    db.demonstrations.insert_one(demo)
+    db.demo_notifications_queue.insert_one(
+        {
+            "_id": ObjectId(),
+            "demo_id": demo_id,
+            "status": "completed",
+            "created_at": recent_time,
+            "processed_at": recent_time,
+            "marks_admin_contact": True,
+            "notification_type": "admin_pending_reminder",
+        }
+    )
+
+    monkeypatch.setattr(
+        script,
+        "generate_demo_approve_link",
+        lambda demo_id: f"https://example.test/{demo_id}/approve",
+    )
+    monkeypatch.setattr(
+        script,
+        "generate_demo_preview_link",
+        lambda demo_id: f"https://example.test/{demo_id}/preview",
+    )
+    monkeypatch.setattr(
+        script,
+        "generate_demo_reject_link",
+        lambda demo_id: f"https://example.test/{demo_id}/reject",
+    )
+
+    script._enqueue_admin_reminders(db)
+
+    assert (
+        db.demo_notifications_queue.count_documents(
+            {"demo_id": demo_id, "notification_type": "admin_pending_reminder"}
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary
- make completed admin notification jobs block new pending-demo reminders only inside the 24-hour reminder window
- keep pending and processing admin notification jobs as duplicate blockers
- preserve cancelled recurring break-date children instead of deleting them during recurring cleanup
- add admin demo listing filters for year, required hashtag, and missing hashtag; general search now also checks descriptions and tags
- add regression coverage for notification reminders and admin listing tag/year filters

## Tests
- .venv/bin/python -m pytest tests/test_background_jobs.py -k "process_submit_notifications or admin_pending_reminder"
- .venv/bin/python -m pytest tests/test_background_jobs.py
- .venv/bin/python -m pytest tests/test_admin_recu_demo.py::test_recurring_runner_skips_break_dates_and_cancels_existing_children tests/test_background_jobs.py
- .venv/bin/python -m pytest tests/test_admin_demo_views.py tests/test_admin_recu_demo.py::test_recurring_runner_skips_break_dates_and_cancels_existing_children tests/test_background_jobs.py
- .venv/bin/python -m pytest