### PR TITLE
Complete public sitemap and today city pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Streamlined `_path_value` logic in test route smoke tests and enhanced payload generation for better test coverage and maintainability.
 
 ### Added
+* Added polished public city and today views so visitors can browse demonstrations by city, see Finland-wide demonstrations today, and open city-specific today pages from the city hub and sitemap.
 * Added public and admin city management so enabled contact-person cities appear from the top navigation, can be toggled in admin, and remain ready for city-scoped user permissions.
 * Admin demonstration listing can now filter by event year, required hashtag, and missing hashtag while general search also matches tags and descriptions.
 * Organization information suggestion pages now accept logo URL suggestions, and admin suggestion review shows logo previews before applying selected fields.

--- a/mielenosoitukset_fi/basic_routes.py
+++ b/mielenosoitukset_fi/basic_routes.py
@@ -11,6 +11,7 @@ from mielenosoitukset_fi.utils.time_utils import utcnow
 from datetime import datetime, date, timedelta
 from flask_babel import _, format_date
 from flask import (
+    Response,
     redirect,
     render_template,
     send_file,
@@ -104,6 +105,33 @@ SUBMIT_ERROR_CODES = {
 
 PANIC_MODE = False  # Forced maintenance mode for security remediation
 
+CITY_INESSIVE_OVERRIDES = {
+    "helsinki": "Helsingissä",
+    "tampere": "Tampereella",
+    "turku": "Turussa",
+    "kokkola": "Kokkolassa",
+    "porvoo": "Porvoossa",
+    "kuopio": "Kuopiossa",
+    "pieksamaki": "Pieksämäellä",
+    "jyvaskyla": "Jyväskylässä",
+    "pietarsaari": "Pietarsaaressa",
+    "vaasa": "Vaasassa",
+    "seinajoki": "Seinäjoella",
+    "lappeenranta": "Lappeenrannassa",
+    "sastamala": "Sastamalassa",
+    "savonlinna": "Savonlinnassa",
+    "oulu": "Oulussa",
+    "rovaniemi": "Rovaniemellä",
+    "joensuu": "Joensuussa",
+    "varkaus": "Varkaudessa",
+    "kotka": "Kotkassa",
+    "pori": "Porissa",
+    "kemi": "Kemissä",
+    "hamina": "Haminassa",
+    "kajaani": "Kajaanissa",
+    "raasepori": "Raaseporissa",
+}
+
 
 def _normalize_tag_value(tag):
     if tag is None:
@@ -118,6 +146,32 @@ def _normalize_tag_list(raw_tags):
         if cleaned:
             normalized.append(cleaned)
     return normalized
+
+
+def _city_display_name(raw_city):
+    city_key = normalize_city_key(raw_city)
+    return CITY_KEY_TO_NAME.get(city_key) or str(raw_city or "").strip()
+
+
+def _city_inessive_phrase(city_name):
+    city_key = normalize_city_key(city_name)
+    return CITY_INESSIVE_OVERRIDES.get(city_key) or f"kaupungissa {city_name}"
+
+
+def _demo_detail_identifier(demo):
+    return demo.get("slug") or demo.get("running_number") or str(demo.get("_id"))
+
+
+def _today_demo_query(city_name=None):
+    query = {**DEMO_FILTER, "date": date.today().isoformat()}
+    if city_name:
+        city_display = _city_display_name(city_name)
+        city_key = normalize_city_key(city_display)
+        query["$or"] = [
+            {"city_key": city_key},
+            {"city": {"$regex": f"^{re.escape(city_display)}$", "$options": "i"}},
+        ]
+    return query
 
 
 def _normalize_route_points(raw_route):
@@ -758,9 +812,6 @@ def init_routes(app):
         return send_from_directory(api_dir, "api.yaml", mimetype="application/yaml")
 
         
-    from flask import Response, url_for
-    import xml.etree.ElementTree as ET
-    from flask import Flask, Response, url_for
     import xml.etree.ElementTree as ET
 
     @app.route("/sitemap.xml", methods=["GET"])
@@ -800,17 +851,27 @@ def init_routes(app):
                 {"loc": "index"},
                 {"loc": "submit"},
                 {"loc": "demonstrations"},
+                {"loc": "today_demos"},
+                {"loc": "cities"},
+                {"loc": "calendar_month_view"},
+                {"loc": "calendar_year_view", "values": {"year": date.today().year}},
+                {"loc": "public_guides"},
                 {"loc": "info"},
+                {"loc": "terms"},
                 {"loc": "privacy"},
                 {"loc": "contact"},
+                {"loc": "api_docs"},
+                {"loc": "pride_nakyvaksi"},
                 {"loc": "campaign.index"},
             ]
 
             # Helper to add url + optional alternate links
-            def _add_url_with_alternates(parent, endpoint, **values):
+            def _add_url_with_alternates(parent, endpoint, lastmod=None, **values):
                 url_el = ET.SubElement(parent, "url")
                 loc_el = ET.SubElement(url_el, "loc")
                 loc_el.text = url_for(endpoint, _external=True, **values)
+                if lastmod:
+                    ET.SubElement(url_el, "lastmod").text = lastmod
                 if include_alternates:
                     for lang in locales:
                         ET.SubElement(
@@ -827,7 +888,7 @@ def init_routes(app):
 
             # Add static routes
             for r in static_routes:
-                _add_url_with_alternates(urlset, r["loc"])
+                _add_url_with_alternates(urlset, r["loc"], **r.get("values", {}))
 
             # Demonstration URLs: limit to demos in reasonable date window
             query_filter = DEMO_FILTER.copy()
@@ -835,20 +896,20 @@ def init_routes(app):
             end_date = (date.today() + timedelta(days=365 * 2)).strftime("%Y-%m-%d")
             query_filter["date"] = {"$gte": start_date, "$lte": end_date}
 
-            def _format_lastmod_for_demo(demo):
+            def _format_lastmod_for_doc(doc):
                 """
-                Determine a suitable lastmod value for a demo.
+                Determine a suitable lastmod value for a Mongo-style document.
 
                 The function prefers explicit timestamp fields (updated_at, modified_at, ...)
-                and falls back to the demo.date field. When an explicit timestamp is found
+                and falls back to the document date field. When an explicit timestamp is found
                 it is normalized to a date string in "YYYY-MM-DD" form. If only a date
                 string is available, it is returned as-is. Returns None if no sensible
                 value is found.
 
                 Parameters
                 ----------
-                demo : dict
-                    Demonstration document.
+                doc : dict
+                    Mongo-style document.
 
                 Returns
                 -------
@@ -911,15 +972,15 @@ def init_routes(app):
 
                 # Prefer explicit timestamp-like fields and always normalize to YYYY-MM-DD when possible
                 for key in candidates:
-                    v = demo.get(key)
+                    v = doc.get(key)
                     if not v:
                         continue
                     date_str = _to_date_str(v)
                     if date_str:
                         return date_str
 
-                # Fallback to demo['date']
-                v = demo.get("date")
+                # Fallback to doc['date']
+                v = doc.get("date")
                 if v:
                     date_str = _to_date_str(v)
                     if date_str:
@@ -928,6 +989,58 @@ def init_routes(app):
                     if isinstance(v, str) and v.strip():
                         return v
                 return None
+
+            demo_city_keys = set()
+            for row in demonstrations_collection.aggregate(
+                [
+                    {"$match": {**DEMO_FILTER, "city": {"$exists": True, "$ne": ""}}},
+                    {"$group": {"_id": {"city_key": "$city_key", "city": "$city"}}},
+                ]
+            ):
+                raw = row.get("_id") or {}
+                city_key = raw.get("city_key") or normalize_city_key(raw.get("city"))
+                if city_key in CITY_KEY_TO_NAME:
+                    demo_city_keys.add(city_key)
+
+            enabled_city_keys_for_sitemap = {
+                normalize_city_key(city)
+                for city in enabled_city_names(mongo)
+                if normalize_city_key(city) in CITY_KEY_TO_NAME
+            }
+            for city_key in sorted(
+                enabled_city_keys_for_sitemap | demo_city_keys,
+                key=lambda key: CITY_KEY_TO_NAME[key],
+            ):
+                _add_url_with_alternates(
+                    urlset,
+                    "city_demos",
+                    city=CITY_KEY_TO_NAME[city_key].lower(),
+                )
+                _add_url_with_alternates(
+                    urlset,
+                    "today_city_demos",
+                    city=CITY_KEY_TO_NAME[city_key].lower(),
+                )
+
+            for org_doc in mongo.organizations.find({}).sort("name", 1):
+                _add_url_with_alternates(
+                    urlset,
+                    "org",
+                    lastmod=_format_lastmod_for_doc(org_doc),
+                    org_id=str(org_doc["_id"]),
+                )
+
+            tag_pipeline = [
+                {"$match": DEMO_FILTER},
+                {"$unwind": "$tags"},
+                {"$match": {"tags": {"$type": "string", "$ne": ""}}},
+                {"$group": {"_id": "$tags"}},
+                {"$sort": {"_id": 1}},
+            ]
+            for row in demonstrations_collection.aggregate(tag_pipeline):
+                tag_name = str(row.get("_id") or "").strip().lstrip("#")
+                if tag_name:
+                    _add_url_with_alternates(urlset, "tag_detail", tag_name=tag_name)
 
             for demo in demonstrations_collection.find(query_filter):
                 demo_identifier = (
@@ -942,7 +1055,7 @@ def init_routes(app):
                 )
 
                 # lastmod for the demonstration if available
-                lastmod_val = _format_lastmod_for_demo(demo)
+                lastmod_val = _format_lastmod_for_doc(demo)
                 if lastmod_val:
                     ET.SubElement(url_el, "lastmod").text = lastmod_val
 
@@ -1740,7 +1853,7 @@ def init_routes(app):
         demo_city_keys = set()
         for row in demonstrations_collection.aggregate(
             [
-                {"$match": {"city": {"$exists": True, "$ne": ""}}},
+                {"$match": {**DEMO_FILTER, "city": {"$exists": True, "$ne": ""}}},
                 {"$group": {"_id": {"city_key": "$city_key", "city": "$city"}}},
             ]
         ):
@@ -1766,9 +1879,61 @@ def init_routes(app):
                     ],
                 }
             )
-            city_rows.append({"key": city_key, "name": city_name, "demo_count": demo_count})
+            today_count = demonstrations_collection.count_documents(_today_demo_query(city_name))
+            city_rows.append(
+                {
+                    "key": city_key,
+                    "name": city_name,
+                    "phrase": _city_inessive_phrase(city_name),
+                    "demo_count": demo_count,
+                    "today_count": today_count,
+                }
+            )
 
         return render_template("cities.html", cities=city_rows)
+
+    def _render_today_demonstrations(city=None):
+        city_name = _city_display_name(city) if city else None
+        if city is not None and not city_name:
+            abort(404)
+
+        query = _today_demo_query(city_name)
+        demos = list(demonstrations_collection.find(query).sort("start_time", ASCENDING))
+        for demo in demos:
+            demo["detail_identifier"] = _demo_detail_identifier(demo)
+
+        today_value = date.today()
+        if city_name:
+            title = f"Mielenosoitukset {_city_inessive_phrase(city_name)} tänään"
+            description = (
+                f"Tänään järjestettävät mielenosoitukset {_city_inessive_phrase(city_name)}. "
+                "Katso ajat, paikat ja aiheet yhdestä näkymästä."
+            )
+        else:
+            title = "Mielenosoitukset Suomessa tänään"
+            description = (
+                "Tänään järjestettävät mielenosoitukset Suomessa. "
+                "Katso päivän tapahtumat, kaupungit, ajat ja aiheet yhdestä näkymästä."
+            )
+
+        return render_template(
+            "today_demos.html",
+            city_name=city_name,
+            city_phrase=_city_inessive_phrase(city_name) if city_name else None,
+            date_value=today_value,
+            date_label=format_date(today_value, format="long"),
+            demonstrations=demos,
+            page_title=title,
+            page_description=description,
+        )
+
+    @app.route("/mielenosoitukset-tanaan")
+    def today_demos():
+        return _render_today_demonstrations()
+
+    @app.route("/city/<city>/tanaan")
+    def today_city_demos(city):
+        return _render_today_demonstrations(city=city)
 
 
     @app.route("/city/<city>") # TODO: lets make this use the api too

--- a/mielenosoitukset_fi/templates/cities.html
+++ b/mielenosoitukset_fi/templates/cities.html
@@ -1,71 +1,258 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ _('Kaupungit') }} – Mielenosoitukset.fi{% endblock %}
+{% block title %}{{ _('Kaupungit') }} - Mielenosoitukset.fi{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ _('Selaa mielenosoituksia kaupungeittain ja katso missä järjestetään mielenosoituksia tänään.') }}" />
+<meta name="robots" content="index, follow" />
+{% endblock %}
 
 {% block styles %}
 <style>
   .cities-page {
+    color: var(--color-text);
+  }
+
+  .cities-hero {
+    background: linear-gradient(135deg, #f7fbff 0%, #ffffff 48%, #eef7f1 100%);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .cities-shell {
     max-width: 1120px;
     margin: 0 auto;
     padding: 3rem 1rem;
   }
 
-  .cities-hero {
-    margin-bottom: 2rem;
-  }
-
-  .cities-hero h1 {
-    font-size: clamp(2rem, 5vw, 3.5rem);
+  .cities-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--color-primary);
+    font-weight: 750;
     margin-bottom: 1rem;
   }
 
+  .cities-hero h1 {
+    max-width: 780px;
+    font-size: clamp(2rem, 4.8vw, 4.25rem);
+    line-height: 1.02;
+    margin: 0 0 1rem;
+  }
+
   .cities-hero p {
-    max-width: 760px;
+    max-width: 720px;
     color: var(--color-text-secondary);
+    font-size: 1.08rem;
     line-height: 1.7;
+  }
+
+  .cities-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .cities-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    min-height: 44px;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    background: var(--color-card-bg);
+    color: var(--color-text);
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  .cities-button.primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+
+  .cities-button:hover,
+  .cities-button:focus {
+    transform: translateY(-1px);
+    color: var(--color-primary);
+  }
+
+  .cities-button.primary:hover,
+  .cities-button.primary:focus {
+    color: #fff;
+    filter: brightness(0.96);
+  }
+
+  .cities-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+    margin-top: -1.5rem;
+  }
+
+  .cities-stat {
+    border: 1px solid var(--color-border);
+    background: var(--color-card-bg);
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 8px 26px rgba(0, 0, 0, 0.05);
+  }
+
+  .cities-stat strong {
+    display: block;
+    font-size: 1.7rem;
+    line-height: 1;
+    margin-bottom: 0.35rem;
+  }
+
+  .cities-stat span {
+    color: var(--color-text-secondary);
+  }
+
+  .city-grid-section {
+    padding-top: 2rem;
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    font-size: clamp(1.45rem, 3vw, 2.1rem);
+  }
+
+  .section-heading p {
+    max-width: 520px;
+    margin: 0;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
   }
 
   .city-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.75rem;
-    margin: 2rem 0;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 0.9rem;
   }
 
-  .city-link {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.9rem 1rem;
+  .city-card {
+    display: grid;
+    gap: 0.95rem;
+    min-height: 190px;
+    padding: 1rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
-    color: var(--color-text);
     background: var(--color-card-bg);
+    color: var(--color-text);
     text-decoration: none;
-    font-weight: 650;
   }
 
-  .city-link:hover,
-  .city-link:focus {
-    color: var(--color-primary);
+  .city-card:hover,
+  .city-card:focus-within {
     border-color: var(--color-primary);
+    box-shadow: 0 12px 34px rgba(0, 86, 179, 0.1);
   }
 
-  .city-link small {
+  .city-card-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .city-card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+  }
+
+  .city-today-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 30px;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: #eaf6ef;
+    color: #17633a;
+    font-size: 0.9rem;
+    font-weight: 750;
+    white-space: nowrap;
+  }
+
+  .city-card p {
+    margin: 0;
     color: var(--color-text-secondary);
-    font-weight: 500;
+    line-height: 1.55;
+  }
+
+  .city-card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-self: end;
+  }
+
+  .city-card-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 38px;
+    padding: 0.55rem 0.7rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  .city-card-actions a:hover,
+  .city-card-actions a:focus {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
   }
 
   .city-system {
-    border-top: 1px solid var(--color-border);
+    margin-top: 2.5rem;
     padding-top: 2rem;
-    color: var(--color-text);
+    border-top: 1px solid var(--color-border);
+  }
+
+  .city-system h2 {
+    margin-top: 0;
   }
 
   .city-system ol {
+    display: grid;
+    gap: 0.75rem;
     padding-left: 1.25rem;
-    line-height: 1.8;
+    line-height: 1.7;
+  }
+
+  .city-system p {
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+  }
+
+  @media (max-width: 720px) {
+    .cities-shell {
+      padding: 2rem 1rem;
+    }
+
+    .section-heading {
+      display: block;
+    }
+
+    .section-heading p {
+      margin-top: 0.5rem;
+    }
   }
 </style>
 {% endblock %}
@@ -73,31 +260,90 @@
 {% block content %}
 <main class="cities-page">
   <section class="cities-hero">
-    <h1>{{ _('Kaupungit') }}</h1>
-    <p>
-      {{ _('Tältä sivulta löytyvät kaupungit, joissa on jo ilmoitettu mielenosoituksia tai joihin on löydetty paikallinen yhteyshenkilö. Kaupunkisivuilla näkyvät kyseisen paikkakunnan tulevat mielenosoitukset.') }}
-    </p>
+    <div class="cities-shell">
+      <div class="cities-kicker">
+        <i class="fa-solid fa-location-dot"></i>
+        {{ _('Paikalliset mielenosoitukset') }}
+      </div>
+      <h1>{{ _('Mielenosoitukset kaupungeittain') }}</h1>
+      <p>
+        {{ _('Löydä nopeasti missä kaupungeissa on mielenosoituksia, katso päivän tapahtumat ja avaa kaupunkikohtainen näkymä tuleville mielenosoituksille.') }}
+      </p>
+      <div class="cities-actions">
+        <a class="cities-button primary" href="{{ url_for('today_demos') }}">
+          <i class="fa-solid fa-calendar-day"></i>
+          {{ _('Mielenosoitukset Suomessa tänään') }}
+        </a>
+        <a class="cities-button" href="{{ url_for('demonstrations') }}">
+          <i class="fa-solid fa-list"></i>
+          {{ _('Kaikki tulevat mielenosoitukset') }}
+        </a>
+      </div>
+    </div>
   </section>
 
-  <section class="city-grid" aria-label="{{ _('Kaupunkilista') }}">
-    {% for city in cities %}
-    <a class="city-link" href="{{ url_for('city_demos', city=city.name|lower) }}">
-      <span><i class="fa-solid fa-location-dot me-2"></i>{{ city.name }}</span>
-      <small>{{ city.demo_count }}</small>
-    </a>
-    {% endfor %}
-  </section>
+  <div class="cities-shell">
+    <section class="cities-summary" aria-label="{{ _('Yhteenveto') }}">
+      <div class="cities-stat">
+        <strong>{{ cities|length }}</strong>
+        <span>{{ _('kaupunkia listalla') }}</span>
+      </div>
+      <div class="cities-stat">
+        <strong>{{ cities|sum(attribute='demo_count') }}</strong>
+        <span>{{ _('tulevaa mielenosoitusta kaupunkisivuilla') }}</span>
+      </div>
+      <div class="cities-stat">
+        <strong>{{ cities|sum(attribute='today_count') }}</strong>
+        <span>{{ _('mielenosoitusta tänään') }}</span>
+      </div>
+    </section>
 
-  <section class="city-system">
-    <h2>{{ _('Miten kaupunki lisätään?') }}</h2>
-    <ol>
-      <li>{{ _('Etsitään kaupungista yhteyshenkilö tai paikallinen tiimi.') }}</li>
-      <li>{{ _('Kaupunki otetaan käyttöön ylläpidon kaupunkihallinnassa.') }}</li>
-      <li>{{ _('Yhteyshenkilöille annetaan kaupungin mielenosoitusten käsittelyyn tarvittavat oikeudet.') }}</li>
-    </ol>
-    <p>
-      {{ _('Jos haluat auttaa kaupungissa, jota ei vielä näy listalla, ota yhteyttä ylläpitoon ja kerro paikkakunta sekä miten haluaisit osallistua.') }}
-    </p>
-  </section>
+    <section class="city-grid-section">
+      <div class="section-heading">
+        <h2>{{ _('Kaupunkisivut') }}</h2>
+        <p>{{ _('Jokaisesta kaupungista löytyy oma päivänäkymä sekä laajempi lista tulevista mielenosoituksista.') }}</p>
+      </div>
+
+      <div class="city-grid" aria-label="{{ _('Kaupunkilista') }}">
+        {% for city in cities %}
+        <article class="city-card">
+          <div class="city-card-head">
+            <h3>{{ city.name }}</h3>
+            <span class="city-today-badge">
+              <i class="fa-solid fa-calendar-day"></i>
+              {{ city.today_count }} {{ _('tänään') }}
+            </span>
+          </div>
+          <p>
+            {{ _('Mielenosoitukset') }} {{ city.phrase }}:
+            {{ city.demo_count }} {{ _('tulevaa tapahtumaa') }}.
+          </p>
+          <div class="city-card-actions">
+            <a href="{{ url_for('today_city_demos', city=city.name|lower) }}">
+              <i class="fa-solid fa-calendar-day"></i>
+              {{ _('Tänään') }}
+            </a>
+            <a href="{{ url_for('city_demos', city=city.name|lower) }}">
+              <i class="fa-solid fa-arrow-right"></i>
+              {{ _('Kaikki') }}
+            </a>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section class="city-system">
+      <h2>{{ _('Miten kaupunki lisätään?') }}</h2>
+      <ol>
+        <li>{{ _('Etsitään kaupungista yhteyshenkilö tai paikallinen tiimi.') }}</li>
+        <li>{{ _('Kaupunki otetaan käyttöön ylläpidon kaupunkihallinnassa.') }}</li>
+        <li>{{ _('Yhteyshenkilöille annetaan kaupungin mielenosoitusten käsittelyyn tarvittavat oikeudet.') }}</li>
+      </ol>
+      <p>
+        {{ _('Jos haluat auttaa kaupungissa, jota ei vielä näy listalla, ota yhteyttä ylläpitoon ja kerro paikkakunta sekä miten haluaisit osallistua.') }}
+      </p>
+    </section>
+  </div>
 </main>
 {% endblock %}

--- a/mielenosoitukset_fi/templates/today_demos.html
+++ b/mielenosoitukset_fi/templates/today_demos.html
@@ -1,0 +1,328 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ page_title }} - Mielenosoitukset.fi{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ page_description }}" />
+<meta name="robots" content="index, follow" />
+{% endblock %}
+
+{% block styles %}
+<style>
+  .today-page {
+    color: var(--color-text);
+  }
+
+  .today-hero {
+    background:
+      linear-gradient(135deg, rgba(0, 86, 179, 0.09), rgba(23, 99, 58, 0.1)),
+      linear-gradient(180deg, #ffffff, #f7fbff);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .today-shell {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 3rem 1rem;
+  }
+
+  .today-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem 0.65rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--color-primary);
+    font-weight: 750;
+  }
+
+  .today-hero h1 {
+    max-width: 780px;
+    margin: 1rem 0;
+    font-size: clamp(2rem, 4.7vw, 4rem);
+    line-height: 1.05;
+  }
+
+  .today-hero p {
+    max-width: 720px;
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: 1.08rem;
+    line-height: 1.7;
+  }
+
+  .today-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .today-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    min-height: 44px;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-card-bg);
+    color: var(--color-text);
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  .today-button.primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+
+  .today-button:hover,
+  .today-button:focus {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+
+  .today-button.primary:hover,
+  .today-button.primary:focus {
+    color: #fff;
+    filter: brightness(0.96);
+  }
+
+  .today-list-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .today-list-head h2 {
+    margin: 0;
+    font-size: clamp(1.4rem, 3vw, 2rem);
+  }
+
+  .today-count {
+    color: var(--color-text-secondary);
+    font-weight: 700;
+  }
+
+  .today-list {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .today-demo {
+    display: grid;
+    grid-template-columns: minmax(96px, 132px) 1fr;
+    gap: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-card-bg);
+    text-decoration: none;
+    color: var(--color-text);
+  }
+
+  .today-demo:hover,
+  .today-demo:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 12px 34px rgba(0, 86, 179, 0.1);
+  }
+
+  .today-time {
+    display: grid;
+    align-content: start;
+    gap: 0.35rem;
+    color: var(--color-primary);
+    font-weight: 800;
+  }
+
+  .today-time span {
+    color: var(--color-text-secondary);
+    font-size: 0.92rem;
+    font-weight: 650;
+  }
+
+  .today-demo h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1.25rem;
+  }
+
+  .today-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 1rem;
+    color: var(--color-text-secondary);
+    font-size: 0.98rem;
+  }
+
+  .today-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .today-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.8rem;
+  }
+
+  .today-tag {
+    border-radius: 999px;
+    background: #eef7f1;
+    color: #17633a;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  .today-empty {
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-card-bg);
+    padding: 2rem;
+  }
+
+  .today-empty h2 {
+    margin-top: 0;
+  }
+
+  .today-empty p {
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+  }
+
+  @media (max-width: 680px) {
+    .today-shell {
+      padding: 2rem 1rem;
+    }
+
+    .today-list-head {
+      display: block;
+    }
+
+    .today-count {
+      display: block;
+      margin-top: 0.4rem;
+    }
+
+    .today-demo {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<main class="today-page">
+  <section class="today-hero">
+    <div class="today-shell">
+      <div class="today-kicker">
+        <i class="fa-solid fa-calendar-day"></i>
+        <span>{{ date_label }}</span>
+      </div>
+      <h1>{{ page_title }}</h1>
+      <p>{{ page_description }}</p>
+      <div class="today-actions">
+        {% if city_name %}
+        <a class="today-button primary" href="{{ url_for('city_demos', city=city_name|lower) }}">
+          <i class="fa-solid fa-location-dot"></i>
+          {{ _('Kaikki tulevat') }} {{ city_phrase }}
+        </a>
+        <a class="today-button" href="{{ url_for('today_demos') }}">
+          <i class="fa-solid fa-map"></i>
+          {{ _('Koko Suomi tänään') }}
+        </a>
+        {% else %}
+        <a class="today-button primary" href="{{ url_for('cities') }}">
+          <i class="fa-solid fa-city"></i>
+          {{ _('Selaa kaupunkeja') }}
+        </a>
+        <a class="today-button" href="{{ url_for('demonstrations') }}">
+          <i class="fa-solid fa-list"></i>
+          {{ _('Kaikki tulevat mielenosoitukset') }}
+        </a>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  <section class="today-shell" aria-label="{{ _('Tämän päivän mielenosoitukset') }}">
+    {% if demonstrations %}
+    <div class="today-list-head">
+      <h2>{{ _('Tänään') }}</h2>
+      <span class="today-count">
+        {{ demonstrations|length }} {{ _('mielenosoitusta') }}
+      </span>
+    </div>
+    <div class="today-list">
+      {% for demo in demonstrations %}
+      <a class="today-demo" href="{{ url_for('demonstration_detail', demo_id=demo.detail_identifier) }}">
+        <div class="today-time">
+          {% if demo.start_time %}
+          {{ demo.start_time }}
+          {% else %}
+          {{ _('Aika avoin') }}
+          {% endif %}
+          <span>{{ demo.end_time or '' }}</span>
+        </div>
+        <div>
+          <h3>{{ demo.title }}</h3>
+          <div class="today-meta">
+            <span><i class="fa-solid fa-city"></i>{{ demo.city }}</span>
+            {% if demo.address %}
+            <span><i class="fa-solid fa-location-dot"></i>{{ demo.address }}</span>
+            {% endif %}
+          </div>
+          {% if demo.tags %}
+          <div class="today-tags">
+            {% for tag in demo.tags %}
+            <span class="today-tag">#{{ tag }}</span>
+            {% endfor %}
+          </div>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="today-empty">
+      {% if city_name %}
+      <h2>{{ _('Ei mielenosoituksia tänään') }} {{ city_phrase }}</h2>
+      <p>{{ _('Tälle päivälle ei löytynyt hyväksyttyjä mielenosoituksia tästä kaupungista. Voit silti katsoa kaikki kaupungin tulevat tapahtumat tai palata kaupunkilistaan.') }}</p>
+      <div class="today-actions">
+        <a class="today-button primary" href="{{ url_for('city_demos', city=city_name|lower) }}">
+          <i class="fa-solid fa-arrow-right"></i>
+          {{ _('Katso kaupungin tulevat') }}
+        </a>
+        <a class="today-button" href="{{ url_for('cities') }}">
+          <i class="fa-solid fa-city"></i>
+          {{ _('Muut kaupungit') }}
+        </a>
+      </div>
+      {% else %}
+      <h2>{{ _('Ei mielenosoituksia tänään') }}</h2>
+      <p>{{ _('Tälle päivälle ei löytynyt hyväksyttyjä mielenosoituksia. Voit katsoa kaikki tulevat mielenosoitukset tai selata tapahtumia kaupungeittain.') }}</p>
+      <div class="today-actions">
+        <a class="today-button primary" href="{{ url_for('demonstrations') }}">
+          <i class="fa-solid fa-list"></i>
+          {{ _('Kaikki tulevat mielenosoitukset') }}
+        </a>
+        <a class="today-button" href="{{ url_for('cities') }}">
+          <i class="fa-solid fa-city"></i>
+          {{ _('Selaa kaupunkeja') }}
+        </a>
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+  </section>
+</main>
+{% endblock %}

--- a/tests/surface_manifest.json
+++ b/tests/surface_manifest.json
@@ -119,8 +119,8 @@
       ]
     },
     "mielenosoitukset_fi/basic_routes.py": {
-      "count": 47,
-      "sha256": "89084643b12a6f5557a6da6fa3e4f78a18099a858ef9e86599f5175c22ac91b0",
+      "count": 49,
+      "sha256": "47426cbe1018d9777f6ca6107552c8be27e547958fee44078fdafe2a596bd1b5",
       "coverage": [
         "integration",
         "e2e-public"

--- a/tests/test_sitemap_and_today_pages.py
+++ b/tests/test_sitemap_and_today_pages.py
@@ -1,0 +1,68 @@
+import xml.etree.ElementTree as ET
+from datetime import date
+
+from flask import url_for
+
+
+def _sitemap_locs(response):
+    root = ET.fromstring(response.data)
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    return {loc.text for loc in root.findall(".//sm:loc", ns)}
+
+
+def test_sitemap_includes_public_city_org_tag_and_today_pages(app, db, seeded_data):
+    response = app.test_client().get("/sitemap.xml", base_url="https://example.test")
+
+    assert response.status_code == 200
+    locs = _sitemap_locs(response)
+
+    with app.test_request_context(base_url="https://example.test"):
+        expected_urls = {
+            url_for("cities", _external=True),
+            url_for("today_demos", _external=True),
+            url_for("city_demos", city="helsinki", _external=True),
+            url_for("today_city_demos", city="helsinki", _external=True),
+            url_for("org", org_id=str(seeded_data["org_id"]), _external=True),
+            url_for("tag_detail", tag_name="test-tag", _external=True),
+            url_for("public_guides", _external=True),
+            url_for("api_docs", _external=True),
+            url_for("pride_nakyvaksi", _external=True),
+        }
+
+    assert expected_urls <= locs
+    assert not any("/api/v1/" in loc for loc in locs)
+    assert not any("/save_suggestion" in loc for loc in locs)
+
+
+def test_cities_page_links_to_today_and_future_city_views(app, seeded_data):
+    response = app.test_client().get("/cities")
+
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Mielenosoitukset kaupungeittain" in page
+    assert "/mielenosoitukset-tanaan" in page
+    assert "/city/helsinki/tanaan" in page
+    assert "/city/helsinki" in page
+
+
+def test_today_pages_render_finland_and_city_specific_demos(app, db, seeded_data):
+    today = date.today().isoformat()
+    db.demonstrations.update_one(
+        {"_id": seeded_data["demo_id"]},
+        {"$set": {"date": today, "start_time": "12:30", "city": "Helsinki", "city_key": "helsinki"}},
+    )
+
+    client = app.test_client()
+    finland_response = client.get("/mielenosoitukset-tanaan")
+    city_response = client.get("/city/helsinki/tanaan")
+
+    assert finland_response.status_code == 200
+    assert city_response.status_code == 200
+
+    finland_page = finland_response.get_data(as_text=True)
+    city_page = city_response.get_data(as_text=True)
+    assert "Mielenosoitukset Suomessa tänään" in finland_page
+    assert "Climate March Helsinki" in finland_page
+    assert "Mielenosoitukset Helsingissä tänään" in city_page
+    assert "Climate March Helsinki" in city_page
+    assert "12:30" in city_page


### PR DESCRIPTION
## Summary

- expands `/sitemap.xml` to include public city, city-today, organization, tag, calendar, guide, API docs, and Pride pages
- adds a polished city hub with per-city today/future links and counts
- adds Finland-wide and city-specific “mielenosoitukset tänään” pages with server-rendered event listings

## Validation

- `./.venv/bin/python -m pytest tests/test_sitemap_and_today_pages.py tests/test_city_management.py tests/test_surface_manifest.py -q`
- `git diff --cached --check`